### PR TITLE
feat(policy): add non_empty assertion type for yaml_path

### DIFF
--- a/examples/guardian-full.hcl
+++ b/examples/guardian-full.hcl
@@ -171,6 +171,15 @@ rule "file" "catalog_info" {
     message   = "spec.owner must reference a team (e.g., team-platform)"
   }
 
+  # YAML path non-empty assertion — fails when the path is missing or
+  # resolves to an empty string. Use this when you just want a field
+  # set without enforcing a specific value/substring.
+  assertion {
+    yaml_path = "spec.system"
+    non_empty = true
+    message   = "spec.system must be set"
+  }
+
   # Negative assertion — no placeholder values.
   assertion {
     not_pattern = "TODO"

--- a/internal/policy/assertion.go
+++ b/internal/policy/assertion.go
@@ -16,6 +16,7 @@ type CompiledAssertion struct {
 	yamlPath   string
 	contains   string
 	equals     string
+	nonEmpty   bool
 	message    string
 }
 
@@ -41,6 +42,7 @@ func compileAssertion(a *AssertionConfig) (CompiledAssertion, error) {
 		yamlPath: a.YAMLPath,
 		contains: a.Contains,
 		equals:   a.Equals,
+		nonEmpty: a.NonEmpty,
 		message:  a.Message,
 	}
 
@@ -105,6 +107,12 @@ func (ca *CompiledAssertion) evaluateYAMLPath(content string) error {
 
 	if ca.equals != "" {
 		if !slices.Contains(values, ca.equals) {
+			return fmt.Errorf("%s", ca.message)
+		}
+	}
+
+	if ca.nonEmpty {
+		if len(values) == 0 || slices.Contains(values, "") {
 			return fmt.Errorf("%s", ca.message)
 		}
 	}

--- a/internal/policy/assertion_test.go
+++ b/internal/policy/assertion_test.go
@@ -191,6 +191,100 @@ spec:
 	}
 }
 
