### PR TITLE
chore(tooling): remove helm-cr leftovers (IMPL-0010 P9)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ HELM_REGISTRY ?= ""
 
 .PHONY: helm-lint helm-template helm-template-ci helm-package
 .PHONY: helm-unittest helm-test helm-ct-lint helm-ct-list-changed helm-ct-install
-.PHONY: helm-docs helm-diff-check helm-cr-package helm-push
+.PHONY: helm-docs helm-diff-check helm-push
 
 helm-lint: ## Lint Helm chart
 	@ $(MAKE) --no-print-directory log-$@
@@ -236,10 +236,6 @@ helm-docs: ## Generate chart README with helm-docs
 helm-diff-check: ## Show diff between installed release and local chart
 	@ $(MAKE) --no-print-directory log-$@
 	@helm diff upgrade $(RELEASE) $(CHART_DIR)
-
-helm-cr-package: ## Package chart with chart-releaser
-	@ $(MAKE) --no-print-directory log-$@
-	@cr package $(CHART_DIR)
 
 helm-push: ## Push packaged chart to OCI registry
 	@ $(MAKE) --no-print-directory log-$@

--- a/docs/impl/0010-publish-helm-chart-via-oci-registry.md
+++ b/docs/impl/0010-publish-helm-chart-via-oci-registry.md
@@ -596,24 +596,23 @@ path is proven and a real consumer has migrated.
 
 #### Tasks
 
-- [ ] Remove `helm-cr-package` make target from the Makefile if
-      unused after the workflow rewrite (keep if local packaging
-      via `cr` is still useful)
-- [ ] Audit `mise.toml` — remove `helm-cr` if no longer invoked
-      anywhere (chart-testing's `ct` is separate and stays)
-- [ ] Check `.github/workflows/ci.yml` for any reference to
-      `chart-releaser` and remove if present
-- [ ] Grep for `chart-releaser-action`, `helm/chart-releaser-action`,
-      `gh-pages.*helm`, `HELM_OCI_REGISTRY`, and `AWS_ROLE_ARN`
-      (the latter two were only the ECR fan-out plumbing). Ensure
-      only doc references in `docs/design/0005-helm-chart.md`
-      (historical) and
-      `docs/design/0011-publish-helm-chart-via-oci-registry.md`
-      (background) remain
-- [ ] Update `docs/design/0005-helm-chart.md` distribution section
-      with a "Superseded by DESIGN-0011" note. Do NOT change its
-      top-level status (it's Implemented; only the distribution
-      sub-decision is replaced)
+- [x] Remove `helm-cr-package` make target from the Makefile —
+      removed; `helm-package` (already exists) does the same job
+      without chart-releaser dependency
+- [x] Audit `mise.toml` — `helm-cr` removed; chart-testing's `ct`
+      stays
+- [x] Check `.github/workflows/ci.yml` for any reference to
+      `chart-releaser` — none present
+- [x] Grep for `chart-releaser-action`, `helm/chart-releaser-action`,
+      `gh-pages.*helm`, `HELM_OCI_REGISTRY`, and `AWS_ROLE_ARN` —
+      only doc references remain in `docs/design/0005-helm-chart-for-repo-guardian.md`
+      (historical) and `docs/impl/0004-helm-chart-for-repo-guardian.md`
+      (historical IMPL — superseded by IMPL-0010 distribution rewrite)
+- [x] Update `docs/design/0005-helm-chart-for-repo-guardian.md`
+      with a "Superseded by DESIGN-0011" banner — done in PR #61
+      via a follow-up commit to main (top-level status retained
+      as `Implemented`; only the distribution sub-decision is
+      replaced)
 
 #### Success Criteria
 

--- a/mise.toml
+++ b/mise.toml
@@ -39,7 +39,6 @@ syft = "latest"
 
 # helm
 helm = "3.19.0"
-helm-cr = "latest"
 helm-ct = "latest"
 helm-diff = "latest"
 helm-docs = "latest"


### PR DESCRIPTION
## Summary

Phase 9 of IMPL-0010. The chart-releaser → gh-pages distribution
flow was never run in production; this PR removes the last leftover
plumbing now that the OCI publish flow is proven.

## Changes

- \`Makefile\`: drop \`helm-cr-package\`. \`helm-package\` does the same
  job without the \`cr\` binary dependency
- \`mise.toml\`: drop \`helm-cr\`. \`helm-ct\` (chart-testing) stays
- IMPL-0010 phase 9 checkoffs

## Verification

- \`make helm-test\`: 49/49 pass
- \`make helm-ct-lint\`: pass
- Grep for \`chart-releaser-action | helm/chart-releaser-action | gh-pages.*helm | HELM_OCI_REGISTRY | AWS_ROLE_ARN\`
  in active workflows / Makefile / mise.toml: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)