### PR TITLE
chore(release): cut v1.7.0 rollup (chart 0.6.1, appVersion 1.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,38 +3,39 @@
 All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
-## [unreleased]
+## [1.7.0] - 2026-05-31
 
-### Features
+### Bug Fixes
 
-- *(store)* Store interface + in-memory implementation (IMPL-0011 P1.1)
-- *(queue)* Queue interface + in-memory implementation (IMPL-0011 P1.2)
-- *(scheduler)* Scheduler interface + ticker impl; rename old type to Sweeper (IMPL-0011 P1.3)
-- *(policy)* Policy.Version() helper for sweep freshness gate (IMPL-0011 P1.4)
-- *(config)* STORE_BACKEND / QUEUE_BACKEND / SCHEDULER_BACKEND knobs (IMPL-0011 P1.5)
-- *(worker)* Pool consuming queue.Queue.Subscribe (IMPL-0011 P1.7a)
-- *(store)* Postgres-backed Store with embedded migrations (IMPL-0011 P2)
-- *(queue)* Valkey-backed Queue + reaper (IMPL-0011 P3)
-- *(scheduler)* Valkey leader-elected scheduler (IMPL-0011 P4)
-- *(observability,sweep)* Wire IMPL-0011 P5 metrics + StaleSweeper
-- *(chart)* Multi-replica deployment shapes (IMPL-0011 P6)
-- *(test,docs)* Multi-replica integration test + ops docs (IMPL-0011 P7)
+- *(ci)* Use azure/setup-helm + direct plugin install for helm-unittest ([#76](https://github.com/donaldgifford/repo-guardian/issues/76))
 
 ### Refactor
 
-- *(workers)* Migrate webhook + sweeper + main.go to queue.Queue (IMPL-0011 P1.7-9)
+- *(checker)* IMPL-0014 Phase 1 collapse legacy engine path ([#85](https://github.com/donaldgifford/repo-guardian/issues/85))
 
 ### Documentation
 
-- *(impl)* Check off IMPL-0011 Phase 1 store/queue/scheduler interface tasks
-- *(impl)* Check off IMPL-0011 Phase 1 mockery + config tasks
-- *(impl)* Check off IMPL-0011 Phase 1 wiring tasks
-- CLAUDE.md note about IMPL-0011 P1 package layout
-- *(chart)* Scheduler contract tests + 0.5.0 upgrade notes (IMPL-0011 cleanup)
+- *(ops)* Chart 0.5.0 migration runbook (IMPL-0011) ([#75](https://github.com/donaldgifford/repo-guardian/issues/75))
+- *(claude)* Capture CI paths-filter convention + helm CLI gotchas ([#78](https://github.com/donaldgifford/repo-guardian/issues/78))
+- *(inv)* INV-0005 stale PRs when file rules become satisfied on main ([#80](https://github.com/donaldgifford/repo-guardian/issues/80))
+- *(inv)* INV-0006 per-org GitHub App credentials (deferred) ([#81](https://github.com/donaldgifford/repo-guardian/issues/81))
+- *(impl)* IMPL-0013 reconcile open PRs when file rules become satisfied ([#82](https://github.com/donaldgifford/repo-guardian/issues/82))
+- *(inv)* INV-0007 GitLab forge backend + INV-0006 scale clarification ([#84](https://github.com/donaldgifford/repo-guardian/issues/84))
+- DESIGN-0014 + IMPL-0014 — remove legacy engine path and deprecated overlays ([#83](https://github.com/donaldgifford/repo-guardian/issues/83))
+- IMPL-0014 Phase 3 purge legacy markdown + mkdocs nav block ([#87](https://github.com/donaldgifford/repo-guardian/issues/87))
+- *(0014)* Mark DESIGN-0014 + IMPL-0014 as Implemented ([#88](https://github.com/donaldgifford/repo-guardian/issues/88))
+- *(0014)* Check off final cross-phase verification ([#89](https://github.com/donaldgifford/repo-guardian/issues/89))
 
 ### Miscellaneous Tasks
 
-- *(mocks)* Mockery v2 setup + initial generation (IMPL-0011 P1.6)
+- *(ci)* Per-job paths filter via dorny/paths-filter ([#77](https://github.com/donaldgifford/repo-guardian/issues/77))
+- *(deploy)* IMPL-0014 Phase 2 remove Kustomize tree ([#86](https://github.com/donaldgifford/repo-guardian/issues/86))
+
+## [1.6.0] - 2026-05-06
+
+### Features
+
+- Persistent reconcile state + multi-replica coordination (IMPL-0011) ([#74](https://github.com/donaldgifford/repo-guardian/issues/74))
 
 ## [1.5.0] - 2026-05-05
 

--- a/charts/repo-guardian/Chart.yaml
+++ b/charts/repo-guardian/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: repo-guardian
 description: GitHub App that automates repository onboarding and compliance
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: "1.7.0"


### PR DESCRIPTION
## Summary

Rollup release covering IMPL-0013 (PR convergence) + IMPL-0014 (legacy cleanup). Catches the published binary up to the chart's existing `appVersion: 1.7.0` claim.

### Background

| Version | Status before this PR | Notes |
|---|---|---|
| v1.5.0 | Published 2026-05-05 | Last truthful release |
| v1.6.0 | Draft until 2026-05-31 | Goreleaser artifacts assembled for IMPL-0011/IMPL-0012 but never flipped Draft → Latest. Manually published today before opening this PR. |
| chart 0.6.0 | Published with `appVersion: 1.7.0` | Pointed at an image tag that didn't exist (`donaldgifford/repo-guardian:1.7.0`) |
| v1.7.0 | This PR | Becomes real on merge; backs the chart's existing appVersion claim |

All IMPL-0013 and IMPL-0014 work carried the `dont-release` label individually, on the assumption that a rollup release would catch everything up. This is that rollup.

### What's in v1.7.0

- **IMPL-0013** (chart 0.6.0 / appVersion 1.7.0 already advertised): PR auto-close when every file rule is satisfied; sticky reconcile-log PR comment with content-hash idempotency; new metrics (`prs_closed_total`, `pr_orphan_left_total`); new alerts (`RepoGuardianStaleOpenPRs`, `RepoGuardianPRDrift`); operator runbook at `docs/operations/pr-convergence-migration.md`.
- **IMPL-0014** (this rollup): legacy `NewEngine` path collapsed (~545 LOC removed); `internal/rules` slimmed to TemplateStore + embedded templates; Kustomize `deploy/` tree replaced by `deploy/MIGRATED.md` six-month tombstone; legacy markdown + mkdocs `Legacy:` nav block purged.

### Chart bump

`charts/repo-guardian/Chart.yaml`: `version: 0.6.0` → `0.6.1`. The chart's rendered manifests didn't change between 0.6.0 and 0.6.1 — only `appVersion` becomes truthful. Patch-level bump.

## Test plan

- [x] Pre-merge: `helm lint charts/repo-guardian/` clean
- [x] Pre-merge: chart-release dry-run validated post-IMPL-0014 (run 26717238630)
- [ ] Post-merge: `release.yml` fires, jefflinse/pr-semver-bump bumps v1.6.0 → v1.7.0, goreleaser builds binaries, docker image pushed to ghcr.io
- [ ] Post-merge: `chart-release.yml` fires (paths-filter matches `charts/**`), publishes chart 0.6.1 to OCI registry
- [ ] Post-merge: cosign verify on both artifacts
- [ ] Operator: bump homelab ArgoCD Application to chart 0.6.1, smoke-test repo onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)