### PR TITLE
fix: use local source for bake-action and add metadata target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
         uses: docker/bake-action@v6
         with:
           targets: ci
+          source: .
           set: |-
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,7 @@ jobs:
         uses: docker/bake-action@v6
         with:
           targets: release
+          source: .
           files: |
             docker-bake.hcl
             ${{ steps.meta.outputs.bake-file-tags }}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -64,10 +64,13 @@ target "ci" {
   cache-to   = ["type=gha,mode=max"]
 }
 
+// Populated by docker/metadata-action in CI with computed tags and labels.
+target "docker-metadata-action" {}
+
 // Release build — multi-arch, pushes to registry.
 // In CI, docker/metadata-action overrides tags via the bake file merge pattern.
 target "release" {
-  inherits  = ["_common"]
+  inherits  = ["_common", "docker-metadata-action"]
   tags      = tags(VERSION)
   platforms = ["linux/amd64", "linux/arm64"]
   output    = ["type=registry"]


### PR DESCRIPTION
## Summary

- Set `source: .` on `docker/bake-action@v6` in both CI and release workflows to use the local checkout instead of git source context, which prevents resolving host-filesystem paths (like metadata-action bake files)
- Add empty `docker-metadata-action` target to `docker-bake.hcl` so the `release` target can inherit CI-computed tags and labels via the bake file merge pattern

Fixes the `docker-metadata-action-bake-tags.json: no such file or directory` error from https://github.com/donaldgifford/repo-guardian/actions/runs/21826736452/job/62973869831

## Test plan

- [ ] Release workflow docker job completes without `lstat` errors
- [ ] Published image tags match semver pattern from metadata-action

🤖 Generated with [Claude Code](https://claude.com/claude-code)