### PR TITLE
fix(github): idempotent CreateOrUpdateFile (INV-0003) + appVersion 1.4.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,9 +120,7 @@ GoReleaser builds for linux/darwin on amd64/arm64 (CGO disabled). Releases are G
 
 **`DRY_RUN` precedence at runtime:** env var (set on the Deployment) overrides any `dry_run` from HCL or built-in defaults via `applyEnvOverrides` running last in `Load()`. A kustomize patch or Helm values setting `DRY_RUN=true` will silently keep the engine in dry-run regardless of the policy file. Always check `kubectl get deploy ... -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="DRY_RUN")]}'` first when the binary appears to be reading the wrong policy state.
 
-## Known Issues
-
-- **Pre-existing-branch 422 on subsequent reconciles** (open, found 2026-05-02 during homelab smoke test of chart 0.3.2). When a repo has an open PR from a prior reconcile, the next reconcile against the same repo fails: engine sees the file missing on the default branch, tries to PUT-create it on `repo-guardian/add-missing-files`, GitHub returns `422 Invalid request "sha" wasn't supplied` because the file already exists on the branch. The engine's file-creation path needs to detect the pre-existing branch + file, GET the sha first, and either UPDATE (with sha) or skip if already correct. Workaround: merge open repo-guardian PRs quickly, or `gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/repo-guardian/add-missing-files` between runs. Worth its own INV/IMPL.
+**Idempotent file commits on the reconcile branch (INV-0003, appVersion 1.4.1):** `internal/github/client.go.CreateOrUpdateFile` does GET-on-target-branch first, then either skips (identical content), updates with the existing blob `sha` (different content), or creates fresh (file missing). Before this fix the wrapper called `Repositories.CreateFile` unconditionally, so a second reconcile against a repo with an open `repo-guardian/add-missing-files` branch would 422 with "sha wasn't supplied." If you ever rename or rewrite this function, preserve the three-branch behavior — the package-level `GetContents(ctx, owner, repo, path)` helper is *default-branch-only* and will not protect you against the same bug if you swap to it.
 
 ## Rules
 

--- a/charts/repo-guardian/Chart.yaml
+++ b/charts/repo-guardian/Chart.yaml
@@ -4,4 +4,4 @@ name: repo-guardian
 description: GitHub App that automates repository onboarding and compliance
 type: application
 version: 0.3.2
-appVersion: "1.4.0"
+appVersion: "1.4.1"

--- a/charts/repo-guardian/tests/deployment_test.yaml
+++ b/charts/repo-guardian/tests/deployment_test.yaml
@@ -20,7 +20,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "ghcr.io/donaldgifford/repo-guardian:1\\.4\\.0"
+          pattern: "ghcr.io/donaldgifford/repo-guardian:1\\.4\\.1"
 
   - it: should use custom image tag when set
     set:

