### PR TITLE
chore(chart): add revisionHistoryLimit, bump PG 16.4 → 17.4, CNPG cutover runbook

### DIFF
--- a/charts/repo-guardian/Chart.yaml
+++ b/charts/repo-guardian/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: repo-guardian
 description: GitHub App that automates repository onboarding and compliance
 type: application
-version: 0.6.1
+version: 0.6.2
 appVersion: "1.7.0"

--- a/charts/repo-guardian/README.md
+++ b/charts/repo-guardian/README.md
@@ -11,7 +11,7 @@ with cosign keyless, SLSA Level 3 provenance).
 ```bash
 helm install repo-guardian \
   oci://ghcr.io/donaldgifford/charts/repo-guardian \
-  --version 0.6.0 \
+  --version 0.6.2 \
   --namespace repo-guardian \
   --create-namespace \
   -f values.yaml
@@ -47,7 +47,7 @@ secrets:
 ```bash
 helm install repo-guardian \
   oci://ghcr.io/donaldgifford/charts/repo-guardian \
-  --version 0.6.0 \
+  --version 0.6.2 \
   --namespace repo-guardian \
   --create-namespace \
   -f values.yaml
@@ -141,7 +141,7 @@ cosign verify \
     '^https://github.com/donaldgifford/repo-guardian/.+' \
   --certificate-oidc-issuer \
     'https://token.actions.githubusercontent.com' \
-  ghcr.io/donaldgifford/charts/repo-guardian:0.6.0
+  ghcr.io/donaldgifford/charts/repo-guardian:0.6.2
 ```
 
 ### SLSA provenance
@@ -152,7 +152,7 @@ cosign verify-attestation --type slsaprovenance \
     '^https://github.com/slsa-framework/slsa-github-generator/.+' \
   --certificate-oidc-issuer \
     'https://token.actions.githubusercontent.com' \
-  ghcr.io/donaldgifford/charts/repo-guardian:0.6.0
+  ghcr.io/donaldgifford/charts/repo-guardian:0.6.2
 ```
 
 The provenance attestation records the build workflow path, source