+func TestEvaluate_YAMLPathNonEmptyPass(t *testing.T) {
+	content := `
+spec:
+  owner: donald
+`
+	compiled, err := CompileAssertions([]AssertionConfig{
+		{YAMLPath: "spec.owner", NonEmpty: true, Message: "owner must be set"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := compiled[0].Evaluate(content); err != nil {
+		t.Errorf("expected pass, got: %v", err)
+	}
+}
+
+func TestEvaluate_YAMLPathNonEmpty_MissingPathFails(t *testing.T) {
+	content := `
+spec:
+  lifecycle: production
+`
+	compiled, err := CompileAssertions([]AssertionConfig{
+		{YAMLPath: "spec.owner", NonEmpty: true, Message: "owner must be set"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = compiled[0].Evaluate(content)
+	if err == nil {
+		t.Fatal("expected failure for missing path")
+	}
+
+	if err.Error() != "owner must be set" {
+		t.Errorf("got %q, want %q", err, "owner must be set")
+	}
+}
+
+func TestEvaluate_YAMLPathNonEmpty_EmptyStringFails(t *testing.T) {
+	content := `
+spec:
+  owner: ""
+`
+	compiled, err := CompileAssertions([]AssertionConfig{
+		{YAMLPath: "spec.owner", NonEmpty: true, Message: "owner must be set"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = compiled[0].Evaluate(content)
+	if err == nil {
+		t.Fatal("expected failure for empty string value")
+	}
+}
+
+func TestEvaluate_YAMLPathNonEmpty_BareKeyFails(t *testing.T) {
+	// `owner:` with no value parses as nil → empty string in our resolver.
+	content := `
+spec:
+  owner:
+`
+	compiled, err := CompileAssertions([]AssertionConfig{
+		{YAMLPath: "spec.owner", NonEmpty: true, Message: "owner must be set"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := compiled[0].Evaluate(content); err == nil {
+		t.Fatal("expected failure for bare key with no value")
+	}
+}
+
+func TestEvaluate_YAMLPathNonEmpty_AllValuesMustBeNonEmpty(t *testing.T) {
+	// Wildcard match where one entry is empty — fail.
+	content := `
+updates:
+  - package-ecosystem: gomod
+  - package-ecosystem: ""
+`
+	compiled, err := CompileAssertions([]AssertionConfig{
+		{YAMLPath: "updates[*].package-ecosystem", NonEmpty: true, Message: "every entry must be set"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := compiled[0].Evaluate(content); err == nil {
+		t.Fatal("expected failure when any wildcard value is empty")
+	}
+}
+
 func TestEvaluateAssertions_AllPass(t *testing.T) {
 	content := `
 spec:

--- a/internal/policy/loader.go
+++ b/internal/policy/loader.go
@@ -736,6 +736,8 @@ func decodeAssertionBlock(block *hcl.Block, ctx *hcl.EvalContext) (*AssertionCon
 			a.Contains = val.AsString()
 		case "equals":
 			a.Equals = val.AsString()
+		case "non_empty":
+			a.NonEmpty = val.True()
 		case "message":
 			a.Message = val.AsString()
 		}

--- a/internal/policy/types.go
+++ b/internal/policy/types.go
@@ -187,13 +187,15 @@ type PRTemplate struct {
 
 // AssertionConfig defines a content assertion for a file rule.
 // Pattern and YAMLPath are mutually exclusive.
-// When YAMLPath is set, either Contains or Equals must also be set.
+// When YAMLPath is set, exactly one of Contains, Equals, or NonEmpty
+// must also be set.
 type AssertionConfig struct {
 	Pattern    string `hcl:"pattern,optional"`
 	NotPattern string `hcl:"not_pattern,optional"`
 	YAMLPath   string `hcl:"yaml_path,optional"`
 	Contains   string `hcl:"contains,optional"`
 	Equals     string `hcl:"equals,optional"`
+	NonEmpty   bool   `hcl:"non_empty,optional"`
 	Message    string `hcl:"message"`
 }
 

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -128,9 +128,9 @@ func validateAssertion(a *AssertionConfig, prefix string) []error {
 		))
 	}
 
-	if hasYAMLPath && a.Contains == "" && a.Equals == "" {
+	if hasYAMLPath && a.Contains == "" && a.Equals == "" && !a.NonEmpty {
 		errs = append(errs, fmt.Errorf(
-			"%s: yaml_path requires either contains or equals",
+			"%s: yaml_path requires one of contains, equals, or non_empty",
 			prefix,
 		))
 	}

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -252,8 +252,8 @@ func TestValidate_AssertionYAMLPathRequiresContainsOrEquals(t *testing.T) {
 		t.Fatal("expected error for yaml_path without contains/equals")
 	}
 
-	if !strings.Contains(err.Error(), "requires either contains or equals") {
-		t.Errorf("error %q should mention requires contains or equals", err)
+	if !strings.Contains(err.Error(), "requires one of contains, equals, or non_empty") {
+		t.Errorf("error %q should mention requires contains, equals, or non_empty", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `non_empty = true` to the `assertion {}` HCL block. Usable alongside `yaml_path` to express "the value at this path must be set" without prescribing a substring or specific value.

```hcl
assertion {
  yaml_path = "spec.owner"
  non_empty = true
  message   = "spec.owner must be set"
}
```

### Why

Catalog-info policies often want to require that `spec.owner` is populated, but previously the only options were:

- **Regex `pattern`** against the entire file — matches `owner:` with no value (loose); matches comments containing the word "owner" (false positives).
- **`contains` substring** under `yaml_path` — prescribes a specific shape (`"team"`, `":"`, etc.) that may not fit how operators name their owners.

`non_empty` is the natural fallback when you just want the field to exist with *some* value.

### Semantics

| Resolved values | Result |
|---|---|
| Path missing → no values | fail |
| Single value `""` | fail |
| Wildcard `[*]` with any value `""` | fail (ALL semantics) |
| All values non-empty | pass |

### Schema migration

Additive — no existing HCL needs to change. Validator was relaxed: `yaml_path` now requires one of `{contains, equals, non_empty}` instead of just `{contains, equals}`. Old configs continue to validate.

## Test plan

- [x] `make ci` clean (5 new assertion test cases + updated validator test)
- [x] `go test -v -run 'TestEvaluate_YAMLPathNonEmpty' ./internal/policy/...` passes
- [x] `examples/guardian-full.hcl` updated with a `non_empty` example next to the existing `contains` example

🤖 Generated with [Claude Code](https://claude.com/claude-code)