### PR TITLE
Fix: Docker CI and image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
   docker-build:
     name: Docker Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
 
@@ -116,11 +119,31 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build multi-arch images (no push)
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push dev image
+        if: github.event_name == 'pull_request'
         uses: docker/bake-action@v6
         with:
           targets: ci
           source: .
-          set: |-
+          set: |
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max
+            *.output=type=registry
+
+      - name: Build multi-arch images (post-merge validation)
+        if: github.event_name == 'push'
+        uses: docker/bake-action@v6
+        with:
+          targets: ci
+          source: .
+          set: |
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -65,13 +65,15 @@ target "ci" {
 }
 
 // Populated by docker/metadata-action in CI with computed tags and labels.
-target "docker-metadata-action" {}
+// Default tags are used for local `make docker-push`; CI overrides via bake file merge.
+target "docker-metadata-action" {
+  tags = tags(VERSION)
+}
 
 // Release build — multi-arch, pushes to registry.
-// In CI, docker/metadata-action overrides tags via the bake file merge pattern.
+// Tags are inherited from docker-metadata-action (overridden by metadata-action in CI).
 target "release" {
   inherits  = ["_common", "docker-metadata-action"]
-  tags      = tags(VERSION)
   platforms = ["linux/amd64", "linux/arm64"]
   output    = ["type=registry"]
   cache-from = ["type=gha"]


### PR DESCRIPTION
Fix docker workflow so that dev tag is always and only built from a PR and semver tags are used when a tag is created - typically after a merge to main.