### PR TITLE
chore(ci): per-job paths filter via dorny/paths-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,36 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+      docker: ${{ steps.filter.outputs.docker }}
+      helm: ${{ steps.filter.outputs.helm }}
+      workflows: ${{ steps.filter.outputs.workflows }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            go:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+            docker:
+              - 'Dockerfile'
+              - 'docker-bake.hcl'
+              - '.dockerignore'
+            helm:
+              - 'charts/**'
+            workflows:
+              - '.github/workflows/**'
+
   labeler:
     permissions:
       contents: read
@@ -23,6 +53,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.helm == 'true' || needs.changes.outputs.workflows == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -45,6 +77,8 @@ jobs:
   test-go:
     name: Test Go
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.workflows == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -67,6 +101,8 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.workflows == 'true'
     permissions:
       security-events: write
       contents: read
@@ -87,6 +123,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.workflows == 'true'
     steps:
       - uses: actions/checkout@v6
 
@@ -104,6 +142,8 @@ jobs:
   docker-build:
     name: Docker Build
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.go == 'true' || needs.changes.outputs.docker == 'true' || needs.changes.outputs.workflows == 'true'
     permissions:
       contents: read
       packages: write
@@ -150,6 +190,8 @@ jobs:
   helm-unittest:
     name: Helm Unit Tests
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.helm == 'true' || needs.changes.outputs.workflows == 'true'
     steps:
       - uses: actions/checkout@v6
       - name: Set up Helm
@@ -166,6 +208,8 @@ jobs:
   helm-test:
     name: Helm Chart Test
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.helm == 'true' || needs.changes.outputs.workflows == 'true'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

Adds a `changes` setup job that diffs the PR (or push delta) via `dorny/paths-filter@v3` and emits boolean outputs for four file groups: `go`, `docker`, `helm`, `workflows`. Each downstream job declares `needs: changes` and gates on the relevant outputs:

| Job | Runs when |
|---|---|
| `lint` | `go` ∨ `helm` ∨ `workflows` |
| `test-go` | `go` ∨ `workflows` |
| `security` | `go` ∨ `workflows` |
| `build` | `go` ∨ `workflows` |
| `docker-build` | `go` ∨ `docker` ∨ `workflows` |
| `helm-unittest` | `helm` ∨ `workflows` |
| `helm-test` | `helm` ∨ `workflows` |

`labeler` keeps running unconditionally — it labels every PR based on the diff and is cheap.

## Effect

- **Docs-only PRs** (like the recently-merged #75) skip every heavy job. CI completes in ~5s (just `labeler` + `changes`).
- **Chart-only PRs** skip Go test/build/security/docker.
- **Workflow changes** still trigger everything so the CI config itself gets full validation — including this PR.

## Branch protection

Skipped jobs gated by `if:` on the job (not by workflow-level `paths:` filters) **do** report success against required status checks — this is GitHub's documented semantics. No branch protection changes required.

## Test plan

- [x] YAML lint clean
- [ ] This PR triggers all jobs (it touches `.github/workflows/ci.yml` → `workflows: true`) — proves the gating logic doesn't break the full path
- [ ] After merge, the next docs-only PR should show only `Label PR` and `Detect changes` running

🤖 Generated with [Claude Code](https://claude.com/claude-code)