### PR TITLE
fix(chart): cosign auth to GHCR + roll-forward to 0.3.1

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -41,6 +41,13 @@ jobs:
 
       - uses: sigstore/cosign-installer@v3
 
+      - name: Login to GHCR (docker config — for cosign and helm)
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: orhun/git-cliff-action@v4
         with:
           config: charts/repo-guardian/cliff.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,9 @@ based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
 ## [unreleased]
 
-### Documentation
+### Features
 
-- *(design)* DESIGN-0011 publish Helm chart via OCI registry
-- *(design)* Resolve DESIGN-0011 open questions, mark Approved
-- *(impl)* IMPL-0010 publish Helm chart via OCI registry
-
-### Miscellaneous Tasks
-
-- *(chart)* Bump chart 0.3.0 / appVersion 1.4.0 (IMPL-0010 P1.1-3)
+- *(chart)* Publish to OCI registry with cosign + SLSA (DESIGN-0011 / IMPL-0010) ([#60](https://github.com/donaldgifford/repo-guardian/issues/60))
 
 ## [1.4.0] - 2026-04-26
 

--- a/charts/repo-guardian/CHANGELOG.md
+++ b/charts/repo-guardian/CHANGELOG.md
@@ -4,9 +4,9 @@ Changes to the `repo-guardian` Helm chart only. For application-level
 changes, see the root [CHANGELOG.md](../../CHANGELOG.md).
 ## [unreleased]
 
-### Miscellaneous Tasks
+### Features
 
-- *(chart)* Bump chart 0.3.0 / appVersion 1.4.0 (IMPL-0010 P1.1-3)
+- *(chart)* Publish to OCI registry with cosign + SLSA (DESIGN-0011 / IMPL-0010) ([#60](https://github.com/donaldgifford/repo-guardian/issues/60))
 
 ## [1.3.8] - 2026-03-16
 

--- a/charts/repo-guardian/Chart.yaml
+++ b/charts/repo-guardian/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: repo-guardian
 description: GitHub App that automates repository onboarding and compliance
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "1.4.0"

--- a/charts/repo-guardian/README.md
+++ b/charts/repo-guardian/README.md
@@ -18,7 +18,7 @@ helm install repo-guardian repo-guardian/repo-guardian \
 ```bash
 helm install repo-guardian \
   oci://YOUR_REGISTRY/helm-charts/repo-guardian \
-  --version 0.3.0 \
+  --version 0.3.1 \
   --namespace platform-tools \
   --create-namespace \
   -f values-prod.yaml


### PR DESCRIPTION
## Summary

Post-mortem of the IMPL-0010 first publish (PR #60). The chart pushed
successfully to GHCR but cosign sign failed with UNAUTHORIZED.

**Root cause:** \`helm registry login\` writes to
\`~/.config/helm/registry/config.json\`. Cosign reads from
\`~/.docker/config.json\`. The two credential stores are disjoint, so
cosign had no GHCR credentials.

**Fix:** add \`docker/login-action@v4\` before the cosign sign step.
\`helm registry login\` is kept for helm's own auth path.

**Roll-forward:** chart bumped 0.3.0 → 0.3.1 per the documented
yank semantics. The unsigned 0.3.0 in GHCR is left in place;
consumers will pin to 0.3.1 once published.

## Test plan
- [x] actionlint + yamllint clean
- [x] make helm-test (49/49 pass)
- [x] make helm-ct-lint pass
- [ ] Merge → chart-release.yml runs → 0.3.1 publishes signed
- [ ] Verify cosign signature exists at the new digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)