### PR TITLE
docs: add mise-manual CI workflow examples

### DIFF
--- a/examples/ci-workflows/README.md
+++ b/examples/ci-workflows/README.md
@@ -1,0 +1,171 @@
+# CI workflow examples — mise-manual tool install
+
+The production workflows under `.github/workflows/` use a handful of
+third-party actions to manage the tooling chain:
+
+| Action | Purpose |
+|---|---|
+| `jdx/mise-action` | Install pinned tools from `mise.toml` |
+| `sigstore/cosign-installer@v3` | Install cosign |
+| `orhun/git-cliff-action@v4` | Run git-cliff to regenerate the chart CHANGELOG |
+| `slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0` | Generate + sign SLSA Level 3 provenance |
+
+These examples show alternatives that depend **only** on `actions/checkout`,
+`docker/login-action`, `docker/setup-{qemu,buildx}-action`, and
+`docker/bake-action` — every other tool is installed manually via the
+`mise.run` install script, then driven from `mise.toml`'s pinned versions.
+
+Use these when an organization-level policy restricts which third-party
+actions can run, or when you want every tool version reproducible from a
+single `mise.toml` source of truth.
+
+## What changed vs. the production workflows
+
+### mise install (everywhere)
+
+Where the production workflow would do `uses: jdx/mise-action@v2`, the
+example does:
+
+```yaml
+- name: Install mise
+  run: |
+    set -eo pipefail
+    curl https://mise.run | sh
+    {
+      echo "$HOME/.local/bin"
+      echo "$HOME/.local/share/mise/shims"
+    } >> "$GITHUB_PATH"
+
+- name: Install pinned tools
+  run: mise install
+```
+
+After this, every binary pinned in `mise.toml` is on `PATH` via the
+shim directory — including `cosign`, `git-cliff`, `helm`, `yq`,
+`jq`, etc. No further per-tool install steps needed.
+
+### cosign
+
+Production:
+
+```yaml
+- uses: sigstore/cosign-installer@v3
+```
+
+Example: nothing. `cosign` is pinned in `mise.toml` and was installed
+by the `mise install` step above. Call `cosign sign ...` directly.
+
+### git-cliff
+
+Production:
+
+```yaml
+- uses: orhun/git-cliff-action@v4
+  with:
+    config: charts/repo-guardian/cliff.toml
+    args: --include-path "charts/**" --output charts/repo-guardian/CHANGELOG.md
+```
+
+Example:
+
+```yaml
+- name: Regenerate chart CHANGELOG via git-cliff
+  run: |
+    git-cliff \
+      --config charts/repo-guardian/cliff.toml \
+      --include-path 'charts/**' \
+      --output charts/repo-guardian/CHANGELOG.md
+```
+
+### SLSA provenance
+
+This is the lossy swap. The `slsa-framework/slsa-github-generator`
+reusable workflow runs on a trusted reusable workflow runner and
+produces a SLSA Level 3 provenance attestation — the L3 guarantee is
+that the build environment is isolated from the provenance generator,
+which the reusable workflow gets by construction.
+
+The manual replacement builds a SLSA v1.0 provenance JSON in-line
+from `github.*` context vars and signs it with `cosign attest`. This
+gets a signed in-toto attestation attached to the image in the
+registry, but the build and the attestation both run in the same job
+on the same runner, so the L3 isolation property is lost. Effectively
+this is **SLSA Level 2** (signed provenance, but build and signer are
+the same workload).
+
+If you need full SLSA L3 and cannot use the reusable workflow, the
+real fix is to run the provenance step on a separate isolated runner
+or in a separate signed reusable workflow you control — out of scope
+for these examples.
+
+The example pattern:
+
+```yaml
+- name: Generate SLSA provenance
+  run: |
+    cat > provenance.json <<EOF
+    {
+      "_type": "https://in-toto.io/Statement/v1",
+      "subject": [
+        {
+          "name": "${REGISTRY}/${IMAGE_REPO}",
+          "digest": { "sha256": "${DIGEST_HEX}" }
+        }
+      ],
+      "predicateType": "https://slsa.dev/provenance/v1",
+      "predicate": {
+        "buildDefinition": {
+          "buildType": "https://github.com/Attestations/GitHubActionsWorkflow@v1",
+          "externalParameters": {
+            "workflow": {
+              "ref": "${GITHUB_REF}",
+              "repository": "https://github.com/${GITHUB_REPOSITORY}",
+              "path": "${GITHUB_WORKFLOW_REF}"
+            }
+          },
+          "resolvedDependencies": [
+            {
+              "uri": "git+https://github.com/${GITHUB_REPOSITORY}@${GITHUB_REF}",
+              "digest": { "sha1": "${GITHUB_SHA}" }
+            }
+          ]
+        },
+        "runDetails": {
+          "builder": {
+            "id": "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          },
+          "metadata": {
+            "invocationId": "${GITHUB_RUN_ID}",
+            "startedOn": "${BUILD_STARTED_AT}"
+          }
+        }
+      }
+    }
+    EOF
+
+- name: Sign + attest
+  run: |
+    cosign attest --yes \
+      --predicate provenance.json \
+      --type slsaprovenance1 \
+      "${REGISTRY}/${IMAGE_REPO}@sha256:${DIGEST_HEX}"
+```
+
+Note that `DIGEST_HEX` is the digest **without** the `sha256:` prefix
+(the JSON schema requires the hex value alone). `cosign attest` writes
+the attestation as a sibling OCI artifact in the same registry as the
+image.
+
+## Files
+
+- `ghcr.yml` — image + chart publish to GHCR
+- `ecr.yml` — image + chart publish to ECR (OIDC auth)
+
+The orchestrator (`release.yml`) doesn't use any of the swapped
+third-party actions, so its production version is reusable as-is —
+just point `uses: ./.github/workflows/<file>.yml` at whichever copy of
+`ghcr.yml`/`ecr.yml` you ship.
+
+The files here are illustrative — copy the patterns you need, don't
+drop them in `.github/workflows/` verbatim or you'll have duplicate
+jobs running against the same registry.