@@ -319,6 +319,7 @@ incoming webhook.
 | readinessProbe.periodSeconds | int | `10` |  |
 | replicaCount | int | `1` | Number of replicas |
 | resources | object | `{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | Container resource requests and limits |
+| revisionHistoryLimit | int | `3` | Number of old ReplicaSets retained for rollback. Defaults to 3 to keep the kubectl `get rs` view tidy; bump if you need more rollback headroom. Kubernetes default is 10. |
 | scheduler | object | `{"backend":"ticker"}` | Scheduler (sweep cadence) backend. |
 | scheduler.backend | string | `"ticker"` | Backend implementation: "ticker" (single-replica) or "valkey" (leader-elected via SETNX). Valkey scheduler shares the queue's Valkey instance. |
 | secrets | object | `{"create":true,"existingSecret":"","privateKey":"","privateKeyAsFile":true,"webhookSecret":""}` | GitHub App secrets |
@@ -341,16 +342,16 @@ incoming webhook.
 | staleSweep.batchSize | int | `200` | Cap on rows returned per StaleRepos query. |
 | staleSweep.freshness | string | `"24h"` | Maximum age of a stored last_checked_at before the sweep requeues. Default 24h. Effective only with store.backend=postgres. |
 | staleSweep.rateLimitReserve | float | `0.1` | Fraction of an installation's GitHub rate-limit budget reserved against the stale-sweep enqueue path. |
-| store | object | `{"backend":"memory","postgres":{"baked":{"image":"postgres:16.4","resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}},"storageClassName":"","storageSize":"10Gi"},"cnpg":{"imageName":"ghcr.io/cloudnative-pg/postgresql:16.4","instances":1,"pooler":{"enabled":false,"instances":2,"type":"rw"},"storage":{"size":"10Gi","storageClass":""}},"existingSecret":"","existingSecretKey":"STORE_DSN","maxConns":16,"mode":"baked"}}` | Persistent state store (per-repo reconcile state). See DESIGN-0012 §Backend modes. |
+| store | object | `{"backend":"memory","postgres":{"baked":{"image":"postgres:17.4","resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}},"storageClassName":"","storageSize":"10Gi"},"cnpg":{"imageName":"ghcr.io/cloudnative-pg/postgresql:17.4","instances":1,"pooler":{"enabled":false,"instances":2,"type":"rw"},"storage":{"size":"10Gi","storageClass":""}},"existingSecret":"","existingSecretKey":"STORE_DSN","maxConns":16,"mode":"baked"}}` | Persistent state store (per-repo reconcile state). See DESIGN-0012 §Backend modes. |
 | store.backend | string | `"memory"` | Backend implementation: "memory" (single-replica, no persistence) or "postgres". |
-| store.postgres | object | `{"baked":{"image":"postgres:16.4","resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}},"storageClassName":"","storageSize":"10Gi"},"cnpg":{"imageName":"ghcr.io/cloudnative-pg/postgresql:16.4","instances":1,"pooler":{"enabled":false,"instances":2,"type":"rw"},"storage":{"size":"10Gi","storageClass":""}},"existingSecret":"","existingSecretKey":"STORE_DSN","maxConns":16,"mode":"baked"}` | Postgres-specific configuration. Ignored when backend != postgres. |
-| store.postgres.baked | object | `{"image":"postgres:16.4","resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}},"storageClassName":"","storageSize":"10Gi"}` | Baked Postgres-only configuration. |
-| store.postgres.baked.image | string | `"postgres:16.4"` | Pinned image. Bump intentionally. |
+| store.postgres | object | `{"baked":{"image":"postgres:17.4","resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}},"storageClassName":"","storageSize":"10Gi"},"cnpg":{"imageName":"ghcr.io/cloudnative-pg/postgresql:17.4","instances":1,"pooler":{"enabled":false,"instances":2,"type":"rw"},"storage":{"size":"10Gi","storageClass":""}},"existingSecret":"","existingSecretKey":"STORE_DSN","maxConns":16,"mode":"baked"}` | Postgres-specific configuration. Ignored when backend != postgres. |
+| store.postgres.baked | object | `{"image":"postgres:17.4","resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}},"storageClassName":"","storageSize":"10Gi"}` | Baked Postgres-only configuration. |
+| store.postgres.baked.image | string | `"postgres:17.4"` | Pinned image. Bump intentionally. |
 | store.postgres.baked.resources | object | `{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resource requests/limits for the Postgres container. |
 | store.postgres.baked.storageClassName | string | `""` | StorageClass name. Empty → cluster default. |
 | store.postgres.baked.storageSize | string | `"10Gi"` | Persistent volume size. |
-| store.postgres.cnpg | object | `{"imageName":"ghcr.io/cloudnative-pg/postgresql:16.4","instances":1,"pooler":{"enabled":false,"instances":2,"type":"rw"},"storage":{"size":"10Gi","storageClass":""}}` | CloudNativePG-only configuration. |
-| store.postgres.cnpg.imageName | string | `"ghcr.io/cloudnative-pg/postgresql:16.4"` | CNPG-managed Postgres image. |
+| store.postgres.cnpg | object | `{"imageName":"ghcr.io/cloudnative-pg/postgresql:17.4","instances":1,"pooler":{"enabled":false,"instances":2,"type":"rw"},"storage":{"size":"10Gi","storageClass":""}}` | CloudNativePG-only configuration. |
+| store.postgres.cnpg.imageName | string | `"ghcr.io/cloudnative-pg/postgresql:17.4"` | CNPG-managed Postgres image. |
 | store.postgres.cnpg.instances | int | `1` | Number of CNPG instances. |
 | store.postgres.cnpg.pooler | object | `{"enabled":false,"instances":2,"type":"rw"}` | Connection pooler (PgBouncer). |
 | store.postgres.cnpg.storage | object | `{"size":"10Gi","storageClass":""}` | Storage block. |

--- a/charts/repo-guardian/templates/deployment.yaml
+++ b/charts/repo-guardian/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "repo-guardian.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "repo-guardian.selectorLabels" . | nindent 6 }}

--- a/charts/repo-guardian/tests/deployment_test.yaml
+++ b/charts/repo-guardian/tests/deployment_test.yaml
@@ -16,6 +16,20 @@ tests:
           path: spec.replicas
           value: 3
 
+  - it: should default revisionHistoryLimit to 3
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 3
+
+  - it: should override revisionHistoryLimit from values
+    set:
+      revisionHistoryLimit: 10
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 10
+
   - it: should use default image tag from appVersion
     asserts:
       - matchRegex:

--- a/charts/repo-guardian/values.yaml
+++ b/charts/repo-guardian/values.yaml
@@ -2,6 +2,11 @@
 # -- Number of replicas
 replicaCount: 1
 
+# -- Number of old ReplicaSets retained for rollback. Defaults to 3 to
+# keep the kubectl `get rs` view tidy; bump if you need more rollback
+# headroom. Kubernetes default is 10.
+revisionHistoryLimit: 3
+
 image:
   # -- Container image repository
   repository: ghcr.io/donaldgifford/repo-guardian
@@ -229,7 +234,7 @@ store:
     # -- Baked Postgres-only configuration.
     baked:
       # -- Pinned image. Bump intentionally.
-      image: postgres:16.4
+      image: postgres:17.4
       # -- Persistent volume size.
       storageSize: 10Gi
       # -- StorageClass name. Empty → cluster default.
@@ -247,7 +252,7 @@ store:
       # -- Number of CNPG instances.
       instances: 1
       # -- CNPG-managed Postgres image.
-      imageName: ghcr.io/cloudnative-pg/postgresql:16.4
+      imageName: ghcr.io/cloudnative-pg/postgresql:17.4
       # -- Storage block.
       storage:
         size: 10Gi

--- a/docs/operations/cnpg-homelab-cutover.md
+++ b/docs/operations/cnpg-homelab-cutover.md
@@ -1,0 +1,237 @@
+# Homelab CNPG cutover runbook
+
+You are running chart `0.6.x` with `store.backend=memory` (single-pod,
+no persistence) and want to switch to `store.backend=postgres` with
+`postgres.mode=cnpg` so reconcile state survives pod restarts.
+
+This runbook assumes:
+
+- Chart `0.6.2` or newer (for the `revisionHistoryLimit` knob).
+- A Talos / vanilla k8s cluster managed via ArgoCD.
+- You're OK rotating the in-memory reconcile state — there's no
+  migration from the memory store, you just lose the in-flight
+  knowledge of which repos were recently swept (next sweep
+  catches everything up).
+
+For the full post-cutover smoke gate (8 checks: schema applied,
+leader-election working, queue draining, alerts firing, etc.), see
+[`chart-0.5.0-migration.md`](chart-0.5.0-migration.md) "Smoke checks".
+This doc focuses on the four homelab-specific gaps that runbook
+glosses over.
+
+## Pre-flight (15 min)
+
+### 1. CNPG operator prerequisite
+
+The chart renders a `Cluster` CR (`postgresql.cnpg.io/v1`) and an
+optional `Pooler`. Both require the CNPG operator to be installed
+**before** you apply the chart values change, or ArgoCD will sync
+the Application into a `ComparisonError` state.
+
+```bash
+# Verify the CRDs are present.
+kubectl get crd | grep postgresql.cnpg.io
+# Expected:
+#   backups.postgresql.cnpg.io
+#   clusters.postgresql.cnpg.io
+#   poolers.postgresql.cnpg.io
+#   scheduledbackups.postgresql.cnpg.io
+```
+
+If missing, install the operator first. The maintained path is
+the upstream Helm chart:
+
+```bash
+helm repo add cnpg https://cloudnative-pg.github.io/charts
+helm upgrade --install cnpg cnpg/cloudnative-pg \
+  --namespace cnpg-system \
+  --create-namespace \
+  --version 0.22.x
+```
+
+Pin to a known-good operator version (the chart was tested against
+CNPG operator `1.24.x` lineage). The CNPG operator runs cluster-wide
+and only needs installing once per cluster.
+
+### 2. Pick a StorageClass explicitly
+
+The chart's `store.postgres.cnpg.storage.storageClass` defaults to
+`""`, which falls back to the cluster's default StorageClass. On
+Talos with multiple SCs (rook-ceph, local-path, longhorn, etc.) the
+"default" can drift silently — better to pin it.
+
+```bash
+kubectl get sc
+# Pick the one you want; check it supports ReadWriteOnce.
+```
+
+Add to your values:
+
+```yaml
+store:
+  postgres:
+    cnpg:
+      storage:
+        size: 10Gi
+        storageClass: rook-ceph-block   # or whatever you picked
+```
+
+### 3. CNPG-created Secret timing
+
+When `mode=cnpg`, the chart wires `STORE_DSN` from a Secret that the
+**CNPG operator** creates after it provisions the Cluster — typically
+named `<release-name>-postgres-app`, key `uri`. This secret does not
+exist at the moment ArgoCD applies the manifests; CNPG creates it
+during cluster bootstrap (10-60 seconds typical).
+
+Consequence: the `repo-guardian` Deployment will `CrashLoopBackOff`
+during initial sync because its `STORE_DSN` env var references a
+Secret key that doesn't exist yet. This is **expected** and self-heals
+within 1-2 reconcile loops once CNPG finishes bootstrapping.
+
+If you want the bring-up to look clean in ArgoCD's UI:
+
+- Add `argocd.argoproj.io/sync-wave` annotations so the CNPG
+  `Cluster` resource lands before the `Deployment`. The chart
+  doesn't ship these by default (they're cluster-policy-specific).
+- Or, use `argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true`
+  on the Application to suppress the noise.
+
+For first-time bring-up, just let it CrashLoop for a minute and
+verify it recovers on its own.
+
+### 4. revisionHistoryLimit (chart 0.6.2+)
+
+You're already getting this — chart `0.6.2` defaults
+`revisionHistoryLimit: 3`. If you want a different value, set:
+
+```yaml
+revisionHistoryLimit: 5
+```
+
+This applies to the `repo-guardian` Deployment only. The CNPG-managed
+Postgres Cluster has its own retention via the operator; not exposed
+through the repo-guardian chart.
+
+## Values diff (homelab reference)
+
+```yaml
+# Before (chart 0.6.x, memory store)
+replicaCount: 1
+store:
+  backend: memory
+
+# After (chart 0.6.2, CNPG store)
+replicaCount: 1                         # bump to 3 if you also want HA
+revisionHistoryLimit: 3                 # chart 0.6.2 default; explicit for clarity
+store:
+  backend: postgres
+  postgres:
+    mode: cnpg
+    cnpg:
+      instances: 1                      # bump to 3 for CNPG HA replicas
+      storage:
+        size: 10Gi
+        storageClass: rook-ceph-block   # pin explicitly
+      pooler:
+        enabled: false                  # optional PgBouncer; skip for single-replica
+```
+
+If you also want to flip the queue + scheduler to durable backends
+in the same change (recommended for `replicaCount > 1`, optional for
+single-replica), add:
+
+```yaml
+queue:
+  backend: valkey
+  valkey:
+    mode: baked                         # single-pod Valkey from the chart
+scheduler:
+  backend: valkey                       # SETNX leader-election
+```
+
+The full multi-replica reference is in
+[`chart-0.5.0-migration.md`](chart-0.5.0-migration.md) Stage 2.
+
+## Bring-up sequence
+
+1. Cosign-verify the new chart version:
+
+   ```bash
+   cosign verify \
+     --certificate-identity-regexp \
+       '^https://github.com/donaldgifford/repo-guardian/.+' \
+     --certificate-oidc-issuer \
+       'https://token.actions.githubusercontent.com' \
+     ghcr.io/donaldgifford/charts/repo-guardian:0.6.2
+   ```
+
+2. Render the chart locally and diff against the live state to
+   confirm only expected resources change:
+
+   ```bash
+   helm template repo-guardian \
+     oci://ghcr.io/donaldgifford/charts/repo-guardian \
+     --version 0.6.2 \
+     --namespace repo-guardian \
+     -f values.yaml > /tmp/rg-after.yaml
+   diff <(kubectl get -n repo-guardian deploy,svc,sts,cluster.postgresql.cnpg.io \
+     -o yaml) /tmp/rg-after.yaml
+   ```
+
+   Expect: new `Cluster` resource, new `Service` for Postgres, env
+   var changes on the Deployment (`STORE_BACKEND`, `STORE_DSN`).
+
+3. Sync the ArgoCD Application or run `helm upgrade`.
+
+4. Watch the rollout:
+
+   ```bash
+   kubectl get pods -n repo-guardian -w
+   # Order: CNPG cluster pod(s) → repo-guardian (will crashloop briefly)
+   #        → repo-guardian Ready once Postgres is up.
+   ```
+
+5. Once both pods are Ready, run the [`chart-0.5.0-migration.md`
+   smoke checks](chart-0.5.0-migration.md#smoke-checks-8-gates):
+
+   - Schema applied (`\dt` shows `repo_state`, `schema_migrations`)
+   - Pod restart no longer triggers a full re-sweep (the original
+     reason for this cutover)
+   - `store_query_seconds` metric is populated
+   - No flapping in `RepoGuardianStoreUnavailable` alert
+
+## Rollback
+
+If something goes wrong, the rollback is values-only:
+
+```yaml
+store:
+  backend: memory
+```
+
+After applying, the chart drops the `Cluster` resource. **The CNPG
+operator does not auto-delete the PVC**; you'll need to do that by
+hand if you want the storage reclaimed:
+
+```bash
+kubectl delete pvc -n repo-guardian -l \
+  cnpg.io/cluster=repo-guardian-postgres
+```
+
+The reconcile state in Postgres is lost on rollback (the memory
+store starts empty), but that's the same state you started with
+before this runbook.
+
+## See also
+
+- [`chart-0.5.0-migration.md`](chart-0.5.0-migration.md) — full
+  multi-replica migration runbook (covers Valkey + scheduler too)
+- [`scaling.md`](scaling.md) — replica counts, batch size, freshness
+  tuning
+- [`migrations.md`](migrations.md) — in-process schema migration
+  runner behavior
+- [DESIGN-0012](../design/0012-persistent-reconcile-state-and-multi-replica-coordination.md)
+  — backend mode rationale
+- Chart values: `charts/repo-guardian/values.yaml` (lines 211-259
+  for the CNPG knobs)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
     - Operations:
         - Chart 0.5.0 migration runbook (IMPL-0011): operations/chart-0.5.0-migration.md
         - Chart 0.6.0 / appVersion 1.7.0 — PR convergence migration: operations/pr-convergence-migration.md
+        - Homelab CNPG cutover: operations/cnpg-homelab-cutover.md
         - Postgres schema operations: operations/migrations.md
         - Scaling repo-guardian: operations/scaling.md
         - Template migration guide (chart 0.3.x → 0.4.0): operations/template-migration.md


### PR DESCRIPTION
## Summary

Three operator-quality-of-life improvements bundled into chart `0.6.2`:

1. **`revisionHistoryLimit` knob (default 3, was implicit 10)** — the Deployment was retaining 10 old ReplicaSets per Kubernetes default, which made `kubectl get rs` noisy. The value is now operator-tunable and defaults to 3.
2. **Postgres image bump 16.4 → 17.4** (both `baked` and `cnpg` modes) — 16.4 dated to Aug 2024 and was unbumped through several chart revisions; Postgres 17 has been GA since Sept 2024. Better to start fresh installs on the current major.
3. **`docs/operations/cnpg-homelab-cutover.md` runbook** — memory → CNPG cutover for chart 0.6.x specifically. Covers the four gaps the existing `chart-0.5.0-migration.md` runbook glosses over for a 0.6.x homelab consumer: CNPG operator prereq, explicit StorageClass pinning on Talos, CNPG-created Secret bootstrap timing, and the new `revisionHistoryLimit` knob.

## Breaking changes

None for default users (`store.backend=memory` is untouched). Operators currently running `store.backend=postgres` will see the image pin advance from 16.4 to 17.4; **for in-place upgrade**, pin via values before applying:

```yaml
store:
  postgres:
    baked:
      image: postgres:16.10   # pin to current 16.x patch
```

(Or for CNPG, the `imageName` field.) Major-version upgrade (16 → 17) for existing deployments needs `pg_upgrade` or logical replication; out of scope for this PR.

## Test plan

- [x] `helm lint charts/repo-guardian/` clean
- [x] `helm unittest charts/repo-guardian/` 73/73 pass (2 new cases for revisionHistoryLimit)
- [x] `make helm-docs` regenerated README — version-table reflects new values
- [ ] Post-merge: chart-release.yml fires, publishes chart 0.6.2 to OCI
- [ ] Operator: bump homelab to chart 0.6.2; later, follow the new cnpg-homelab-cutover.md to enable persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)