### PR TITLE
chore(chart): bump 0.3.2 → 0.3.3 (carry appVersion 1.4.1)

### DIFF
--- a/charts/repo-guardian/Chart.yaml
+++ b/charts/repo-guardian/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: repo-guardian
 description: GitHub App that automates repository onboarding and compliance
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: "1.4.1"

--- a/charts/repo-guardian/README.md
+++ b/charts/repo-guardian/README.md
@@ -11,7 +11,7 @@ with cosign keyless, SLSA Level 3 provenance).
 ```bash
 helm install repo-guardian \
   oci://ghcr.io/donaldgifford/charts/repo-guardian \
-  --version 0.3.2 \
+  --version 0.3.3 \
   --namespace repo-guardian \
   --create-namespace \
   -f values.yaml
@@ -47,7 +47,7 @@ secrets:
 ```bash
 helm install repo-guardian \
   oci://ghcr.io/donaldgifford/charts/repo-guardian \
-  --version 0.3.2 \
+  --version 0.3.3 \
   --namespace repo-guardian \
   --create-namespace \
   -f values.yaml
@@ -70,7 +70,7 @@ cosign verify \
     '^https://github.com/donaldgifford/repo-guardian/.+' \
   --certificate-oidc-issuer \
     'https://token.actions.githubusercontent.com' \
-  ghcr.io/donaldgifford/charts/repo-guardian:0.3.2
+  ghcr.io/donaldgifford/charts/repo-guardian:0.3.3
 ```
 
 ### SLSA provenance
@@ -81,7 +81,7 @@ cosign verify-attestation --type slsaprovenance \
     '^https://github.com/slsa-framework/slsa-github-generator/.+' \
   --certificate-oidc-issuer \
     'https://token.actions.githubusercontent.com' \
-  ghcr.io/donaldgifford/charts/repo-guardian:0.3.2
+  ghcr.io/donaldgifford/charts/repo-guardian:0.3.3
 ```
 
 The provenance attestation records the build workflow path, source


### PR DESCRIPTION
## Summary

Republishes the chart to make 1.4.1 the default appVersion.

The 1.4.1 binary was published when PR #69 merged, but the chart-release workflow correctly idempotent-skipped because chart version 0.3.2 was already in the registry. Bumping chart version is the prescribed way to roll appVersion forward — chart and binary cadences are independent.

Engine fix verified in homelab via `image.tag` override on chart 0.3.2: pre-existing-branch reconciles now succeed instead of 422'ing (logs show "added file" + "updated existing PR" against the open repo-guardian branches).

## Test plan

- [x] `make helm-test` (49/49 pass)
- [x] `make helm-ct-lint` (passes)
- [x] `make helm-docs` (README install snippets updated to 0.3.3)
- [ ] Chart-release workflow republishes 0.3.3 with appVersion 1.4.1 on merge
- [ ] Homelab kustomize bumps `chart.version: 0.3.3` and removes the temporary `image.tag` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)