--- a/examples/ci-workflows/README.md
+++ b/examples/ci-workflows/README.md
@@ -79,24 +79,69 @@ Example:
 
 ### SLSA provenance
 
-This is the lossy swap. The `slsa-framework/slsa-github-generator`
-reusable workflow runs on a trusted reusable workflow runner and
-produces a SLSA Level 3 provenance attestation — the L3 guarantee is
-that the build environment is isolated from the provenance generator,
-which the reusable workflow gets by construction.
+This is the lossy swap. Both Level 2 and Level 3 produce signed
+in-toto provenance attestations stating "this digest was built from
+this source by this workflow." What changes is whether the build can
+forge its own claims.
 
-The manual replacement builds a SLSA v1.0 provenance JSON in-line
-from `github.*` context vars and signs it with `cosign attest`. This
-gets a signed in-toto attestation attached to the image in the
-registry, but the build and the attestation both run in the same job
-on the same runner, so the L3 isolation property is lost. Effectively
-this is **SLSA Level 2** (signed provenance, but build and signer are
-the same workload).
+| Aspect | L2 | L3 |
+|---|---|---|
+| Provenance signed? | Yes | Yes |
+| Build platform hosted? | Yes (e.g. GHA runners) | Yes |
+| Who generates provenance? | The build job itself | A separately running, trusted workflow the build can't modify |
+| Who holds the signing key? | The build's identity (OIDC token in the build job) | A control plane outside the build's reach |
+| Can the build lie about itself? | **Yes** | **No** |
 