--- a/docs/investigation/0003-pre-existing-branch-422-on-subsequent-reconciles.md
+++ b/docs/investigation/0003-pre-existing-branch-422-on-subsequent-reconciles.md
@@ -1,0 +1,162 @@
+---
+id: INV-0003
+title: "Pre-existing branch 422 on subsequent reconciles"
+status: Open
+author: Donald Gifford
+created: 2026-05-02
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# INV 0003: Pre-existing branch 422 on subsequent reconciles
+
+**Status:** Open
+**Author:** Donald Gifford
+**Date:** 2026-05-02
+
+<!--toc:start-->
+- [Question](#question)
+- [Hypothesis](#hypothesis)
+- [Context](#context)
+- [Approach](#approach)
+- [Environment](#environment)
+- [Findings](#findings)
+  - [Observation 1](#observation-1)
+  - [Observation 2](#observation-2)
+- [Conclusion](#conclusion)
+- [Recommendation](#recommendation)
+- [References](#references)
+<!--toc:end-->
+
+## Question
+
+When a repo already has an open repo-guardian PR (and therefore a
+pre-existing `repo-guardian/add-missing-files` branch with the templated
+files committed to it), the next reconcile against that repo fails with
+`422 Invalid request "sha" wasn't supplied`. What is the minimal engine
+change to make subsequent reconciles idempotent on the already-published
+branch?
+
+## Hypothesis
+
+The file-creation path in the GitHub client wrapper unconditionally calls
+`PUT /repos/{owner}/{repo}/contents/{path}` (the "create file" call)
+without first checking whether the file exists on the target branch. On
+the first reconcile this works because the branch is fresh. On the
+second reconcile the branch and file already exist on the branch, and
+GitHub's contents API requires the existing blob's `sha` for an UPDATE.
+The fix is a small change in the wrapper: GET the file on the branch
+first; if it exists with the same content, no-op; if it exists with
+different content, send the existing `sha` along with the PUT to make
+it an UPDATE.
+
+## Context
+
+Surfaced 2026-05-02 during the chart 0.3.2 homelab smoke test. After
+chart 0.3.2 deployed cleanly (PR #67), the engine successfully created
+PR #1 on `donaldgifford/logpush` (CODEOWNERS) and PR #2 on
+`donaldgifford/repo-guardian-test-repo` (CODEOWNERS, dependabot,
+renovate). On the next reconcile tick the same two repos failed with
+422 because the engine tried to re-PUT files that were already on the
+`repo-guardian/add-missing-files` branch from the open PRs.
+
+The bug only manifests when an open repo-guardian PR exists and the
+weekly scheduler (or a webhook trigger) re-checks the same repo before
+the PR is merged. In a steady state where PRs merge quickly, the bug
+is invisible. In our homelab where PRs are intentionally left open for
+review, every subsequent reconcile against those repos fails.
+
+**Triggered by:** Chart 0.3.2 homelab smoke test (post-PR #67),
+recorded as a Known Issue in `CLAUDE.md`.
+
+## Approach
+
+1. Reproduce locally against `repo-guardian-test-repo` with the engine
+   in a loop: first reconcile creates PR, second reconcile must succeed
+   without 422.
+2. Trace the exact call path from `internal/checker/engine_policy.go`
+   through `internal/github/client.go` to the go-github contents API
+   call. Identify whether the create-or-update logic lives in the
+   wrapper or higher up in the engine.
+3. Inspect what `client.GetContents` (or equivalent) returns when the
+   file exists on the branch — confirm we get a usable `sha` back.
+4. Sketch the minimal patch: branch detection + file existence check +
+   sha forwarding. Confirm it doesn't break the first-reconcile path.
+5. Decide between (a) one-PR fix (small, scoped to client wrapper) and
+   (b) IMPL doc (if the fix touches multiple packages or needs new
+   tests beyond a unit test on the wrapper).
+
+## Environment
+
+| Component | Version / Value |
+|-----------|----------------|
+| Chart | 0.3.2 (production-deployed in homelab) |
+| Binary | appVersion 1.4.0 |
+| go-github | v68 |
+| Target repos (homelab) | `donaldgifford/logpush`, `donaldgifford/repo-guardian-test-repo` |
+| Stale branch | `repo-guardian/add-missing-files` |
+
+## Findings
+
+### Observation 1: Failure log from production
+
+From the homelab pod after the second reconcile tick (2026-05-02):
+
+```
+level=ERROR msg="failed to create file"
+  repo=donaldgifford/logpush
+  path=CODEOWNERS
+  branch=repo-guardian/add-missing-files
+  err="PUT https://api.github.com/repos/donaldgifford/logpush/contents/CODEOWNERS:
+       422 Invalid request. \"sha\" wasn't supplied. []"
+```
+
+GitHub's contents API distinguishes create (no `sha`) from update
+(must include the existing blob `sha`). The current engine path always
+treats the call as a create.
+
+### Observation 2: Workaround confirms the diagnosis
+
+Manually deleting the stale branch
+(`gh api -X DELETE repos/<owner>/<repo>/git/refs/heads/repo-guardian/add-missing-files`)
+allows the next reconcile to succeed, because the engine then re-creates
+the branch fresh and the file genuinely does not exist on it. This
+confirms the failure mode is "branch + file pre-existence" and not, for
+example, a stale token or a permissions regression.
+
+### Observation 3: Pending — code path
+
+To complete the investigation, identify the exact function in
+`internal/github/` (or `internal/checker/`) that issues the PUT and
+confirm whether the wrapper already has a GetContents helper we can
+call before the PUT.
+
+## Conclusion
+
+**Answer:** Pending — investigation is in progress.
+
+Preliminary: hypothesis is consistent with all observed evidence
+(production log + workaround). Remaining work is to read the client
+wrapper and confirm the smallest patch shape.
+
+## Recommendation
+
+**Pending — to be filled after Observation 3.**
+
+Likely shape:
+- If the fix is `<50` lines in `internal/github/client.go` plus a
+  unit test, ship a single PR labeled `fix` with `patch` semver.
+- If the fix touches engine-level logic (e.g., the engine needs to
+  decide between "skip the file because content is identical" vs.
+  "update the file because content differs"), promote to an IMPL doc.
+
+The engine should also surface a metric (`files_skipped_total{reason="already_present"}`?)
+for the no-op-on-identical-content case, so the homelab dashboards
+distinguish "engine did nothing" from "engine had nothing to do."
+
+## References
+
+- Known Issue entry in `CLAUDE.md`
+- Auto-memory pattern: "Pre-existing-branch 422 engine bug"
+- IMPL-0010 (chart 0.3.2 deployed the engine version where this surfaced)
+- GitHub contents API:
+  https://docs.github.com/en/rest/repos/contents#create-or-update-file-contents

--- a/docs/investigation/0003-pre-existing-branch-422-on-subsequent-reconciles.md
+++ b/docs/investigation/0003-pre-existing-branch-422-on-subsequent-reconciles.md
@@ -1,7 +1,7 @@
 ---
 id: INV-0003
 title: "Pre-existing branch 422 on subsequent reconciles"
-status: Open
+status: Resolved
 author: Donald Gifford
 created: 2026-05-02
 ---
@@ -9,7 +9,7 @@ created: 2026-05-02
 
 # INV 0003: Pre-existing branch 422 on subsequent reconciles
 
-**Status:** Open
+**Status:** Resolved
 **Author:** Donald Gifford
 **Date:** 2026-05-02
 
@@ -123,35 +123,66 @@ the branch fresh and the file genuinely does not exist on it. This
 confirms the failure mode is "branch + file pre-existence" and not, for
 example, a stale token or a permissions regression.
 
-### Observation 3: Pending — code path
+### Observation 3: Code path located in client wrapper
 
-To complete the investigation, identify the exact function in
-`internal/github/` (or `internal/checker/`) that issues the PUT and
-confirm whether the wrapper already has a GetContents helper we can
-call before the PUT.
+`internal/checker/engine_policy.go:553` and
+`internal/checker/engine.go:267` both call
+`client.CreateOrUpdateFile`. The wrapper at
+`internal/github/client.go:184-201` was misnamed — it called only
+`Repositories.CreateFile`, never `UpdateFile`, and never read the
+existing blob first. On a fresh branch this works; on a re-used
+`repo-guardian/add-missing-files` branch with the file already
+present, the call hits 422.
+
+The package already had a `GetContents` helper, but it took no `Ref`
+parameter and so always queried the default branch — useless for the
+"does the file exist on the target branch?" question we needed to
+answer. The fix inlines `Repositories.GetContents` with
+`RepositoryContentGetOptions{Ref: branch}` directly inside
+`CreateOrUpdateFile`, since this is the only caller that needs
+branch-scoped existence checks.
 
 ## Conclusion
 
-**Answer:** Pending — investigation is in progress.
+**Answer:** Yes — fix is small (≈35 lines in
+`internal/github/client.go` plus three unit tests) and lives entirely
+in the GitHub client wrapper.
 
-Preliminary: hypothesis is consistent with all observed evidence
-(production log + workaround). Remaining work is to read the client
-wrapper and confirm the smallest patch shape.
+`CreateOrUpdateFile` now performs:
+
+1. `GetContents(..., Ref: branch)` to check the target branch.
+2. If 404 → `CreateFile` (unchanged path).
+3. If 200 with byte-identical decoded content → return nil (idempotent
+   skip; no commit, no API write).
+4. If 200 with differing content → `UpdateFile` with the existing
+   blob's `sha`.
+
+This makes the function name truthful (it now actually creates *or*
+updates) and makes engine reconciles idempotent on the
+`repo-guardian/add-missing-files` branch.
 
 ## Recommendation
 
-**Pending — to be filled after Observation 3.**
+Shipping in this PR. Decisions made:
 
-Likely shape:
-- If the fix is `<50` lines in `internal/github/client.go` plus a
-  unit test, ship a single PR labeled `fix` with `patch` semver.
-- If the fix touches engine-level logic (e.g., the engine needs to
-  decide between "skip the file because content is identical" vs.
-  "update the file because content differs"), promote to an IMPL doc.
-
-The engine should also surface a metric (`files_skipped_total{reason="already_present"}`?)
-for the no-op-on-identical-content case, so the homelab dashboards
-distinguish "engine did nothing" from "engine had nothing to do."
+- **One-PR fix, not an IMPL.** All changes are in
+  `internal/github/client.go` and `internal/github/client_test.go`.
+  No engine logic changed, no public API changed, signature of
+  `CreateOrUpdateFile` is preserved so callers in `engine.go` and
+  `engine_policy.go` are unaffected.
+- **No new metric.** The "skipped because identical" case is silent.
+  Adding a `files_skipped_total{reason}` metric would be useful for
+  homelab dashboards, but it expands scope beyond the bug fix and
+  belongs in a separate PR if/when the dashboard need surfaces.
+  Logging a debug-level `"file unchanged on branch"` line was
+  considered and rejected for the same scope-creep reason.
+- **Bumped chart `appVersion` to 1.4.1.** Real bug fix, real binary
+  change → patch semver bump on the binary. Chart `version` stays
+  at 0.3.2 (no chart-level changes).
+- **Test coverage added.** Three tests cover all three branches:
+  `TestCreateOrUpdateFile_FileMissing_Creates`,
+  `TestCreateOrUpdateFile_FileExistsIdentical_Skips`,
+  `TestCreateOrUpdateFile_FileExistsDifferent_Updates`.
 
 ## References
 

--- a/docs/investigation/README.md
+++ b/docs/investigation/README.md
@@ -15,6 +15,7 @@ Design docs, plans, and implementation docs can reference investigations by ID
 |----|-------|--------|------|--------|------|
 | INV-0001 | Tailscale Funnel for Webhook Testing | Concluded | 2026-03-14 | Donald Gifford | [0001-tailscale-funnel-for-webhook-testing.md](0001-tailscale-funnel-for-webhook-testing.md) |
 | INV-0002 | Multi-org and Forgejo support for repo-guardian | Open | 2026-04-25 | Donald Gifford | [0002-multi-org-and-forgejo-support-for-repo-guardian.md](0002-multi-org-and-forgejo-support-for-repo-guardian.md) |
+| INV-0003 | Pre-existing branch 422 on subsequent reconciles | Open | 2026-05-02 | Donald Gifford | [0003-pre-existing-branch-422-on-subsequent-reconciles.md](0003-pre-existing-branch-422-on-subsequent-reconciles.md) |
 <!-- END DOCZ AUTO-GENERATED -->
 <!-- BEGIN DOCZ AUTO-GENERATED -->
 <!-- END DOCZ AUTO-GENERATED -->

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -182,18 +182,49 @@ func (c *GitHubClient) DeleteBranch(ctx context.Context, owner, repo, branch str
 }
 
 // CreateOrUpdateFile creates or updates a file on the given branch.
+//
+// If the file already exists on the branch with identical content, it is a
+// no-op. If it exists with different content, the existing blob sha is
+// forwarded so GitHub treats the call as an update rather than a create
+// (which would otherwise return 422 "sha wasn't supplied").
 func (c *GitHubClient) CreateOrUpdateFile(
 	ctx context.Context,
 	owner, repo, branch, path, content, message string,
 ) error {
+	existing, _, resp, err := c.ghClient().Repositories.GetContents(
+		ctx, owner, repo, path,
+		&gh.RepositoryContentGetOptions{Ref: branch},
+	)
+	if err != nil && (resp == nil || resp.StatusCode != http.StatusNotFound) {
+		return fmt.Errorf("checking file %s on %s in %s/%s: %w", path, branch, owner, repo, err)
+	}
+
 	opts := &gh.RepositoryContentFileOptions{
 		Message: gh.Ptr(message),
 		Content: []byte(content),
 		Branch:  gh.Ptr(branch),
 	}
 
-	_, _, err := c.ghClient().Repositories.CreateFile(ctx, owner, repo, path, opts)
-	if err != nil {
+	if existing != nil {
+		decoded, decodeErr := existing.GetContent()
+		if decodeErr != nil {
+			return fmt.Errorf("decoding existing %s on %s in %s/%s: %w", path, branch, owner, repo, decodeErr)
+		}
+
+		if decoded == content {
+			return nil
+		}
+
+		opts.SHA = existing.SHA
+
+		if _, _, err := c.ghClient().Repositories.UpdateFile(ctx, owner, repo, path, opts); err != nil {
+			return fmt.Errorf("updating file %s on %s in %s/%s: %w", path, branch, owner, repo, err)
+		}
+
+		return nil
+	}
+
+	if _, _, err := c.ghClient().Repositories.CreateFile(ctx, owner, repo, path, opts); err != nil {
 		return fmt.Errorf("creating file %s in %s/%s: %w", path, owner, repo, err)
 	}
 

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -244,6 +245,193 @@ func TestCreatePullRequest(t *testing.T) {
 
 	if receivedBase != "main" {
 		t.Errorf("expected base 'main', got %q", receivedBase)
+	}
+}
+
+func TestCreateOrUpdateFile_FileMissing_Creates(t *testing.T) {
+	t.Parallel()
+
+	var (
+		createCalled bool
+		createBody   gh.RepositoryContentFileOptions
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"GET /api/v3/repos/owner/repo/contents/CODEOWNERS",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		},
+	)
+	mux.HandleFunc(
+		"PUT /api/v3/repos/owner/repo/contents/CODEOWNERS",
+		func(w http.ResponseWriter, r *http.Request) {
+			createCalled = true
+
+			if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+				t.Errorf("decoding request: %v", err)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+
+			if err := json.NewEncoder(w).Encode(&gh.RepositoryContentResponse{}); err != nil {
+				t.Errorf("encoding response: %v", err)
+			}
+		},
+	)
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	err := client.CreateOrUpdateFile(
+		context.Background(),
+		"owner", "repo", "repo-guardian/add-missing-files", "CODEOWNERS",
+		"* @platform-team", "chore: add CODEOWNERS",
+	)
+	if err != nil {
+		t.Fatalf("CreateOrUpdateFile: %v", err)
+	}
+
+	if !createCalled {
+		t.Fatal("expected create PUT to fire when file is missing")
+	}
+
+	if createBody.SHA != nil {
+		t.Errorf("expected no sha on create, got %q", *createBody.SHA)
+	}
+
+	if string(createBody.Content) != "* @platform-team" {
+		t.Errorf("expected content forwarded to create, got %q", string(createBody.Content))
+	}
+}
+
+func TestCreateOrUpdateFile_FileExistsIdentical_Skips(t *testing.T) {
+	t.Parallel()
+
+	var putCalled bool
+
+	content := "* @platform-team"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"GET /api/v3/repos/owner/repo/contents/CODEOWNERS",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			resp := &gh.RepositoryContent{
+				Name:     gh.Ptr("CODEOWNERS"),
+				Path:     gh.Ptr("CODEOWNERS"),
+				Type:     gh.Ptr("file"),
+				SHA:      gh.Ptr("abc123"),
+				Encoding: gh.Ptr("base64"),
+				Content:  gh.Ptr(base64.StdEncoding.EncodeToString([]byte(content))),
+			}
+
+			if err := json.NewEncoder(w).Encode(resp); err != nil {
+				t.Errorf("encoding response: %v", err)
+			}
+		},
+	)
+	mux.HandleFunc(
+		"PUT /api/v3/repos/owner/repo/contents/CODEOWNERS",
+		func(w http.ResponseWriter, _ *http.Request) {
+			putCalled = true
+
+			w.WriteHeader(http.StatusOK)
+		},
+	)
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	err := client.CreateOrUpdateFile(
+		context.Background(),
+		"owner", "repo", "repo-guardian/add-missing-files", "CODEOWNERS",
+		content, "chore: add CODEOWNERS",
+	)
+	if err != nil {
+		t.Fatalf("CreateOrUpdateFile: %v", err)
+	}
+
+	if putCalled {
+		t.Error("expected no PUT when content matches existing file")
+	}
+}
+
+func TestCreateOrUpdateFile_FileExistsDifferent_Updates(t *testing.T) {
+	t.Parallel()
+
+	var (
+		putCalled bool
+		putBody   gh.RepositoryContentFileOptions
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(
+		"GET /api/v3/repos/owner/repo/contents/CODEOWNERS",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+
+			resp := &gh.RepositoryContent{
+				Name:     gh.Ptr("CODEOWNERS"),
+				Path:     gh.Ptr("CODEOWNERS"),
+				Type:     gh.Ptr("file"),
+				SHA:      gh.Ptr("oldsha456"),
+				Encoding: gh.Ptr("base64"),
+				Content:  gh.Ptr(base64.StdEncoding.EncodeToString([]byte("* @old-team"))),
+			}
+
+			if err := json.NewEncoder(w).Encode(resp); err != nil {
+				t.Errorf("encoding response: %v", err)
+			}
+		},
+	)
+	mux.HandleFunc(
+		"PUT /api/v3/repos/owner/repo/contents/CODEOWNERS",
+		func(w http.ResponseWriter, r *http.Request) {
+			putCalled = true
+
+			if err := json.NewDecoder(r.Body).Decode(&putBody); err != nil {
+				t.Errorf("decoding request: %v", err)
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+
+			if err := json.NewEncoder(w).Encode(&gh.RepositoryContentResponse{}); err != nil {
+				t.Errorf("encoding response: %v", err)
+			}
+		},
+	)
+
+	client, server := newTestClient(t, mux)
+	defer server.Close()
+
+	err := client.CreateOrUpdateFile(
+		context.Background(),
+		"owner", "repo", "repo-guardian/add-missing-files", "CODEOWNERS",
+		"* @new-team", "chore: update CODEOWNERS",
+	)
+	if err != nil {
+		t.Fatalf("CreateOrUpdateFile: %v", err)
+	}
+
+	if !putCalled {
+		t.Fatal("expected PUT to fire when content differs from existing file")
+	}
+
+	if putBody.SHA == nil || *putBody.SHA != "oldsha456" {
+		got := "<nil>"
+		if putBody.SHA != nil {
+			got = *putBody.SHA
+		}
+
+		t.Errorf("expected sha 'oldsha456' on update, got %q", got)
+	}
+
+	if string(putBody.Content) != "* @new-team" {
+		t.Errorf("expected new content on update, got %q", string(putBody.Content))
 	}
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,7 @@ nav:
         - Overview: investigation/README.md
         - 'INV-0001: Tailscale Funnel for Webhook Testing': investigation/0001-tailscale-funnel-for-webhook-testing.md
         - 'INV-0002: Multi-org and Forgejo support for repo-guardian': investigation/0002-multi-org-and-forgejo-support-for-repo-guardian.md
+        - 'INV-0003: Pre-existing branch 422 on subsequent reconciles': investigation/0003-pre-existing-branch-422-on-subsequent-reconciles.md
     - Legacy:
         - Custom Properties Implementation Plan: legacy/custom_properties_implementation.md
         - 'Feature Plan: Custom Properties from Backstage catalog-info.yaml': legacy/custom_properties.md


### PR DESCRIPTION
## Summary

Resolves the pre-existing-branch 422 surfaced during the chart 0.3.2 homelab smoke test (INV-0003).

- **Fix:** `internal/github/client.go.CreateOrUpdateFile` now GETs the file on the target branch first, then dispatches: identical content → no-op, different content → `UpdateFile` with the existing blob `sha`, missing → `CreateFile` (unchanged path).
- **Why one PR:** scoped entirely to the client wrapper. No engine logic, no public API change, no caller signatures touched. Three unit tests cover the three branches.
- **Investigation doc:** INV-0003 updated to Resolved with the code-path findings and the rationale for shipping in one PR vs. promoting to an IMPL.
- **Versioning:** chart `appVersion` 1.4.0 → 1.4.1 (real bug fix, patch semver). Chart `version` stays at 0.3.2 — no chart-level changes; the next chart publish will pick up the new appVersion.
- **CLAUDE.md / auto-memory:** updated to record the three-branch contract so a future rename of the function preserves the bug-fix invariant.

## Test plan

- [x] `go test -v -race -run TestCreateOrUpdateFile ./internal/github/...` (3/3 pass)
- [x] `make test` (full suite passes)
- [x] `make lint` (0 issues)
- [x] `make helm-test` (49/49 pass after appVersion regex bump)
- [ ] Homelab smoke test on the next reconcile tick — pre-existing branch should now succeed instead of 422 (validates after merge + chart publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)