### PR TITLE
feat: add Docker Bake for multi-arch image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,5 +7,6 @@ docs
 Makefile
 .golangci.yml
 .goreleaser.yml
+docker-bake.hcl
 mise.toml
 coverage.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,23 @@ jobs:
         with:
           version: "~> v2"
           args: build --snapshot --clean
+
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build multi-arch images (no push)
+        uses: docker/bake-action@v6
+        with:
+          targets: ci
+          set: |
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
   issues: read
   pull-requests: read
 
@@ -67,3 +68,48 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ secrets.GPG_FINGERPRINT }}
+
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    needs: [bump-version, release]
+    if: needs.bump-version.outputs.skipped != 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.bump-version.outputs.tag }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/donaldgifford/repo-guardian
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.bump-version.outputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.bump-version.outputs.tag }}
+            type=raw,value=latest
+
+      - name: Build and push Docker images
+        uses: docker/bake-action@v6
+        with:
+          targets: release
+          files: |
+            docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file-tags }}
+            ${{ steps.meta.outputs.bake-file-labels }}
+          set: |
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # Build stage
-FROM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /src
 
@@ -9,7 +12,8 @@ RUN go mod download
 
 # Copy source and build.
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /repo-guardian ./cmd/repo-guardian
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags="-s -w" -o /repo-guardian ./cmd/repo-guardian
 
 # Runtime stage
 FROM gcr.io/distroless/static-debian12:nonroot

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,27 @@ release-local: ## Test goreleaser without publishing
 	@ $(MAKE) --no-print-directory log-$@
 	goreleaser release --snapshot --clean --skip=publish --skip=sign
 
+###############
+##@ Docker
+
+.PHONY: docker-build docker-build-multiarch docker-bake-print docker-push
+
+docker-build: ## Build local dev image (single-arch)
+	@ $(MAKE) --no-print-directory log-$@
+	@docker buildx bake dev
+
+docker-build-multiarch: ## Validate multi-arch build (no push)
+	@ $(MAKE) --no-print-directory log-$@
+	@docker buildx bake ci
+
+docker-bake-print: ## Print resolved bake config (debug)
+	@ $(MAKE) --no-print-directory log-$@
+	@docker buildx bake --print dev
+
+docker-push: ## Build and push multi-arch image to registry
+	@ $(MAKE) --no-print-directory log-$@
+	@docker buildx bake release
+
 
 ########################################################################
 ## Self-Documenting Makefile Help                                     ##

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,76 @@
+// docker-bake.hcl — single source of truth for all Docker image builds.
+//
+// Targets:
+//   dev     — local single-arch build, loads into Docker daemon
+//   ci      — multi-arch validation build, no push
+//   release — multi-arch build, pushes to registry
+
+variable "REGISTRY" {
+  default = "ghcr.io"
+}
+
+variable "IMAGE_NAME" {
+  default = "donaldgifford/repo-guardian"
+}
+
+variable "VERSION" {
+  default = "dev"
+}
+
+variable "COMMIT_SHA" {
+  default = ""
+}
+
+variable "BUILD_DATE" {
+  default = ""
+}
+
+function "tags" {
+  params = [version]
+  result = version == "dev" ? [
+    "${REGISTRY}/${IMAGE_NAME}:dev",
+  ] : [
+    "${REGISTRY}/${IMAGE_NAME}:${version}",
+    "${REGISTRY}/${IMAGE_NAME}:latest",
+  ]
+}
+
+// Base target with shared configuration.
+target "_common" {
+  dockerfile = "Dockerfile"
+  context    = "."
+  labels = {
+    "org.opencontainers.image.source"   = "https://github.com/donaldgifford/repo-guardian"
+    "org.opencontainers.image.revision" = "${COMMIT_SHA}"
+    "org.opencontainers.image.created"  = "${BUILD_DATE}"
+    "org.opencontainers.image.version"  = "${VERSION}"
+  }
+}
+
+// Local development build — single-arch, loads into Docker daemon.
+target "dev" {
+  inherits  = ["_common"]
+  tags      = tags("dev")
+  output    = ["type=docker"]
+}
+
+// CI validation build — multi-arch, no push.
+target "ci" {
+  inherits  = ["_common"]
+  tags      = tags(VERSION)
+  platforms = ["linux/amd64", "linux/arm64"]
+  output    = ["type=cacheonly"]
+  cache-from = ["type=gha"]
+  cache-to   = ["type=gha,mode=max"]
+}
+
+// Release build — multi-arch, pushes to registry.
+// In CI, docker/metadata-action overrides tags via the bake file merge pattern.
+target "release" {
+  inherits  = ["_common"]
+  tags      = tags(VERSION)
+  platforms = ["linux/amd64", "linux/arm64"]
+  output    = ["type=registry"]
+  cache-from = ["type=gha"]
+  cache-to   = ["type=gha,mode=max"]
+}


### PR DESCRIPTION
## Summary

- Add `docker-bake.hcl` as single source of truth for Docker image builds with `dev`, `ci`, and `release` targets
- Update `Dockerfile` for multi-arch buildx using native Go cross-compilation (`BUILDPLATFORM`/`TARGETOS`/`TARGETARCH`) to avoid QEMU emulation during compile
- Add CI job to validate multi-arch builds (linux/amd64, linux/arm64) on every PR without pushing
- Add release job to build and push semver-tagged images to `ghcr.io/donaldgifford/repo-guardian` after GoReleaser completes
- Add Makefile targets: `docker-build`, `docker-build-multiarch`, `docker-bake-print`, `docker-push`

## Test plan

- [ ] `make docker-build` — builds local dev image, verify with `docker images | grep repo-guardian`
- [ ] `make docker-bake-print` — inspect resolved bake config, verify tags/labels
- [ ] `make docker-build-multiarch` — validate multi-arch builds locally (requires buildx)
- [ ] `make lint` — confirm no Go regressions (verified locally: 0 issues)
- [ ] `make test` — confirm all tests pass (verified locally: all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)