-If you need full SLSA L3 and cannot use the reusable workflow, the
-real fix is to run the provenance step on a separate isolated runner
-or in a separate signed reusable workflow you control — out of scope
-for these examples.
+**Concretely in GitHub Actions:**
+
+- **L2** (this example — `cosign attest` in the same job that built
+  the image): the build job constructs the provenance JSON, signs it
+  with its own OIDC identity, and pushes. Anything with RCE inside
+  the build — a malicious `npm install`, a compromised base image, a
+  goofy `Makefile` — can override what gets written. The signature is
+  valid; the contents can be fiction. The verifier proves "someone
+  with this repo's OIDC identity signed this attestation." It cannot
+  prove the attestation describes reality.
+
+- **L3** (`slsa-framework/slsa-github-generator`): the build job
+  emits the image digest as an output. A separate reusable workflow
+  in a different repo, signed by the SLSA project, takes that digest
+  as input, queries GitHub's API for run metadata, generates the
+  provenance, signs with its own ephemeral OIDC identity, attests.
+  The build job has no way to tamper with the provenance generator's
+  logic, environment, or signing key — they share only the digest
+  string crossing the workflow boundary. The verifier proves "this
+  digest was built by workflow X in repo Y at commit Z." High-
+  confidence reality claim.
+
+**Threat model L3 defends against that L2 doesn't:** an attacker who
+compromises one of your build dependencies (typosquat, malicious PR
+merge, supply-chain attack on a base image) but doesn't get any
+further access. With L2 they can quietly emit "everything's fine"
+provenance signed with your OIDC identity. With L3 they can't,
+because the provenance step isn't running their code.
+
+**When L2 is actually fine:**
+
+- You're the only person who can push to the repo
+- You audit the build steps yourself
+- Consumers aren't running `slsa-verifier` in their install pipeline
+- Compliance documents don't require L3 specifically
+
+**When you need L3:**
+
+- You're publishing artifacts that downstream consumers verify
+  automatically against a specific provenance shape
+- Your security review demands non-forgeable build claims
+- You're publishing to ecosystems (e.g. distroless, Kubernetes core)
+  where L3 is table stakes
+
+If you need full L3 and cannot use the SLSA reusable workflow, the
+real fix is to host an equivalent **trusted control plane** yourself
+— a separately signed reusable workflow you control that takes a
+digest as input and emits provenance from an isolated environment.
+Out of scope for these examples; the manual `cosign attest` pattern
+below is the L2 fallback.
 
 The example pattern:
 

