### PR TITLE
fix(chart): stamp namespace into every template (0.3.1 → 0.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 - *(chart)* Publish to OCI registry with cosign + SLSA (DESIGN-0011 / IMPL-0010) ([#60](https://github.com/donaldgifford/repo-guardian/issues/60))
 
+### Bug Fixes
+
+- *(chart)* Authenticate cosign to GHCR via docker login (post-mortem 0.3.0) ([#61](https://github.com/donaldgifford/repo-guardian/issues/61))
+
+### Documentation
+
+- *(chart)* Refresh install + verify + yank docs (IMPL-0010 P6) ([#62](https://github.com/donaldgifford/repo-guardian/issues/62))
+- *(impl)* Mark IMPL-0010 In Progress with phase summary ([#64](https://github.com/donaldgifford/repo-guardian/issues/64))
+- *(impl)* IMPL-0010 Phase 4 complete — GHCR public verified ([#65](https://github.com/donaldgifford/repo-guardian/issues/65))
+- IMPL-0010 retrospective + DESIGN-0011 Implemented ([#66](https://github.com/donaldgifford/repo-guardian/issues/66))
+
+### Miscellaneous Tasks
+
+- *(tooling)* Remove helm-cr leftovers (IMPL-0010 P9) ([#63](https://github.com/donaldgifford/repo-guardian/issues/63))
+
 ## [1.4.0] - 2026-04-26
 
 ### Bug Fixes

--- a/charts/repo-guardian/CHANGELOG.md
+++ b/charts/repo-guardian/CHANGELOG.md
@@ -8,6 +8,14 @@ changes, see the root [CHANGELOG.md](../../CHANGELOG.md).
 
 - *(chart)* Publish to OCI registry with cosign + SLSA (DESIGN-0011 / IMPL-0010) ([#60](https://github.com/donaldgifford/repo-guardian/issues/60))
 
+### Bug Fixes
+
+- *(chart)* Authenticate cosign to GHCR via docker login (post-mortem 0.3.0) ([#61](https://github.com/donaldgifford/repo-guardian/issues/61))
+
+### Documentation
+
+- *(chart)* Refresh install + verify + yank docs (IMPL-0010 P6) ([#62](https://github.com/donaldgifford/repo-guardian/issues/62))
+
 ## [1.3.8] - 2026-03-16
 
 ### Bug Fixes

--- a/charts/repo-guardian/Chart.yaml
+++ b/charts/repo-guardian/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: repo-guardian
 description: GitHub App that automates repository onboarding and compliance
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "1.4.0"

--- a/charts/repo-guardian/README.md
+++ b/charts/repo-guardian/README.md
@@ -11,7 +11,7 @@ with cosign keyless, SLSA Level 3 provenance).
 ```bash
 helm install repo-guardian \
   oci://ghcr.io/donaldgifford/charts/repo-guardian \
-  --version 0.3.1 \
+  --version 0.3.2 \
   --namespace repo-guardian \
   --create-namespace \
   -f values.yaml
@@ -47,7 +47,7 @@ secrets:
 ```bash
 helm install repo-guardian \
   oci://ghcr.io/donaldgifford/charts/repo-guardian \
-  --version 0.3.1 \
+  --version 0.3.2 \
   --namespace repo-guardian \
   --create-namespace \
   -f values.yaml
@@ -70,7 +70,7 @@ cosign verify \
     '^https://github.com/donaldgifford/repo-guardian/.+' \
   --certificate-oidc-issuer \
     'https://token.actions.githubusercontent.com' \
-  ghcr.io/donaldgifford/charts/repo-guardian:0.3.1
+  ghcr.io/donaldgifford/charts/repo-guardian:0.3.2
 ```
 
 ### SLSA provenance
@@ -81,7 +81,7 @@ cosign verify-attestation --type slsaprovenance \
     '^https://github.com/slsa-framework/slsa-github-generator/.+' \
   --certificate-oidc-issuer \
     'https://token.actions.githubusercontent.com' \
-  ghcr.io/donaldgifford/charts/repo-guardian:0.3.1
+  ghcr.io/donaldgifford/charts/repo-guardian:0.3.2
 ```
 
 The provenance attestation records the build workflow path, source

--- a/charts/repo-guardian/templates/configmap.yaml
+++ b/charts/repo-guardian/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "repo-guardian.fullname" . }}-templates
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "repo-guardian.labels" . | nindent 4 }}
 data:

--- a/charts/repo-guardian/templates/deployment.yaml
+++ b/charts/repo-guardian/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "repo-guardian.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "repo-guardian.labels" . | nindent 4 }}
 spec:

--- a/charts/repo-guardian/templates/policy-configmap.yaml
+++ b/charts/repo-guardian/templates/policy-configmap.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "repo-guardian.fullname" . }}-policy
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "repo-guardian.labels" . | nindent 4 }}
 data:

--- a/charts/repo-guardian/templates/secret.yaml
+++ b/charts/repo-guardian/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "repo-guardian.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "repo-guardian.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/repo-guardian/templates/service.yaml
+++ b/charts/repo-guardian/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "repo-guardian.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "repo-guardian.labels" . | nindent 4 }}
 spec:

--- a/charts/repo-guardian/templates/serviceaccount.yaml
+++ b/charts/repo-guardian/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "repo-guardian.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "repo-guardian.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/repo-guardian/templates/servicemonitor.yaml
+++ b/charts/repo-guardian/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "repo-guardian.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "repo-guardian.labels" . | nindent 4 }}
     {{- with .Values.serviceMonitor.labels }}

--- a/charts/repo-guardian/templates/tailscale-configmap.yaml
+++ b/charts/repo-guardian/templates/tailscale-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "repo-guardian.fullname" . }}-tailscale-serve-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "repo-guardian.labels" . | nindent 4 }}
 data:

--- a/charts/repo-guardian/templates/tailscale-rbac.yaml
+++ b/charts/repo-guardian/templates/tailscale-rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "repo-guardian.fullname" . }}-tailscale
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "repo-guardian.labels" . | nindent 4 }}
 rules:
@@ -14,11 +15,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "repo-guardian.fullname" . }}-tailscale
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "repo-guardian.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "repo-guardian.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: {{ include "repo-guardian.fullname" . }}-tailscale


### PR DESCRIPTION
## Summary

Chart templates didn't include \`metadata.namespace\`, so under
kustomize+helm via ArgoCD all rendered resources landed wherever
\`spec.destination.namespace\` pointed (in homelab's ApplicationSet,
that's hardcoded to \`argocd\`). The Deployment ended up in \`argocd\`
namespace while its OnePasswordItem-synced secrets were in
\`repo-guardian\`, causing Degraded health.

## Fix

Explicitly stamp \`namespace: {{ .Release.Namespace }}\` into every
template's metadata:
- configmap.yaml, deployment.yaml, policy-configmap.yaml,
  secret.yaml, service.yaml, serviceaccount.yaml,
  servicemonitor.yaml, tailscale-configmap.yaml,
  tailscale-rbac.yaml (Role + RoleBinding + subject namespace)

Chart bump: 0.3.1 → 0.3.2. \`appVersion\` stays at 1.4.0 (no Go
code changed). Both CHANGELOG.md files regenerated.

## Verification

\`\`\`bash
helm template repo-guardian charts/repo-guardian \\
  --namespace repo-guardian \\
  --set config.appId=12345 --set config.org=test \\
  --set secrets.webhookSecret=foo --set secrets.privateKey=bar \\
  | grep -E '^kind:|^  namespace:'
\`\`\`

Output now shows every resource with \`namespace: repo-guardian\`.

- \`make helm-test\`: 49/49 pass
- \`make helm-ct-lint\`: pass
- \`make helm-docs\`: regenerated, no diff

## Rollout (consumer side)

After this lands and 0.3.2 publishes:
1. Bump homelab \`kustomization.yaml\` from 0.3.1 → 0.3.2
2. Commit + push
3. Cleanup the misplaced resources still in argocd namespace:
   \`kubectl -n argocd delete deploy,svc,sa,cm,role,rolebinding,servicemonitor -l app.kubernetes.io/instance=repo-guardian\`
4. ArgoCD self-heals → resources land in \`repo-guardian\` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)