### PR TITLE
chore(chart): bump 0.6.2 → 0.6.3, appVersion 1.7.0 → 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project are documented here. The format is
 based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 this project adheres to [Semantic Versioning](https://semver.org/).
+## [1.8.0] - 2026-05-31
+
+### Features
+
+- *(policy)* Add non_empty assertion type for yaml_path ([#92](https://github.com/donaldgifford/repo-guardian/issues/92))
+
+### Miscellaneous Tasks
+
+- *(chart)* Add revisionHistoryLimit, bump PG 16.4 → 17.4, CNPG cutover runbook ([#91](https://github.com/donaldgifford/repo-guardian/issues/91))
+
 ## [1.7.0] - 2026-05-31
 
 ### Bug Fixes
@@ -30,6 +40,7 @@ this project adheres to [Semantic Versioning](https://semver.org/).
 
 - *(ci)* Per-job paths filter via dorny/paths-filter ([#77](https://github.com/donaldgifford/repo-guardian/issues/77))
 - *(deploy)* IMPL-0014 Phase 2 remove Kustomize tree ([#86](https://github.com/donaldgifford/repo-guardian/issues/86))
+- *(release)* Cut v1.7.0 rollup (chart 0.6.1, appVersion 1.7.0) ([#90](https://github.com/donaldgifford/repo-guardian/issues/90))
 
 ## [1.6.0] - 2026-05-06
 

--- a/charts/repo-guardian/Chart.yaml
+++ b/charts/repo-guardian/Chart.yaml
@@ -3,5 +3,5 @@ apiVersion: v2
 name: repo-guardian
 description: GitHub App that automates repository onboarding and compliance
 type: application
-version: 0.6.2
-appVersion: "1.7.0"
+version: 0.6.3
+appVersion: "1.8.0"

--- a/charts/repo-guardian/README.md
+++ b/charts/repo-guardian/README.md
@@ -11,7 +11,7 @@ with cosign keyless, SLSA Level 3 provenance).
 ```bash
 helm install repo-guardian \
   oci://ghcr.io/donaldgifford/charts/repo-guardian \
-  --version 0.6.2 \
+  --version 0.6.3 \
   --namespace repo-guardian \
   --create-namespace \
   -f values.yaml
@@ -47,7 +47,7 @@ secrets:
 ```bash
 helm install repo-guardian \
   oci://ghcr.io/donaldgifford/charts/repo-guardian \
-  --version 0.6.2 \
+  --version 0.6.3 \
   --namespace repo-guardian \
   --create-namespace \
   -f values.yaml
@@ -141,7 +141,7 @@ cosign verify \
     '^https://github.com/donaldgifford/repo-guardian/.+' \
   --certificate-oidc-issuer \
     'https://token.actions.githubusercontent.com' \
-  ghcr.io/donaldgifford/charts/repo-guardian:0.6.2
+  ghcr.io/donaldgifford/charts/repo-guardian:0.6.3
 ```
 
 ### SLSA provenance
@@ -152,7 +152,7 @@ cosign verify-attestation --type slsaprovenance \
     '^https://github.com/slsa-framework/slsa-github-generator/.+' \
   --certificate-oidc-issuer \
     'https://token.actions.githubusercontent.com' \
-  ghcr.io/donaldgifford/charts/repo-guardian:0.6.2
+  ghcr.io/donaldgifford/charts/repo-guardian:0.6.3
 ```
 
 The provenance attestation records the build workflow path, source

--- a/charts/repo-guardian/tests/deployment_test.yaml
+++ b/charts/repo-guardian/tests/deployment_test.yaml
@@ -34,7 +34,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "ghcr.io/donaldgifford/repo-guardian:1\\.7\\.0"
+          pattern: "ghcr.io/donaldgifford/repo-guardian:1\\.8\\.0"
 
   - it: should use custom image tag when set
     set:


### PR DESCRIPTION
## Summary

Picks up the v1.8.0 binary release (non_empty assertion type, #92). No chart resource changes — appVersion-only carry.

- `Chart.yaml`: `version: 0.6.2 → 0.6.3`, `appVersion: "1.7.0" → "1.8.0"`
- `README.md`: helm-docs regen
- `tests/deployment_test.yaml`: appVersion regex updated
- `CHANGELOG.md`: git-cliff regen

`dont-release` label — no Go changes; the v1.8.0 binary already exists. Chart-release workflow fires on `charts/**` change and publishes chart 0.6.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)