--- a/examples/ci-workflows/ecr.yml
+++ b/examples/ci-workflows/ecr.yml
@@ -1,0 +1,383 @@
+---
+# Example: ECR publish using mise-installed tools (no third-party
+# wrapper actions for cosign, git-cliff, or SLSA generation).
+#
+# See ./README.md for the full diff vs. the production workflow at
+# .github/workflows/ecr.yml.
+name: Publish to ECR (mise-manual example)
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        required: false
+        default: ''
+      dry_run:
+        type: boolean
+        required: false
+        default: false
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        required: false
+        default: ''
+      dry_run:
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  IMAGE_NAME: repo-guardian
+  CHART_NAME: repo-guardian
+  CHART_REPO: repo-guardian-chart
+
+jobs:
+  aws-auth:
+    name: AWS OIDC + ECR login
+    runs-on: ubuntu-latest
+    outputs:
+      registry: ${{ steps.registry.outputs.registry }}
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.ECR_ROLE_ARN }}
+          role-session-name: github-actions-repo-guardian-publish
+          aws-region: ${{ secrets.ECR_REGION }}
+
+      - name: Compute registry hostname
+        id: registry
+        run: |
+          echo "registry=${{ secrets.ECR_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.ECR_REGION }}.amazonaws.com" >> "$GITHUB_OUTPUT"
+
+  image:
+    name: Publish image
+    runs-on: ubuntu-latest
+    needs: aws-auth
+    if: inputs.tag != ''
+    outputs:
+      digest: ${{ steps.digest.outputs.digest }}
+      digest_hex: ${{ steps.digest.outputs.digest_hex }}
+      published: ${{ steps.digest.outputs.published }}
+      registry: ${{ needs.aws-auth.outputs.registry }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Install mise
+        run: |
+          set -eo pipefail
+          curl https://mise.run | sh
+          {
+            echo "$HOME/.local/bin"
+            echo "$HOME/.local/share/mise/shims"
+          } >> "$GITHUB_PATH"
+
+      - name: Install pinned tools
+        run: mise install
+
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.ECR_ROLE_ARN }}
+          role-session-name: github-actions-repo-guardian-image
+          aws-region: ${{ secrets.ECR_REGION }}
+
+      - uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ needs.aws-auth.outputs.registry }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }}
+            type=raw,value=latest
+
+      - name: Record build start timestamp
+        id: ts
+        run: echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        id: bake
+        if: inputs.dry_run != true
+        uses: docker/bake-action@v7
+        with:
+          targets: release
+          source: .
+          files: |
+            docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file-tags }}
+            ${{ steps.meta.outputs.bake-file-labels }}
+          set: |-
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max
+
+      - name: Capture image digest
+        id: digest
+        if: steps.bake.conclusion == 'success' && inputs.dry_run != true
+        run: |
+          digest=$(echo '${{ steps.bake.outputs.metadata }}' | jq -r '.release."containerimage.digest"')
+          if [ -z "${digest}" ] || [ "${digest}" = "null" ]; then
+            echo "ERROR: failed to capture image digest from bake metadata"
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "digest_hex=${digest#sha256:}" >> "$GITHUB_OUTPUT"
+          echo "published=true" >> "$GITHUB_OUTPUT"
+
+      - name: Sign image with cosign (mise-managed)
+        if: steps.digest.outputs.published == 'true'
+        run: |
+          cosign sign --yes \
+            "${{ needs.aws-auth.outputs.registry }}/${IMAGE_NAME}@${{ steps.digest.outputs.digest }}"
+
+      - name: Generate SLSA provenance JSON
+        if: steps.digest.outputs.published == 'true'
+        run: |
+          cat > provenance.json <<EOF
+          {
+            "_type": "https://in-toto.io/Statement/v1",
+            "subject": [
+              {
+                "name": "${{ needs.aws-auth.outputs.registry }}/${IMAGE_NAME}",
+                "digest": { "sha256": "${{ steps.digest.outputs.digest_hex }}" }
+              }
+            ],
+            "predicateType": "https://slsa.dev/provenance/v1",
+            "predicate": {
+              "buildDefinition": {
+                "buildType": "https://github.com/Attestations/GitHubActionsWorkflow@v1",
+                "externalParameters": {
+                  "workflow": {
+                    "ref": "${GITHUB_REF}",
+                    "repository": "https://github.com/${GITHUB_REPOSITORY}",
+                    "path": "${GITHUB_WORKFLOW_REF}"
+                  }
+                },
+                "resolvedDependencies": [
+                  {
+                    "uri": "git+https://github.com/${GITHUB_REPOSITORY}@${GITHUB_REF}",
+                    "digest": { "sha1": "${GITHUB_SHA}" }
+                  }
+                ]
+              },
+              "runDetails": {
+                "builder": {
+                  "id": "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+                },
+                "metadata": {
+                  "invocationId": "${GITHUB_RUN_ID}",
+                  "startedOn": "${{ steps.ts.outputs.started_at }}"
+                }
+              }
+            }
+          }
+          EOF
+
+      - name: Attach SLSA provenance with cosign attest
+        if: steps.digest.outputs.published == 'true'
+        run: |
+          cosign attest --yes \
+            --predicate provenance.json \
+            --type slsaprovenance1 \
+            "${{ needs.aws-auth.outputs.registry }}/${IMAGE_NAME}@${{ steps.digest.outputs.digest }}"
+
+      - name: Write image summary
+        if: always()
+        run: |
+          {
+            echo "## ECR Image Publish"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Image | \`${{ needs.aws-auth.outputs.registry }}/${IMAGE_NAME}\` |"
+            echo "| Tag | \`${{ inputs.tag }}\` |"
+            echo "| Pushed | \`${{ steps.digest.outputs.published || 'false' }}\` |"
+            if [ -n "${{ steps.digest.outputs.digest }}" ]; then
+              echo "| Digest | \`${{ steps.digest.outputs.digest }}\` |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  chart:
+    name: Publish chart
+    runs-on: ubuntu-latest
+    needs: aws-auth
+    outputs:
+      chart_version: ${{ steps.version.outputs.chart_version }}
+      digest: ${{ steps.push.outputs.digest }}
+      digest_hex: ${{ steps.push.outputs.digest_hex }}
+      published: ${{ steps.push.outputs.published }}
+      registry: ${{ needs.aws-auth.outputs.registry }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install mise
+        run: |
+          set -eo pipefail
+          curl https://mise.run | sh
+          {
+            echo "$HOME/.local/bin"
+            echo "$HOME/.local/share/mise/shims"
+          } >> "$GITHUB_PATH"
+
+      - name: Install pinned tools
+        run: mise install
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.ECR_ROLE_ARN }}
+          role-session-name: github-actions-repo-guardian-chart
+          aws-region: ${{ secrets.ECR_REGION }}
+
+      - uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Regenerate chart CHANGELOG via git-cliff (mise-managed)
+        run: |
+          git-cliff \
+            --config charts/repo-guardian/cliff.toml \
+            --include-path 'charts/**' \
+            --output charts/repo-guardian/CHANGELOG.md
+
+      - name: Read chart version
+        id: version
+        run: |
+          chart_version=$(yq '.version' charts/repo-guardian/Chart.yaml)
+          echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
+          echo "Chart version: ${chart_version}"
+
+      - name: Record build start timestamp
+        id: ts
+        run: echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Check if version already published
+        id: idempotency
+        run: |
+          registry="${{ needs.aws-auth.outputs.registry }}"
+          if helm pull \
+              "oci://${registry}/${CHART_REPO}" \
+              --version "${{ steps.version.outputs.chart_version }}" \
+              --destination /tmp 2>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Chart ${{ steps.version.outputs.chart_version }} already published, skipping."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Helm registry login
+        if: steps.idempotency.outputs.exists != 'true'
+        run: |
+          registry="${{ needs.aws-auth.outputs.registry }}"
+          aws ecr get-login-password --region "${{ secrets.ECR_REGION }}" | \
+            helm registry login "${registry}" \
+              --username AWS --password-stdin
+
+      - name: Package chart
+        if: steps.idempotency.outputs.exists != 'true'
+        run: helm package charts/repo-guardian
+
+      - name: Push chart
+        id: push
+        if: |
+          steps.idempotency.outputs.exists != 'true' &&
+          inputs.dry_run != true
+        run: |
+          registry="${{ needs.aws-auth.outputs.registry }}"
+          tgz="${CHART_NAME}-${{ steps.version.outputs.chart_version }}.tgz"
+          helm push "${tgz}" "oci://${registry}/${CHART_REPO}" 2>&1 | tee /tmp/push.log
+          digest=$(grep -oE 'sha256:[a-f0-9]{64}' /tmp/push.log | head -1)
+          if [ -z "${digest}" ]; then
+            echo "ERROR: failed to capture digest from helm push output"
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "digest_hex=${digest#sha256:}" >> "$GITHUB_OUTPUT"
+          echo "published=true" >> "$GITHUB_OUTPUT"
+
+      - name: Sign chart with cosign (mise-managed)
+        if: steps.push.outputs.published == 'true'
+        run: |
+          cosign sign --yes \
+            "${{ needs.aws-auth.outputs.registry }}/${CHART_REPO}@${{ steps.push.outputs.digest }}"
+
+      - name: Generate SLSA provenance JSON (chart)
+        if: steps.push.outputs.published == 'true'
+        run: |
+          cat > chart-provenance.json <<EOF
+          {
+            "_type": "https://in-toto.io/Statement/v1",
+            "subject": [
+              {
+                "name": "${{ needs.aws-auth.outputs.registry }}/${CHART_REPO}",
+                "digest": { "sha256": "${{ steps.push.outputs.digest_hex }}" }
+              }
+            ],
+            "predicateType": "https://slsa.dev/provenance/v1",
+            "predicate": {
+              "buildDefinition": {
+                "buildType": "https://github.com/Attestations/GitHubActionsWorkflow@v1",
+                "externalParameters": {
+                  "workflow": {
+                    "ref": "${GITHUB_REF}",
+                    "repository": "https://github.com/${GITHUB_REPOSITORY}",
+                    "path": "${GITHUB_WORKFLOW_REF}"
+                  }
+                },
+                "resolvedDependencies": [
+                  {
+                    "uri": "git+https://github.com/${GITHUB_REPOSITORY}@${GITHUB_REF}",
+                    "digest": { "sha1": "${GITHUB_SHA}" }
+                  }
+                ]
+              },
+              "runDetails": {
+                "builder": {
+                  "id": "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+                },
+                "metadata": {
+                  "invocationId": "${GITHUB_RUN_ID}",
+                  "startedOn": "${{ steps.ts.outputs.started_at }}"
+                }
+              }
+            }
+          }
+          EOF
+
+      - name: Attach SLSA provenance with cosign attest (chart)
+        if: steps.push.outputs.published == 'true'
+        run: |
+          cosign attest --yes \
+            --predicate chart-provenance.json \
+            --type slsaprovenance1 \
+            "${{ needs.aws-auth.outputs.registry }}/${CHART_REPO}@${{ steps.push.outputs.digest }}"
+
+      - name: Write chart summary
+        if: always()
+        run: |
+          {
+            echo "## ECR Chart Publish"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Chart | \`${CHART_NAME}\` |"
+            echo "| Version | \`${{ steps.version.outputs.chart_version }}\` |"
+            echo "| Already published | \`${{ steps.idempotency.outputs.exists }}\` |"
+            echo "| Pushed | \`${{ steps.push.outputs.published || 'false' }}\` |"
+            if [ -n "${{ steps.push.outputs.digest }}" ]; then
+              ver="${{ steps.version.outputs.chart_version }}"
+              uri="oci://${{ needs.aws-auth.outputs.registry }}/${CHART_REPO}:${ver}"
+              echo "| Digest | \`${{ steps.push.outputs.digest }}\` |"
+              echo "| OCI URL | \`${uri}\` |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/examples/ci-workflows/ghcr.yml
+++ b/examples/ci-workflows/ghcr.yml
@@ -1,0 +1,361 @@
+---
+# Example: GHCR publish using mise-installed tools (no third-party
+# wrapper actions for cosign, git-cliff, or SLSA generation).
+#
+# See ./README.md for the full diff vs. the production workflow at
+# .github/workflows/ghcr.yml.
+name: Publish to GHCR (mise-manual example)
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Image tag to publish (e.g. v1.8.2). Empty = skip image push.'
+        type: string
+        required: false
+        default: ''
+      dry_run:
+        type: boolean
+        required: false
+        default: false
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        required: false
+        default: ''
+      dry_run:
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_REPO: donaldgifford/repo-guardian
+  CHART_NAMESPACE: donaldgifford/charts
+  CHART_NAME: repo-guardian
+
+jobs:
+  image:
+    name: Publish image
+    runs-on: ubuntu-latest
+    if: inputs.tag != ''
+    outputs:
+      digest: ${{ steps.digest.outputs.digest }}
+      digest_hex: ${{ steps.digest.outputs.digest_hex }}
+      published: ${{ steps.digest.outputs.published }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Install mise
+        run: |
+          set -eo pipefail
+          curl https://mise.run | sh
+          {
+            echo "$HOME/.local/bin"
+            echo "$HOME/.local/share/mise/shims"
+          } >> "$GITHUB_PATH"
+
+      - name: Install pinned tools
+        run: mise install
+
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.tag }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }}
+            type=raw,value=latest
+
+      - name: Record build start timestamp
+        id: ts
+        run: echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        id: bake
+        if: inputs.dry_run != true
+        uses: docker/bake-action@v7
+        with:
+          targets: release
+          source: .
+          files: |
+            docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file-tags }}
+            ${{ steps.meta.outputs.bake-file-labels }}
+          set: |-
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max
+
+      - name: Capture image digest
+        id: digest
+        if: steps.bake.conclusion == 'success' && inputs.dry_run != true
+        run: |
+          digest=$(echo '${{ steps.bake.outputs.metadata }}' | jq -r '.release."containerimage.digest"')
+          if [ -z "${digest}" ] || [ "${digest}" = "null" ]; then
+            echo "ERROR: failed to capture image digest from bake metadata"
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "digest_hex=${digest#sha256:}" >> "$GITHUB_OUTPUT"
+          echo "published=true" >> "$GITHUB_OUTPUT"
+
+      - name: Sign image with cosign (mise-managed)
+        if: steps.digest.outputs.published == 'true'
+        run: |
+          cosign sign --yes \
+            "${REGISTRY}/${IMAGE_REPO}@${{ steps.digest.outputs.digest }}"
+
+      - name: Generate SLSA provenance JSON
+        if: steps.digest.outputs.published == 'true'
+        run: |
+          cat > provenance.json <<EOF
+          {
+            "_type": "https://in-toto.io/Statement/v1",
+            "subject": [
+              {
+                "name": "${REGISTRY}/${IMAGE_REPO}",
+                "digest": { "sha256": "${{ steps.digest.outputs.digest_hex }}" }
+              }
+            ],
+            "predicateType": "https://slsa.dev/provenance/v1",
+            "predicate": {
+              "buildDefinition": {
+                "buildType": "https://github.com/Attestations/GitHubActionsWorkflow@v1",
+                "externalParameters": {
+                  "workflow": {
+                    "ref": "${GITHUB_REF}",
+                    "repository": "https://github.com/${GITHUB_REPOSITORY}",
+                    "path": "${GITHUB_WORKFLOW_REF}"
+                  }
+                },
+                "resolvedDependencies": [
+                  {
+                    "uri": "git+https://github.com/${GITHUB_REPOSITORY}@${GITHUB_REF}",
+                    "digest": { "sha1": "${GITHUB_SHA}" }
+                  }
+                ]
+              },
+              "runDetails": {
+                "builder": {
+                  "id": "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+                },
+                "metadata": {
+                  "invocationId": "${GITHUB_RUN_ID}",
+                  "startedOn": "${{ steps.ts.outputs.started_at }}"
+                }
+              }
+            }
+          }
+          EOF
+
+      - name: Attach SLSA provenance with cosign attest
+        if: steps.digest.outputs.published == 'true'
+        run: |
+          cosign attest --yes \
+            --predicate provenance.json \
+            --type slsaprovenance1 \
+            "${REGISTRY}/${IMAGE_REPO}@${{ steps.digest.outputs.digest }}"
+
+      - name: Write image summary
+        if: always()
+        run: |
+          {
+            echo "## GHCR Image Publish"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Image | \`${REGISTRY}/${IMAGE_REPO}\` |"
+            echo "| Tag | \`${{ inputs.tag }}\` |"
+            echo "| Pushed | \`${{ steps.digest.outputs.published || 'false' }}\` |"
+            if [ -n "${{ steps.digest.outputs.digest }}" ]; then
+              echo "| Digest | \`${{ steps.digest.outputs.digest }}\` |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  chart:
+    name: Publish chart
+    runs-on: ubuntu-latest
+    outputs:
+      chart_version: ${{ steps.version.outputs.chart_version }}
+      digest: ${{ steps.push.outputs.digest }}
+      digest_hex: ${{ steps.push.outputs.digest_hex }}
+      published: ${{ steps.push.outputs.published }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install mise
+        run: |
+          set -eo pipefail
+          curl https://mise.run | sh
+          {
+            echo "$HOME/.local/bin"
+            echo "$HOME/.local/share/mise/shims"
+          } >> "$GITHUB_PATH"
+
+      - name: Install pinned tools
+        run: mise install
+
+      - name: Login to GHCR (docker config — for cosign and helm)
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Regenerate chart CHANGELOG via git-cliff (mise-managed)
+        run: |
+          git-cliff \
+            --config charts/repo-guardian/cliff.toml \
+            --include-path 'charts/**' \
+            --output charts/repo-guardian/CHANGELOG.md
+
+      - name: Read chart version
+        id: version
+        run: |
+          chart_version=$(yq '.version' charts/repo-guardian/Chart.yaml)
+          echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
+          echo "Chart version: ${chart_version}"
+
+      - name: Record build start timestamp
+        id: ts
+        run: echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Check if version already published
+        id: idempotency
+        run: |
+          if helm pull \
+              "oci://${REGISTRY}/${CHART_NAMESPACE}/${CHART_NAME}" \
+              --version "${{ steps.version.outputs.chart_version }}" \
+              --destination /tmp 2>/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Chart ${{ steps.version.outputs.chart_version }} already published, skipping."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Helm registry login
+        if: steps.idempotency.outputs.exists != 'true'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login "${REGISTRY}" \
+              --username "${{ github.actor }}" \
+              --password-stdin
+
+      - name: Package chart
+        if: steps.idempotency.outputs.exists != 'true'
+        run: helm package charts/repo-guardian
+
+      - name: Push chart
+        id: push
+        if: |
+          steps.idempotency.outputs.exists != 'true' &&
+          inputs.dry_run != true
+        run: |
+          tgz="${CHART_NAME}-${{ steps.version.outputs.chart_version }}.tgz"
+          helm push "${tgz}" "oci://${REGISTRY}/${CHART_NAMESPACE}" 2>&1 | tee /tmp/push.log
+          digest=$(grep -oE 'sha256:[a-f0-9]{64}' /tmp/push.log | head -1)
+          if [ -z "${digest}" ]; then
+            echo "ERROR: failed to capture digest from helm push output"
+            exit 1
+          fi
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "digest_hex=${digest#sha256:}" >> "$GITHUB_OUTPUT"
+          echo "published=true" >> "$GITHUB_OUTPUT"
+
+      - name: Sign chart with cosign (mise-managed)
+        if: steps.push.outputs.published == 'true'
+        run: |
+          cosign sign --yes \
+            "${REGISTRY}/${CHART_NAMESPACE}/${CHART_NAME}@${{ steps.push.outputs.digest }}"
+
+      - name: Generate SLSA provenance JSON (chart)
+        if: steps.push.outputs.published == 'true'
+        run: |
+          cat > chart-provenance.json <<EOF
+          {
+            "_type": "https://in-toto.io/Statement/v1",
+            "subject": [
+              {
+                "name": "${REGISTRY}/${CHART_NAMESPACE}/${CHART_NAME}",
+                "digest": { "sha256": "${{ steps.push.outputs.digest_hex }}" }
+              }
+            ],
+            "predicateType": "https://slsa.dev/provenance/v1",
+            "predicate": {
+              "buildDefinition": {
+                "buildType": "https://github.com/Attestations/GitHubActionsWorkflow@v1",
+                "externalParameters": {
+                  "workflow": {
+                    "ref": "${GITHUB_REF}",
+                    "repository": "https://github.com/${GITHUB_REPOSITORY}",
+                    "path": "${GITHUB_WORKFLOW_REF}"
+                  }
+                },
+                "resolvedDependencies": [
+                  {
+                    "uri": "git+https://github.com/${GITHUB_REPOSITORY}@${GITHUB_REF}",
+                    "digest": { "sha1": "${GITHUB_SHA}" }
+                  }
+                ]
+              },
+              "runDetails": {
+                "builder": {
+                  "id": "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+                },
+                "metadata": {
+                  "invocationId": "${GITHUB_RUN_ID}",
+                  "startedOn": "${{ steps.ts.outputs.started_at }}"
+                }
+              }
+            }
+          }
+          EOF
+
+      - name: Attach SLSA provenance with cosign attest (chart)
+        if: steps.push.outputs.published == 'true'
+        run: |
+          cosign attest --yes \
+            --predicate chart-provenance.json \
+            --type slsaprovenance1 \
+            "${REGISTRY}/${CHART_NAMESPACE}/${CHART_NAME}@${{ steps.push.outputs.digest }}"
+
+      - name: Write chart summary
+        if: always()
+        run: |
+          {
+            echo "## GHCR Chart Publish"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Chart | \`${CHART_NAME}\` |"
+            echo "| Version | \`${{ steps.version.outputs.chart_version }}\` |"
+            echo "| Already published | \`${{ steps.idempotency.outputs.exists }}\` |"
+            echo "| Pushed | \`${{ steps.push.outputs.published || 'false' }}\` |"
+            if [ -n "${{ steps.push.outputs.digest }}" ]; then
+              ver="${{ steps.version.outputs.chart_version }}"
+              uri="oci://${REGISTRY}/${CHART_NAMESPACE}/${CHART_NAME}:${ver}"
+              echo "| Digest | \`${{ steps.push.outputs.digest }}\` |"
+              echo "| OCI URL | \`${uri}\` |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds `examples/ci-workflows/` with alternate `ghcr.yml` + `ecr.yml` that depend only on official `actions/*` and `docker/*` actions plus `aws-actions/*` for ECR. Every other tool (cosign, git-cliff, helm, yq, jq) is installed via `curl https://mise.run | sh` + `mise install` against the existing `mise.toml`.

## What it swaps

| Production action | Example replacement |
|---|---|
| `jdx/mise-action` | `curl https://mise.run | sh` + `mise install` |
| `sigstore/cosign-installer@v3` | cosign comes from `mise install` (already pinned in `mise.toml`) |
| `orhun/git-cliff-action@v4` | direct `git-cliff` invocation (mise-managed) |
| `slsa-framework/slsa-github-generator/.../generator_container_slsa3.yml@v2.0.0` | hand-rolled SLSA v1.0 provenance JSON signed via `cosign attest --predicate ... --type slsaprovenance1` |

## Known tradeoff

The SLSA swap drops from Level 3 → effectively Level 2. The reusable workflow's L3 guarantee comes from build/signer runtime isolation; signing in the same job loses that. The README calls this out and points at the real fix (a separate signed reusable workflow you control) if full L3 is required.

## Test plan

- [x] `actionlint` clean (only SC2129 style warnings, identical to the production workflows)
- [ ] Optional: copy `examples/ci-workflows/ghcr.yml` over `.github/workflows/ghcr.yml` on a throwaway branch and confirm a release publishes + signs

🤖 Generated with [Claude Code](https://claude.com/claude-code)