### PR TITLE
docs(ops): add AWS deployment guide (RDS/Aurora + ElastiCache for Valkey)

### DIFF
--- a/docs/design/0015-per-installation-valkey-queue-partitioning.md
+++ b/docs/design/0015-per-installation-valkey-queue-partitioning.md
@@ -1,0 +1,405 @@
+---
+id: DESIGN-0015
+title: "Per-installation Valkey queue partitioning"
+status: Draft
+author: Donald Gifford
+created: 2026-06-22
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# DESIGN 0015: Per-installation Valkey queue partitioning
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-06-22
+
+<!--toc:start-->
+- [Overview](#overview)
+- [Goals and Non-Goals](#goals-and-non-goals)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Background](#background)
+- [Detailed Design](#detailed-design)
+  - [Key layout](#key-layout)
+  - [Worker scheduling strategies](#worker-scheduling-strategies)
+  - [Per-installation concurrency cap](#per-installation-concurrency-cap)
+  - [Reaper changes](#reaper-changes)
+  - [Installation lifecycle](#installation-lifecycle)
+  - [Compatibility with cluster mode](#compatibility-with-cluster-mode)
+- [API / Interface Changes](#api--interface-changes)
+- [Data Model](#data-model)
+- [Testing Strategy](#testing-strategy)
+- [Migration / Rollout Plan](#migration--rollout-plan)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Overview
+
+Split the single global Valkey queue (`repo-guardian:queue:jobs`) into per-installation
+queues so that one noisy installation cannot starve work for the rest. Workers schedule
+across the per-installation queues with bounded per-installation concurrency,
+producing strict fairness and unlocking per-installation queue-depth metrics.
+
+This is **partitioning** at the application layer — different conceptually from Valkey
+cluster-mode sharding. See `docs/operations/aws.md` for the distinction.
+
+## Goals and Non-Goals
+
+### Goals
+
+- Bound noisy-installation impact: a single installation cannot consume more than its
+  fair share of worker slots.
+- Per-installation observability: `queue_depth{installation_id}` and
+  `queue_dispatched_total{installation_id}` exposed as Prometheus metric labels.
+- Backward-compatible rollout: existing single-queue deployments continue to work;
+  partitioning is opt-in via a chart value.
+- Survives in both single-node Valkey and Valkey cluster-mode-disabled topologies
+  (the recommended ElastiCache shape per `docs/operations/aws.md`).
+
+### Non-Goals
+
+- Valkey cluster-mode (sharding) support. Tracked separately — orthogonal axis. This
+  design DOES leave the door open by keeping all per-installation keys for one
+  installation in the same hash slot via tags, so a future cluster-mode rollout
+  doesn't require redesign.
+- Per-installation priority weights or QoS tiers. Future enhancement; the initial
+  scheduler is round-robin with a uniform cap.
+- Cross-installation work stealing. Strategy A (BLPOP-many) is naturally
+  work-conserving; explicit work-stealing is out of scope for v1.
+- Memory-backend partitioning. Memory mode is single-replica and the noisy-org
+  problem doesn't arise there.
+
+## Background
+
+repo-guardian's queue today is a single LIST + ZSET pair:
+
+```
+repo-guardian:queue:jobs        LIST  (FIFO of pending jobs)
+repo-guardian:queue:inflight    ZSET  (jobID → dispatch_ts; reaper input)
+```
+
+`Queue.Enqueue(job)` LPUSHes onto `jobs`. `Subscribe`-driven workers BRPOPLPUSH from
+`jobs` into `inflight`, process, then ZREM the in-flight entry. The reaper goroutine
+scans `inflight` periodically and requeues jobs whose dispatch_ts is older than
+`JOB_ACK_TIMEOUT`.
+
+At fleet scale (3000 repos across 25 GitHub orgs — see `docs/operations/aws.md`), one
+large org can have 500+ actionable repos per sweep while smaller orgs have only a
+handful. The single-FIFO queue means the noisy org's burst always enters before the
+smaller orgs' webhook-triggered work, regardless of webhook arrival order. Workers
+drain the noisy org's burst before getting to smaller orgs.
+
+The existing `staleSweep.batchSize` and `config.workerCount` knobs give *eventual*
+fairness — every org's work clears within a sweep cycle — but not strict round-robin.
+For operators with per-org SLAs or sensitive webhook-driven workflows, eventual
+fairness is insufficient.
+
+## Detailed Design
+
+### Key layout
+
+Each known installation gets its own LIST + ZSET. A registry SET tracks known
+installation IDs so workers and the reaper can iterate.
+
+```
+repo-guardian:queue:{install-12345}:jobs       LIST
+repo-guardian:queue:{install-12345}:inflight   ZSET
+repo-guardian:queue:{install-67890}:jobs       LIST
+repo-guardian:queue:{install-67890}:inflight   ZSET
+repo-guardian:queue:installations              SET  (member: stringified install ID)
+```
+
+Note the `{install-N}` hash-tag braces. Valkey treats text inside `{ }` as the hash
+slot key in cluster mode. Tagging the LIST and ZSET for installation N together
+guarantees they land on the same shard — required for multi-key Lua scripts that
+operate atomically across the pair. The installations-registry SET has no tag because
+no multi-key operation needs it alongside the per-installation keys.
+
+`Enqueue(job)` becomes:
+
+```redis
+LPUSH repo-guardian:queue:{install-<job.InstallationID>}:jobs <job-json>
+SADD  repo-guardian:queue:installations <job.InstallationID>
+```
+
+Both ops; SADD is idempotent so no harm if the installation already exists in the
+registry.
+
+### Worker scheduling strategies
+
+Three workable shapes considered. Recommended initial implementation is **A with a
+per-installation soft cap**; B and C are future extensions if A proves insufficient.
+
+| Strategy | How it works | Pros | Cons |
+|---|---|---|---|
+| **A. BLPOP across all keys** | Worker reads `SMEMBERS installations`, issues `BLPOP key1 key2 … keyN <timeout>` — Valkey returns from whichever queue has work first | Trivial code; natural fairness for ready work; no extra coordination state | No strict cap on per-installation parallelism — a noisy org can still claim every worker slot |
+| **B. Round-robin with per-installation concurrency cap** | Maintain `repo-guardian:queue:{install-N}:in_flight_count` counter; worker iterates installations in round-robin order, skips any at cap | Strict fairness; bounds noisy-installation parallelism | More state; atomic check-and-incr Lua script required |
+| **C. Weighted random by depth + rate-limit headroom** | Worker picks an installation at random, weighted by `(queue_depth × rate_limit_remaining)` | Adapts dynamically to rate limits; statistically fair | Most state; depth + headroom snapshots; harder to reason about |
+
+**Recommendation: A with a soft cap.** Combines BLPOP-many's simplicity with an
+explicit per-installation in-flight ceiling. The cap is enforced application-side:
+when a worker successfully BLPOPs from installation N's queue, it increments a local
+counter for N; subsequent BLPOPs exclude N from the key list once N is at cap. The
+counter decrements on job completion. No Valkey-side coordination needed.
+
+```go
+// Sketch
+func (w *Worker) loop(ctx context.Context) {
+    for ctx.Err() == nil {
+        installs := w.snapshotInstallations()              // local cache, refreshed periodically
+        eligible := w.filterAtCap(installs)                // exclude installations at perInstallationCap
+        if len(eligible) == 0 { time.Sleep(idleBackoff); continue }
+        keys := installToKeys(eligible)
+        result, err := w.redis.BLPop(ctx, w.blpopTimeout, keys...).Result()
+        // ... dispatch
+    }
+}
+```
+
+### Per-installation concurrency cap
+
+Default formula:
+
+```
+perInstallationCap = max(2, ceil(workerCount / max(installations_count, 1)))
+```
+
+Examples (workerCount=15 per replica, 3 replicas → 45 concurrent workers total):
+
+- 1 installation:  cap = 45 (effectively uncapped — only one tenant)
+- 5 installations: cap = 9   (no one tenant exceeds 9 of 45)
+- 25 installations: cap = 2  (noisy org limited to 2 of 45)
+
+Operator override: `queue.partitioning.perInstallationCap` in values.yaml.
+
+### Reaper changes
+
+The current reaper scans one ZSET (`inflight`) on every tick. With partitioning, it
+scans all per-installation inflight ZSETs:
+
+```go
+installs, err := r.redis.SMembers(ctx, "repo-guardian:queue:installations").Result()
+for _, install := range installs {
+    expired, err := r.redis.ZRangeByScore(ctx, fmt.Sprintf("repo-guardian:queue:{install-%s}:inflight", install), ...)
+    // ... requeue expired
+}
+```
+
+Per-tick cost grows O(installations). At 25 installations × 1 ZRANGEBYSCORE call = 25
+Valkey ops per tick. With the default 30-second reaper interval, that's <1 op/sec.
+Negligible.
+
+### Installation lifecycle
+
+**Discovery:** installations are added to the registry on first Enqueue (idempotent
+SADD). The legacy `Sweeper` (and the proposed replacement per DESIGN-0017) handles
+populating the registry initially.
+
+**Removal:** uninstalling a GitHub App should remove the installation from the
+registry. Handled via the existing `installation.deleted` webhook event — webhook
+handler issues `SREM` and deletes the per-installation LIST + ZSET keys.
+
+**Stale registry entries:** if a worker crashes mid-removal, an installation may
+linger in the registry with no LIST. BLPOP on a non-existent key blocks waiting for
+LPUSH; this is fine — no jobs ever arrive, the worker times out and moves on. A
+janitor goroutine could periodically `EXISTS` each registry entry and SREM stale
+ones, but it's not on the critical path.
+
+### Compatibility with cluster mode
+
+The hash-tag layout (`{install-N}`) ensures cluster-mode safety even though this
+design doesn't target cluster mode in v1. If a future operator deploys against
+ElastiCache cluster-mode-enabled, the per-installation keys still co-locate on one
+shard (required for the multi-key BLPOP across multiple keys in a single ZRANGE+ZREM
+Lua script).
+
+Also requires the `cmd/repo-guardian/main.go` wiring to use `redis.NewUniversalClient`
+(or detect cluster topology) instead of `redis.NewClient`. Out of scope for this
+DESIGN — captured as a follow-up.
+
+## API / Interface Changes
+
+### `internal/queue/Queue` interface
+
+Unchanged externally:
+
+```go
+type Queue interface {
+    Enqueue(ctx context.Context, job Job) error
+    Subscribe(ctx context.Context, handler Handler) error
+    Close() error
+}
+```
+
+The `Job` struct already carries `InstallationID`. The implementation selects the key
+based on this field.
+
+### `internal/queue/valkey/`
+
+- LUA scripts rewritten to operate on per-installation keys.
+- New private method `installKeys(installationID int64) (jobsKey, inflightKey string)`
+  centralises key naming.
+- BLPOP-multi loop in `Subscribe` polls all installations registered in
+  `repo-guardian:queue:installations`.
+
+### `internal/worker/`
+
+- Per-worker local state: `inFlightByInstall map[int64]int`.
+- Configurable `PerInstallationCap` (default per formula above).
+- Filter eligible installations before BLPOP.
+
+### `internal/metrics/`
+
+- `repo_guardian_queue_depth` becomes `repo_guardian_queue_depth{installation_id}` —
+  GaugeVec rather than Gauge.
+- `repo_guardian_queue_dispatched_total` gains the same label.
+- `repo_guardian_queue_partitions` (new) — count of registered installations.
+- Cardinality budget: 25 installations × 4 series = 100 series. Negligible.
+
+### Chart values
+
+```yaml
+queue:
+  valkey:
+    partitioning:
+      enabled: false               # opt-in during rollout
+      perInstallationCap: ""       # empty → formula default; integer to override
+```
+
+## Data Model
+
+No schema changes (queue is Valkey, not Postgres). Key namespace evolves as
+described in [Key layout](#key-layout). Existing single-queue deployments retain the
+`repo-guardian:queue:jobs` and `repo-guardian:queue:inflight` keys until the
+[migration](#migration--rollout-plan) drains them.
+
+## Testing Strategy
+
+### Unit tests (`internal/queue/valkey/`)
+
+- Key-name selector correctness for various `installationID` values.
+- Idempotent SADD on repeated Enqueue.
+- BLPOP-multi returns from any non-empty installation queue.
+
+### Contract tests (`contract_test.go` extension)
+
+Add fairness assertions to the existing Queue contract suite:
+
+- **Strict fairness under burst:** enqueue 100 jobs for install-A, 1 job for
+  install-B; with `perInstallationCap=2` and 5 workers, install-B's job dispatches
+  within 1 second of install-A's burst arrival.
+- **No starvation under uniform load:** enqueue 50 jobs for each of 5 installations;
+  every installation's first job dispatches before any installation's tenth.
+- **Cap enforcement:** with `perInstallationCap=3`, no worker dispatches more than 3
+  concurrent jobs for a single installation.
+
+### Integration tests (`_integration_test.go`)
+
+- Run the existing in-flight + reaper integration tests with the new key layout.
+- Add ElastiCache test target (`cache.t4g.micro`) running alongside the existing
+  testcontainer Valkey target.
+
+### Chaos tests
+
+- Worker crash mid-job: verify reaper requeues from the correct per-installation
+  inflight ZSET.
+- Installation uninstall during active processing: verify `installation.deleted`
+  webhook drains the queue cleanly.
+
+## Migration / Rollout Plan
+
+### Phase 1 — Feature flag (default off)
+
+- Land partitioning behind `queue.valkey.partitioning.enabled=false`.
+- Existing deployments unaffected.
+- Operators opt in by enabling the flag + bumping the chart.
+
+### Phase 2 — Drain-and-cutover
+
+- When `enabled=true`, binary on startup:
+  1. Drains residual jobs from the legacy `repo-guardian:queue:jobs` LIST by
+     re-enqueueing them through the new partitioning logic (jobs already carry
+     `InstallationID`; they route to per-installation keys).
+  2. Deletes the legacy keys when drained.
+  3. Resumes normal operation against the per-installation key space.
+
+- The drain is idempotent — repeated restarts during the migration window do not
+  duplicate work.
+
+### Phase 3 — Promote to default
+
+After ≥ 1 release cycle of opt-in production usage:
+
+- Flip the chart default to `enabled=true`.
+- Document the migration recipe in `docs/operations/`.
+- Mark the legacy single-key code path deprecated; remove in a future release.
+
+### Rollback
+
+If a bug surfaces in partitioning, operators set `enabled=false` and restart. The
+binary drains residual partitioned jobs back into the legacy LIST on startup (mirror
+of the Phase 2 drain).
+
+## Open Questions
+
+**(a)** Per-installation cap formula.
+
+- **(a) = `max(2, ceil(workerCount / installations_count))` (recommended).** Scales
+  inversely with fleet breadth; gives single-tenant deployments effectively-uncapped
+  behaviour and multi-tenant deployments strict fairness.
+- (b) Static cap (`perInstallationCap=N` fixed by operator). Simpler, but requires
+  retuning whenever installations are added or workerCount changes.
+- (c) Dynamic cap derived from per-installation rate-limit headroom. More fair
+  under unequal rate-limit budgets (e.g., GHEC orgs at 12.5k/hr vs non-enterprise at
+  5k/hr); much more state.
+- other:
+
+**(b)** Worker scheduling strategy at GA.
+
+- **(a) = Strategy A (BLPOP-many) with soft cap (recommended).** Simplest implementation;
+  good enough for the vast majority of fleets.
+- (b) Strategy B (round-robin with hard cap). Reach for it if BLPOP-many's
+  "exclude-at-cap" application-side check proves insufficient (e.g., under sustained
+  noisy-org bursts where the local cap counter races against worker startup).
+- (c) Strategy C (weighted random by depth + headroom). Future enhancement only.
+- other:
+
+**(c)** Installation registry consistency mechanism.
+
+- **(a) = Idempotent SADD on Enqueue, SREM on `installation.deleted` webhook, no
+  periodic janitor (recommended).** Simplest; stale entries cause BLPOP timeouts
+  but no correctness issue.
+- (b) Periodic janitor SCAN/EXISTS pass. Defensive but more code. Easy to add later
+  if stale entries accumulate.
+- other:
+
+**(d)** Per-installation metric cardinality cap.
+
+- **(a) = No cap (recommended).** Realistic fleets are < 100 installations; 4 series
+  × 100 = 400 series per metric, well under Prometheus practical limits.
+- (b) Cardinality cap (e.g., top-N by depth). Defensive but adds aggregation
+  complexity. Premature optimisation.
+- other:
+
+**(e)** Drain-on-cutover behaviour during Phase 2.
+
+- **(a) = Auto-drain on startup, idempotent (recommended).** Operators flip the flag
+  and restart; the binary handles the migration transparently.
+- (b) Operator-driven drain via a CLI subcommand (e.g.,
+  `repo-guardian queue migrate-partitioned`). More explicit, less convenient.
+- other:
+
+## References
+
+- `docs/operations/aws.md` § Partitioning, sharding, and the noisy-org problem —
+  explains the distinction and the user-visible motivation
+- `docs/operations/scaling.md` § Scaling for GitHub Enterprise (multi-org,
+  multi-thousand-repo) — the fleet shape this design targets
+- [DESIGN-0012: Persistent reconcile state and multi-replica coordination](0012-persistent-reconcile-state-and-multi-replica-coordination.md)
+  — established the Queue + Scheduler interfaces this design extends
+- [IMPL-0011: Persistent reconcile state and multi-replica coordination](../impl/0011-persistent-reconcile-state-and-multi-replica-coordination.md)
+  — implementation of DESIGN-0012; baseline for this design's deltas
+- [DESIGN-0017: Stale-sweep cutover and repository discovery](0017-stale-sweep-cutover-and-repository-discovery.md)
+  — sibling design; partitioning + discovery cutover together close out the
+  multi-replica scaling story

--- a/docs/design/0016-separate-postgres-read-and-write-endpoints.md
+++ b/docs/design/0016-separate-postgres-read-and-write-endpoints.md
@@ -1,0 +1,389 @@
+---
+id: DESIGN-0016
+title: "Separate Postgres read and write endpoints"
+status: Draft
+author: Donald Gifford
+created: 2026-06-22
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# DESIGN 0016: Separate Postgres read and write endpoints
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-06-22
+
+<!--toc:start-->
+- [Overview](#overview)
+- [Goals and Non-Goals](#goals-and-non-goals)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Background](#background)
+- [Detailed Design](#detailed-design)
+  - [Two-pool wiring](#two-pool-wiring)
+  - [Read/write query classification](#readwrite-query-classification)
+  - [Replica-lag tolerance](#replica-lag-tolerance)
+  - [Reader-unavailable fallback](#reader-unavailable-fallback)
+  - [Chart values surface](#chart-values-surface)
+- [API / Interface Changes](#api--interface-changes)
+- [Data Model](#data-model)
+- [Testing Strategy](#testing-strategy)
+- [Migration / Rollout Plan](#migration--rollout-plan)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Overview
+
+Wire repo-guardian's `internal/store/postgres/` to maintain two pgxpool connection
+pools — a writer pool for state mutations and a reader pool for stale-sweep queries
+— so chart deployments can route read-heavy traffic at Postgres reader endpoints
+(CNPG `<cluster>-ro` service, Aurora reader endpoint, RDS read replicas).
+
+Single-endpoint deployments remain supported via fallback: if only one DSN is
+provided, both pools point at it. The change is opt-in and backward-compatible.
+
+## Goals and Non-Goals
+
+### Goals
+
+- Route `Store.StaleRepos` (the per-sweep read-heavy hotpath) at a reader endpoint
+  when one is configured.
+- Support both CNPG and Aurora reader-endpoint shapes from the same chart.
+- Preserve backward compatibility: existing single-DSN deployments behave identically.
+- Graceful degradation if the reader endpoint is unavailable — fall back to the
+  writer pool, log + count the fallback so operators can alert on it.
+
+### Non-Goals
+
+- Read-after-write consistency handling for repo-guardian's own writes. The state
+  table is updated once per reconcile (after worker finishes); the next sweep tick
+  is the natural read point and replica lag (~20ms on Aurora) is well under any
+  sweep interval. We do not need synchronous-replica or commit-wait semantics.
+- Connection-aware routing inside a single transaction. We don't do multi-statement
+  transactions that mix reads and writes; if we ever do, they go to the writer
+  pool unconditionally.
+- Per-query dynamic routing decisions based on load. Static classification per
+  Store method.
+- Direct integration with AWS RDS Proxy's reader endpoint feature beyond DSN
+  configuration (operator points the read DSN at the Proxy's reader endpoint).
+
+## Background
+
+`internal/store/postgres/` today holds a single `*pgxpool.Pool` constructed from one
+DSN (`STORE_DSN` env var). Every query — reads (`StaleRepos`, `Get`, etc.) and writes
+(`Upsert`, `Touch`) — uses the same pool against the same endpoint.
+
+This is the right default for:
+
+- Baked Postgres mode (single instance, one endpoint)
+- CNPG with `instances=1` (no replicas)
+- Operators who don't care about read offload
+
+It leaves performance on the table for:
+
+- CNPG `instances > 1`: CNPG provisions a `<cluster>-rw` service routing only to the
+  primary, plus a `<cluster>-ro` service load-balanced across hot-standby replicas.
+  Replicas sit idle today.
+- Aurora Postgres: cluster has separate writer + reader endpoints. Reader endpoint
+  load-balances across reader instances. Today repo-guardian's binary uses only the
+  writer.
+- RDS provisioned with read replicas: same shape as Aurora at smaller scale.
+
+The hotpath that benefits most is `Store.StaleRepos(freshness, policyVersion,
+batchSize)` — runs once per sweep tick across the (potentially large) state table.
+At 3000 repos × 25 orgs scale (`docs/operations/aws.md`), this is by far the
+heaviest query. Other reads (`Get` for individual repos during worker dispatch) are
+small but frequent.
+
+## Detailed Design
+
+### Two-pool wiring
+
+The Postgres store grows two pools:
+
+```go
+type Store struct {
+    rw     *pgxpool.Pool   // writer; required
+    ro     *pgxpool.Pool   // reader; may equal rw if no separate read DSN
+    metrics *Metrics
+}
+```
+
+Construction:
+
+- If `STORE_DSN_RO` is set: parse, build pool, assign to `ro`.
+- If unset: `ro = rw` (alias the single pool). All queries against `ro` go through
+  the writer endpoint.
+
+The alias case has zero performance impact and zero new code paths beyond the
+constructor.
+
+### Read/write query classification
+
+Static method classification — encoded in the Store implementation, not
+operator-tunable:
+
+| Method | Pool | Rationale |
+|---|---|---|
+| `StaleRepos(ctx, freshness, policyVersion, batchSize)` | `ro` | Per-sweep tick read-heavy hotpath |
+| `Get(ctx, owner, repo)` | `ro` | Per-worker dispatch read; high frequency, no write semantics |
+| `Upsert(ctx, state)` | `rw` | Updates `last_checked_at` and policy version |
+| `Touch(ctx, owner, repo)` | `rw` | Updates `last_checked_at` only |
+| `Close()` | both | Closes rw, and ro if not aliased |
+
+Methods on Store that take a `*pgx.Tx` (none today; future-proofing) always go
+through `rw`. Mixed-mode transactions are not supported — they'd require
+two-phase-commit semantics we don't need.
+
+### Replica-lag tolerance
+
+Aurora and Postgres streaming replication have non-zero lag — typically <20ms under
+healthy conditions, up to seconds under load. Implications:
+
+- **Write-then-read within the same sweep:** does not happen. The worker writes the
+  state row at the END of `engine.CheckRepo`; the read in `StaleRepos` happens at
+  the START of the NEXT sweep tick (minutes-to-hours later). Replica lag is
+  irrelevant at our sweep cadence.
+- **Discovery-then-read:** the legacy Sweeper (or DESIGN-0017's replacement) writes
+  newly-discovered repo rows; the StaleSweeper reads them. If the discovery write
+  hasn't replicated by the time StaleSweeper reads, the repo simply gets enqueued
+  on the next tick. No correctness impact — eventual consistency is sufficient.
+- **Webhook-triggered reconcile:** the webhook handler enqueues a job; the worker's
+  `Get(owner, repo)` reads from the replica. If the previous reconcile's `Upsert`
+  hasn't replicated, the worker sees stale state and may do redundant work (e.g.,
+  re-evaluate rules that already passed). The reconcile is idempotent — no harm
+  done — but it costs an extra GitHub API call cycle. Acceptable.
+
+**Recommended `replica-lag-tolerance` setting:** none. The Store doesn't measure lag
+or wait for it. Documentation flags the eventual-consistency model explicitly.
+
+### Reader-unavailable fallback
+
+If the reader pool's `Acquire` fails (network partition, all reader replicas down,
+Proxy reader pool exhausted), the Store falls back to the writer pool for that
+query. Behaviour:
+
+- Log at WARN with `op=fallback_to_rw method=<method> error=<err>` once per
+  fallback. Throttled via existing `slog` rate-limit or a `sync.Once`-protected
+  warning per replica boot.
+- Increment counter: `repo_guardian_store_fallback_total{from="ro", to="rw"}`.
+- Proceed with the query against `rw`. The query's correctness is identical; only
+  the routing changes.
+
+Alerting:
+
+- Alert if `rate(repo_guardian_store_fallback_total[5m]) > 0.1`. Indicates the
+  reader endpoint is unhealthy.
+
+### Chart values surface
+
+Building on the existing `store.postgres` block:
+
+```yaml
+store:
+  backend: postgres
+  postgres:
+    mode: external                # or cnpg, baked
+    existingSecret: ""            # backward-compat single-DSN deployments
+    existingSecretKey: STORE_DSN
+
+    # NEW: optional read-endpoint configuration
+    readEndpoint:
+      enabled: false              # opt-in
+      existingSecret: ""          # operator-provided; falls back to existingSecret if empty
+      existingSecretKey: STORE_DSN_RO
+
+    # CNPG mode auto-wires both endpoints
+    cnpg:
+      cluster:
+        instances: 3              # primary + 2 standbys
+      pooler:
+        # rw pooler unchanged
+      readPooler:                 # NEW
+        enabled: false
+        # PgBouncer config for the read-only pooler
+```
+
+For CNPG mode with `readEndpoint.enabled=true`, the chart auto-wires the read DSN to
+the CNPG `<cluster>-ro` service (or `<cluster>-r` if `readPooler.enabled=true`).
+Operator doesn't need to construct the read DSN manually.
+
+For external mode (RDS / Aurora), operator provides the read DSN via the same
+ExternalSecret pattern as the writer DSN.
+
+## API / Interface Changes
+
+### `internal/config/`
+
+Two new env vars:
+
+- `STORE_DSN_RO` — optional read-only Postgres DSN. Unset → aliased to `STORE_DSN`.
+- `STORE_DSN_RO_MAX_CONNS` — optional pool size cap for the read pool. Defaults to
+  the same `STORE_POSTGRES_MAX_CONNS` value used for the writer.
+
+### `internal/store/`
+
+`Store` interface unchanged. The `pgx` implementation grows the second pool
+internally; callers don't observe the change.
+
+### `internal/store/postgres/store.go`
+
+- Constructor accepts an optional `ReadDSN string` (empty → alias rw).
+- `ro` and `rw` fields on the Store struct.
+- Each method picks its pool per the [classification table](#readwrite-query-classification).
+
+### `internal/metrics/`
+
+- `repo_guardian_store_query_seconds` gains an `endpoint="rw"|"ro"` label.
+- `repo_guardian_store_fallback_total{from, to}` (new CounterVec) — counts
+  reader→writer fallbacks.
+- `repo_guardian_store_pool_size{endpoint}` (existing → adds label).
+
+### Chart templates
+
+- `_helpers.tpl`: new function `repo-guardian.storeReadSecretName` mirroring
+  `repo-guardian.storeSecretName`. Picks between the chart-rendered CNPG-RO secret,
+  the operator-provided existingSecret, or aliases to the writer secret.
+- `deployment.yaml`: conditional env block for `STORE_DSN_RO` when
+  `readEndpoint.enabled=true`.
+- `store-cnpg-pooler.yaml`: extended to support the `ro` Pooler type alongside the
+  existing `rw`.
+
+## Data Model
+
+No schema changes. The `repo_state` table and its indexes are read and written
+identically; only the connection routing changes.
+
+## Testing Strategy
+
+### Unit tests
+
+- Constructor with `ReadDSN=""` aliases `ro` to `rw`. Both fields are equal.
+- Constructor with non-empty `ReadDSN` builds two distinct pools.
+- Each Store method's pool selection (verify via test-only pool injection).
+
+### Integration tests (`_integration_test.go`)
+
+- Spin two Postgres containers (writer + reader). Configure replication is too
+  heavy for the test loop; instead, run a `pg_dump | psql` after each write to
+  simulate replication for the read-after-write tests.
+- Verify reader-pool failure (kill the reader container) triggers fallback to
+  writer with metric increment.
+- Verify CNPG-style aliasing (single DSN, both pools point at it) gives identical
+  semantics to the pre-change Store.
+
+### Chart tests (`helm-unittest`)
+
+- `readEndpoint.enabled=false` (default) — deployment has no `STORE_DSN_RO` env var.
+- `readEndpoint.enabled=true` with CNPG mode — `STORE_DSN_RO` references the CNPG
+  `<cluster>-ro` service secret.
+- `readEndpoint.enabled=true` with external mode + `existingSecret` provided —
+  `STORE_DSN_RO` references the operator's secret.
+- `readEndpoint.enabled=true` with external mode + empty `existingSecret` — falls
+  back to the writer's secret (graceful single-DSN behaviour).
+
+## Migration / Rollout Plan
+
+### Phase 1 — Implementation (default off)
+
+- Land the two-pool wiring; default `readEndpoint.enabled=false`.
+- Existing deployments unaffected — pools alias to a single endpoint.
+
+### Phase 2 — CNPG operator adoption
+
+- Operators with existing CNPG clusters (homelab, etc.) set
+  `cnpg.cluster.instances=3` and `readEndpoint.enabled=true`.
+- Chart auto-wires the read DSN to `<cluster>-ro`.
+- Validate via metrics: `store_query_seconds{endpoint="ro"}` non-zero,
+  `store_fallback_total` near zero.
+
+### Phase 3 — AWS RDS / Aurora adoption
+
+- Operators on RDS Proxy point a second Proxy at their cluster's reader endpoint.
+- Update the External Secrets resource to expose `STORE_DSN_RO` as a second key.
+- Set `readEndpoint.enabled=true` and reference the secret.
+
+### Phase 4 — Promote as default for multi-instance CNPG
+
+After ≥ 1 release cycle of stable Phase 2 + 3 production usage:
+
+- When `cnpg.cluster.instances > 1`, default `readEndpoint.enabled=true` in the
+  chart. Single-instance and baked modes still default to `enabled=false`.
+
+### Rollback
+
+If a bug surfaces, set `readEndpoint.enabled=false` and restart. The Store
+constructor sees no read DSN, aliases `ro=rw`, and behaviour reverts to
+single-endpoint.
+
+## Open Questions
+
+**(a)** What happens when the read pool is configured but ALL StaleSweeper queries
+fall back to writer for an extended period?
+
+- **(a) = Continue serving (recommended).** Service stays up; metrics surface the
+  problem; operators investigate the reader. This matches the "fallback should be
+  invisible to job correctness" principle.
+- (b) Drain workers / pause sweep until reader recovers. Defensive but degrades the
+  primary user-facing capability for a non-correctness issue. Rejected.
+- other:
+
+**(b)** Reader-pool size formula.
+
+- **(a) = Same as writer (recommended).** Operators tune one knob (`maxConns`)
+  applied to both pools. Simple mental model.
+- (b) Independent knob (`readMaxConns`). More precision but adds a config surface
+  that most operators won't tune.
+- (c) Auto-derive (`readMaxConns = ceil(writer * 0.5)` since reads are usually
+  smaller). Magic number that obscures.
+- other:
+
+**(c)** Per-`Get` routing — should the per-worker dispatch read use `ro` or `rw`?
+
+- **(a) = `ro` (recommended).** Frequent and read-heavy. Stale-read on a recently
+  reconciled repo just costs one extra reconcile cycle; harmless.
+- (b) `rw`. Avoids the stale-read scenario at the cost of doubling writer load.
+- other:
+
+**(d)** Should the chart auto-enable `readEndpoint.enabled=true` for CNPG
+multi-instance from day one, or wait for Phase 4?
+
+- **(a) = Wait for Phase 4 (recommended).** Phase 1-3 are explicit operator opt-ins;
+  Phase 4 promotes once we have production confidence. Safer default-change
+  cadence.
+- (b) Auto-enable in Phase 1. Lower friction for new deployments at the cost of
+  earlier exposure to potential bugs. The CNPG-side wiring is straightforward, so
+  the risk is low — but precedent in this repo is conservative default changes.
+- other:
+
+**(e)** RDS Proxy support — does the design need to know about Proxy-specific
+behaviours (connection pinning, transaction multiplexing, IAM session limits) or
+can we treat the Proxy endpoint as an opaque Postgres endpoint?
+
+- **(a) = Opaque (recommended).** RDS Proxy speaks Postgres protocol; the binary
+  shouldn't be Proxy-aware. Document Proxy behaviours as operator-side concerns in
+  `docs/operations/aws.md`, not in the binary.
+- (b) Proxy-aware. Premature; we have no evidence the Proxy needs special handling
+  for our query shape.
+- other:
+
+## References
+
+- `docs/operations/aws.md` § Postgres on AWS — operator-facing context for the
+  Aurora / RDS / RDS-Proxy combinations
+- `docs/operations/aws.md` § Gaps and workarounds — flagged the single-DSN
+  limitation that this design resolves
+- [DESIGN-0012: Persistent reconcile state and multi-replica coordination](0012-persistent-reconcile-state-and-multi-replica-coordination.md)
+  — established the Store interface this design extends
+- [IMPL-0011: Persistent reconcile state and multi-replica coordination](../impl/0011-persistent-reconcile-state-and-multi-replica-coordination.md)
+  — baseline implementation
+- [DESIGN-0015: Per-installation Valkey queue partitioning](0015-per-installation-valkey-queue-partitioning.md)
+  — sibling design; both close out multi-replica scaling correctness
+- [DESIGN-0017: Stale-sweep cutover and repository discovery](0017-stale-sweep-cutover-and-repository-discovery.md)
+  — sibling design; affects the discovery-then-read pattern this design's
+  Phase 4 promotion depends on
+- [CNPG Pooler documentation](https://cloudnative-pg.io/documentation/current/connection_pooling/)
+  — `rw` and `ro` Pooler types
+- [Aurora Postgres reader endpoint](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Overview.Endpoints.html)
+  — endpoint topology background

--- a/docs/design/0017-stale-sweep-cutover-and-repository-discovery.md
+++ b/docs/design/0017-stale-sweep-cutover-and-repository-discovery.md
@@ -1,0 +1,490 @@
+---
+id: DESIGN-0017
+title: "Stale-sweep cutover and repository discovery"
+status: Draft
+author: Donald Gifford
+created: 2026-06-22
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# DESIGN 0017: Stale-sweep cutover and repository discovery
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-06-22
+
+<!--toc:start-->
+- [Overview](#overview)
+- [Goals and Non-Goals](#goals-and-non-goals)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Background](#background)
+- [Detailed Design](#detailed-design)
+  - [Cold-start enqueue pacing](#cold-start-enqueue-pacing)
+  - [Discovery-only Sweeper mode](#discovery-only-sweeper-mode)
+  - [Webhook-driven incremental discovery](#webhook-driven-incremental-discovery)
+  - [Periodic reconciliation discovery](#periodic-reconciliation-discovery)
+  - [Cutover behaviour](#cutover-behaviour)
+- [API / Interface Changes](#api--interface-changes)
+- [Data Model](#data-model)
+- [Testing Strategy](#testing-strategy)
+- [Migration / Rollout Plan](#migration--rollout-plan)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Overview
+
+Cut over fully from the legacy `Sweeper.ReconcileAll` (full
+`ListInstallations()` → `ListInstallationRepos()` → enqueue-every-repo loop) to
+the IMPL-0011 `StaleSweeper.SweepStale` (Store-backed, only-stale-repos query) on
+the Postgres backend. Today both schedulers run at the same interval, so the
+StaleSweeper's selectivity is wasted — the legacy Sweeper has already enqueued
+every repo by the time StaleSweeper runs.
+
+This DESIGN replaces the legacy Sweeper's "enqueue everything" responsibility with
+a smaller "discover-only" mode that runs at a slower cadence, populates Store rows
+for newly-observed repos, but does NOT enqueue them. StaleSweeper picks them up on
+its next tick. The same path also paces the cold-start enqueue burst when a fresh
+deployment encounters an existing fleet of repos.
+
+## Goals and Non-Goals
+
+### Goals
+
+- Eliminate redundant enqueueing on the Postgres backend. After cutover, each
+  sweep tick enqueues only stale repos, not every repo.
+- Cold-start a deployment against an existing 3000-repo fleet without burning the
+  GitHub API rate-limit budget in the first hour.
+- Keep discovery of new repos working without depending exclusively on webhooks
+  (operators may have webhook delivery gaps, mis-configured installations, or
+  brand-new installations with no historical webhooks).
+- Preserve existing memory-backend behaviour: memory mode has no Store and
+  continues to use the legacy Sweeper unchanged.
+- Bounded blast radius from misconfigured discovery: if discovery breaks, in-flight
+  reconciliation continues; only new-repo onboarding is affected.
+
+### Non-Goals
+
+- Eliminating the legacy Sweeper entirely. Memory backend deployments need it.
+  Postgres backend after cutover doesn't.
+- Webhook-only discovery. Webhooks are best-effort and can be missed; we keep a
+  periodic discovery path as a safety net.
+- Real-time repo discovery (sub-second). Discovery runs at a configurable cadence
+  (default: hourly). New repos can wait minutes for onboarding without harm.
+- Cross-installation deduplication beyond the existing per-Store-row uniqueness.
+
+## Background
+
+`cmd/repo-guardian/main.go` today schedules two handlers at the same interval:
+
+```go
+sched.Schedule(ctx, "sweep", interval, sweeper.ReconcileAll)             // legacy: enumerates EVERYTHING
+if storeBackend == "postgres" {
+    sched.Schedule(ctx, "stale-sweep", interval, staleSweeper.SweepStale) // filtered: stale only
+}
+```
+
+The legacy `Sweeper.ReconcileAll` (in `internal/scheduler/sweep.go`) does:
+
+1. `ListInstallations()` — one API call
+2. For each installation, `ListInstallationRepos()` — one API call per page
+3. For each repo, `Queue.Enqueue` — one Valkey op
+4. Done
+
+The `StaleSweeper.SweepStale` (in `internal/checker/sweep.go`) does:
+
+1. `Store.StaleRepos(freshness, policyVersion, batchSize)` — one Postgres query
+2. For each stale repo, rate-limit check + `Queue.Enqueue` — one Valkey op each
+3. Done
+
+Both run at `policyCfg.Guardian.ParsedScheduleInterval` (default 168h, configurable
+to anything via `SCHEDULE_INTERVAL`). At tick time, the legacy Sweeper dumps every
+known repo into the queue; StaleSweeper then does its filtered work — but by then
+the queue already has every repo. Workers proceed to reconcile each repo
+regardless of `last_checked_at`, because the engine itself has no freshness gate
+(only the queue-feeding StaleSweeper does).
+
+The intent in the IMPL-0011 comment header:
+
+> Bootstrap (populating the store with rows for newly-installed repos) is the
+> legacy Sweeper's job. The two coexist during the IMPL-0011 migration window.
+
+The migration window never closed. The legacy Sweeper still enqueues, not just
+bootstraps.
+
+### Real symptoms
+
+- **Cold start with empty Store:** every repo enqueued on first tick → instant
+  rate-limit pressure as workers race to reconcile 3000 repos × ~10 API calls
+  each = 30k API calls within the first sweep window.
+- **Pod restart with warm Store:** every repo re-enqueued unconditionally, even
+  though Store would have correctly skipped them. Worker pool churns through
+  repos doing redundant work (some short-circuited by the engine's own internal
+  checks, some not).
+- **Steady-state:** legacy Sweeper enqueues N repos every tick; StaleSweeper adds
+  the (small) stale subset. Worker pool processes 2x the work it needs to.
+
+## Detailed Design
+
+### Cold-start enqueue pacing
+
+When a fresh deployment encounters an existing fleet, the Store is empty and
+every repo qualifies as stale. The current StaleSweeper would issue
+`StaleRepos(batchSize=200, …)` → enqueue 200 → repeat next tick → enqueue 200 →
+… eventually catching up.
+
+That pacing is correct in shape but breaks down because the **discovery step**
+(populating the Store) happens via the legacy Sweeper, which doesn't pace —
+it dumps all 3000 repos in one tick.
+
+The fix: split discovery from enqueueing.
+
+```
+Discovery (slow, controlled):
+    ListInstallations() → ListInstallationRepos() → for each repo not in Store: INSERT row with
+    last_checked_at = NOW() - rand(0, freshness*2)
+
+StaleSweeper (existing):
+    StaleRepos(freshness, …) returns repos whose last_checked_at is older than freshness.
+    The jittered initial last_checked_at staggers the cold-start enqueue across multiple
+    sweep ticks.
+```
+
+The randomised initial `last_checked_at` means cold start enqueues a fraction of
+the fleet per tick, naturally pacing against rate-limit budgets. Example with
+freshness=24h, 3000 repos, sweep_interval=1h:
+
+| Sweep tick | Repos with last_checked_at > 24h old | Enqueued (approx.) |
+|---|---|---|
+| 1 | ~125 (those in [24h, 26h] jitter band) | 125 |
+| 2 | next 125 | 125 |
+| … | … | … |
+| 24 | last 125 | 125 |
+| 25 | repos reconciled in tick 1 are now stale → cycle repeats | 125 |
+
+Steady-state is reached in 24 sweep ticks (24 hours at 1h cadence). Worst-case
+API consumption is ~125 repos × 10 calls = 1250 API calls per tick, well within
+even a single installation's 5000/hr budget.
+
+### Discovery-only Sweeper mode
+
+Rename and repurpose `Sweeper.ReconcileAll` into `Sweeper.Discover`. Behaviour:
+
+```go
+func (s *Sweeper) Discover(ctx context.Context) error {
+    installs, _ := s.client.ListInstallations(ctx)
+    for _, inst := range installs {
+        repos, _ := s.client.ListInstallationRepos(ctx, inst.ID)
+        for _, repo := range repos {
+            existing, err := s.store.Get(ctx, repo.Owner, repo.Name)
+            if err != nil { /* log + count */ continue }
+            if existing != nil { continue } // already known
+            initialLastChecked := time.Now().Add(-time.Duration(rand.Int63n(int64(2*s.freshness))))
+            s.store.Upsert(ctx, store.State{
+                Owner:           repo.Owner,
+                Repo:            repo.Name,
+                InstallationID:  inst.ID,
+                LastCheckedAt:   initialLastChecked,
+                PolicyVersion:   "", // forces StaleSweeper to pick it up
+            })
+            metrics.RepoDiscovered.WithLabelValues(strconv.FormatInt(inst.ID, 10)).Inc()
+        }
+    }
+    return nil
+}
+```
+
+Key properties:
+
+- **No Queue.Enqueue.** The Discover loop only writes Store rows.
+- **Idempotent.** Repeated runs do not duplicate rows (`Get`+conditional `Upsert`).
+- **Jittered `last_checked_at`.** Spreads the cold-start enqueue burst.
+- **Empty PolicyVersion.** Forces StaleSweeper to treat the row as stale on its
+  next tick, picking up the repo for first reconciliation.
+
+### Webhook-driven incremental discovery
+
+The webhook handler already processes `installation_repositories.added` events
+(see `internal/webhook/`). Extend it to write Store rows the same way Discover
+does:
+
+```go
+// In webhook handler for installation_repositories.added
+for _, repo := range payload.RepositoriesAdded {
+    s.store.Upsert(ctx, store.State{
+        Owner:          repo.Owner.Login,
+        Repo:           repo.Name,
+        InstallationID: payload.Installation.ID,
+        LastCheckedAt:  time.Now().Add(-time.Duration(rand.Int63n(int64(2*s.freshness)))),
+        PolicyVersion:  "",
+    })
+}
+```
+
+Same idempotency and jitter as Discover. Webhook-driven discovery is the
+primary path during steady-state operation; the periodic Discover is the safety
+net.
+
+### Periodic reconciliation discovery
+
+Cadence: configurable, default 1h. Independent of `SCHEDULE_INTERVAL` (which now
+governs only StaleSweeper).
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `DISCOVERY_INTERVAL` | `1h` | Discovery sweep cadence |
+| `DISCOVERY_ENABLED` | `true` (Postgres backend only) | Toggle for operators who want webhook-only discovery |
+
+The 1h default balances:
+
+- Detecting webhook delivery gaps within an hour
+- Spreading the API cost of `ListInstallations` + `ListInstallationRepos` across
+  many ticks (3000 repos / 100 per page = 30 API calls per discovery tick, well
+  within budget)
+
+### Cutover behaviour
+
+`cmd/repo-guardian/main.go` wiring after this design:
+
+```go
+// Memory backend: legacy Sweeper unchanged (still enqueues).
+if storeBackend == "memory" {
+    sched.Schedule(ctx, "sweep", interval, legacySweeper.ReconcileAll)
+}
+
+// Postgres backend: split discovery from enqueueing.
+if storeBackend == "postgres" {
+    if cfg.DiscoveryEnabled {
+        sched.Schedule(ctx, "discovery", cfg.DiscoveryInterval, discoverer.Discover)
+    }
+    sched.Schedule(ctx, "stale-sweep", cfg.ScheduleInterval, staleSweeper.SweepStale)
+}
+```
+
+The legacy Sweeper is no longer scheduled when Postgres backend is in use. The
+new `Discoverer` (renamed and slimmed from the legacy Sweeper) handles only
+discovery.
+
+## API / Interface Changes
+
+### `internal/scheduler/sweep.go` (existing legacy Sweeper)
+
+- Memory-backend path: unchanged.
+- Postgres-backend path: NEW type `Discoverer` with method `Discover(ctx)`.
+  Re-uses the existing `client.ListInstallations` / `ListInstallationRepos` logic
+  but writes Store rows instead of enqueueing.
+- The legacy `Sweeper.ReconcileAll` stays for memory-backend deployments.
+- Both types live in `internal/scheduler/`; sharing utility functions where
+  appropriate.
+
+### `internal/config/`
+
+Two new env vars:
+
+- `DISCOVERY_INTERVAL` — Go duration string, default `1h`.
+- `DISCOVERY_ENABLED` — bool, default `true` when `STORE_BACKEND=postgres`,
+  `false` otherwise.
+
+### `internal/store/`
+
+`Store` interface unchanged. The discovery path uses existing `Get` and `Upsert`
+methods.
+
+### `internal/webhook/`
+
+Extend the `installation_repositories.added` and `repository.created` handlers
+to write Store rows when the Postgres backend is active. Same idempotent
+`Get`+conditional `Upsert` pattern.
+
+### `internal/metrics/`
+
+- `repo_guardian_repo_discovered_total{installation_id}` — counts newly
+  discovered repos.
+- `repo_guardian_discovery_duration_seconds` — histogram of Discover loop
+  wall-clock time.
+- `repo_guardian_discovery_api_calls_total{installation_id, endpoint}` —
+  counts the ListInstallations / ListInstallationRepos / Get API calls each
+  Discover tick makes.
+
+### Chart values
+
+```yaml
+discovery:
+  # NEW. Only effective when store.backend=postgres.
+  enabled: true
+  interval: "1h"
+```
+
+The values are no-ops when `store.backend=memory` (existing legacy Sweeper path
+is unaffected).
+
+## Data Model
+
+No schema changes. The `repo_state` table is extended in usage:
+
+- New rows can now have `policy_version = ''` (empty string) to signal
+  "discovered but not yet reconciled." The existing StaleSweeper query
+  (`policy_version != $currentVersion`) already handles this correctly — empty
+  string matches the inequality and the repo gets enqueued.
+- The `last_checked_at` column is no longer monotonically derived from
+  reconciliation time; on discovery, it can be set to a past timestamp via the
+  jitter logic. This is harmless — the column's semantic is "when StaleSweeper
+  should next consider this repo," not "wall-clock time of last successful
+  reconcile."
+
+## Testing Strategy
+
+### Unit tests
+
+- `Discoverer.Discover` idempotency: repeated runs do not duplicate rows.
+- Jitter range: `last_checked_at` always within `(now - 2*freshness, now)`.
+- Empty installation list: no Store writes, no panics.
+- Store write failure: error counted, loop continues to next repo.
+
+### Integration tests (`_integration_test.go`)
+
+- Cold-start simulation: start with empty Store, run Discover, verify N rows
+  inserted with jittered timestamps spanning the expected band.
+- Existing rows preserved: rerun Discover after manual `Upsert` with a
+  non-default `policy_version`; verify the manual row is untouched.
+- Webhook-driven discovery: replay `installation_repositories.added` payload,
+  verify the new repo lands in Store with empty `policy_version`.
+
+### Cutover validation
+
+- Spin a Postgres-backed deployment, populate Store with 3000 fake rows whose
+  `last_checked_at` is uniformly random in `[now - 24h, now]`.
+- Start the binary with legacy Sweeper still scheduled (pre-cutover state).
+  Observe: queue depth spikes to 3000 on first tick.
+- Disable legacy Sweeper, enable Discoverer (post-cutover state). Restart.
+  Observe: queue depth on first tick is only the stale subset (~125 with
+  freshness=24h, sweep_interval=1h).
+
+### Chart tests (`helm-unittest`)
+
+- `store.backend=memory`: deployment env has no `DISCOVERY_*` vars (or has them
+  but with `DISCOVERY_ENABLED=false`).
+- `store.backend=postgres` default: `DISCOVERY_ENABLED=true`, `DISCOVERY_INTERVAL=1h`.
+- `store.backend=postgres` with `discovery.enabled=false`: env reflects opt-out.
+
+## Migration / Rollout Plan
+
+### Phase 1 — Land Discoverer alongside legacy Sweeper
+
+- Implement `Discoverer.Discover` and new env vars; ship at default
+  `DISCOVERY_ENABLED=false` for both backends.
+- Existing deployments unaffected.
+
+### Phase 2 — Opt-in cutover
+
+- Operators with Postgres backend set `DISCOVERY_ENABLED=true`.
+- `cmd/repo-guardian/main.go` reads the flag: when true, schedules Discoverer
+  AND disables the legacy Sweeper schedule.
+- Operator-visible behaviour: queue depth drops sharply because the legacy
+  Sweeper no longer enqueues unconditionally.
+- Validate via metrics: `repo_guardian_queue_depth` per sweep tick matches
+  `StaleRepos` result size; `repo_discovered_total` increments on new repos.
+
+### Phase 3 — Default-flip for Postgres backend
+
+After ≥ 1 release cycle of Phase 2 operator validation:
+
+- Chart default flips to `discovery.enabled=true` when `store.backend=postgres`.
+- Memory backend remains on the legacy Sweeper path.
+
+### Phase 4 — Remove legacy Sweeper from Postgres path
+
+Once Phase 3 has been the default for ≥ 1 release cycle:
+
+- `cmd/repo-guardian/main.go` no longer schedules `legacySweeper.ReconcileAll`
+  when `STORE_BACKEND=postgres`, regardless of `DISCOVERY_ENABLED` (the flag
+  itself remains a kill-switch for Discoverer, but the legacy path is removed
+  from the Postgres-backend code path).
+- The legacy Sweeper type stays in the codebase for memory-backend deployments.
+
+### Rollback
+
+If Discoverer misbehaves, set `DISCOVERY_ENABLED=false` and restart. Until
+Phase 4, the legacy Sweeper schedule re-engages and the deployment behaves
+identically to pre-cutover. After Phase 4, the rollback path is via a chart
+revert (the legacy Sweeper isn't scheduled for Postgres regardless of the flag).
+
+## Open Questions
+
+**(a)** Jitter range for the initial `last_checked_at`.
+
+- **(a) = `random in [now - 2*freshness, now]` (recommended).** Spreads the
+  cold-start enqueue across `2 * freshness / sweep_interval` ticks. With
+  freshness=24h, sweep=1h → ~48 ticks.
+- (b) `random in [now - freshness, now]`. Spreads across fewer ticks, faster
+  steady-state but higher per-tick burst.
+- (c) Uniform `now - freshness/2`. No jitter; all repos go stale at the same
+  tick. Bad. Rejected.
+- other:
+
+**(b)** Discovery cadence default.
+
+- **(a) = `1h` (recommended).** Detects webhook delivery gaps within an hour;
+  API cost is negligible at typical fleet sizes.
+- (b) `15m`. More responsive to new-repo events that miss the webhook; 4x the
+  API cost.
+- (c) `24h`. Lower API cost but lets webhook gaps linger for a day.
+- other:
+
+**(c)** Should Discoverer also handle repo *removal* (a repo being archived,
+deleted, or moved out of the installation)?
+
+- **(a) = Out of scope for v1 (recommended).** Repo removal is a soft problem —
+  a stale Store row for an inaccessible repo just hits a 404 on next reconcile
+  and gets handled by error paths. Tracking removal cleanly would require
+  another comparison pass and isn't blocking.
+- (b) Add a "missing repos" pass after each Discover loop. Insert into a
+  removal-pending queue; webhook `repository.deleted` cleans up.
+- other:
+
+**(d)** Webhook handler write-on-discovery vs Discover loop write — what if
+both fire at once?
+
+- **(a) = Idempotent `Get`+conditional `Upsert` (recommended).** Both paths
+  check for an existing row before inserting; race is harmless. Same row
+  inserted twice with the same key just stays as one row.
+- (b) Distributed lock per (owner, repo) during discovery. Overkill for the
+  blast radius.
+- other:
+
+**(e)** Memory-backend behaviour after this design.
+
+- **(a) = Unchanged — legacy Sweeper continues to enqueue (recommended).** Memory
+  backend has no Store; there's no place to write discovery rows. The legacy
+  Sweeper's existing semantics are correct for single-replica memory mode.
+- (b) Extend Discoverer to support a memory-only mode. Adds complexity for a
+  use case that's already correct.
+- other:
+
+**(f)** Single-binary architectural question: should Discoverer be a separate
+process (e.g., a CronJob) or remain in-pod as a goroutine?
+
+- **(a) = In-pod goroutine (recommended).** Matches the existing Scheduler.Schedule
+  pattern. No new resource/deployment shape; existing leader-election covers
+  the multi-replica case.
+- (b) Separate CronJob. Better isolation but adds a deployment surface and
+  needs its own creds + image + chart resources.
+- other:
+
+## References
+
+- `docs/operations/aws.md` § Cold-start validation — operator-facing context for
+  the metrics-watching validation procedure
+- `docs/operations/scaling.md` § Scaling for GitHub Enterprise — fleet-size
+  context this design optimises for
+- `internal/checker/sweep.go` header comment — explicit "the two coexist during
+  the IMPL-0011 migration window" intent that this design closes out
+- [DESIGN-0012: Persistent reconcile state and multi-replica coordination](0012-persistent-reconcile-state-and-multi-replica-coordination.md)
+  — established the StaleSweeper pattern
+- [IMPL-0011: Persistent reconcile state and multi-replica coordination](../impl/0011-persistent-reconcile-state-and-multi-replica-coordination.md)
+  — opened the migration window this design closes
+- [DESIGN-0015: Per-installation Valkey queue partitioning](0015-per-installation-valkey-queue-partitioning.md)
+  — sibling design; fairness within the queue
+- [DESIGN-0016: Separate Postgres read and write endpoints](0016-separate-postgres-read-and-write-endpoints.md)
+  — sibling design; affects the Get + Upsert path Discoverer uses

--- a/docs/design/0017-stale-sweep-cutover-and-repository-discovery.md
+++ b/docs/design/0017-stale-sweep-cutover-and-repository-discovery.md
@@ -20,7 +20,10 @@ created: 2026-06-22
   - [Non-Goals](#non-goals)
 - [Background](#background)
 - [Detailed Design](#detailed-design)
-  - [Cold-start enqueue pacing](#cold-start-enqueue-pacing)
+  - [Pacing — two layered mechanisms](#pacing--two-layered-mechanisms)
+  - [Layer 1 — Budget-aware enqueueing (primary)](#layer-1--budget-aware-enqueueing-primary)
+  - [Layer 2 — Jittered initial last_checked_at (secondary)](#layer-2--jittered-initial-last_checked_at-secondary)
+  - [Cross-replica coordination](#cross-replica-coordination)
   - [Discovery-only Sweeper mode](#discovery-only-sweeper-mode)
   - [Webhook-driven incremental discovery](#webhook-driven-incremental-discovery)
   - [Periodic reconciliation discovery](#periodic-reconciliation-discovery)
@@ -127,45 +130,166 @@ bootstraps.
 
 ## Detailed Design
 
-### Cold-start enqueue pacing
+### Pacing — two layered mechanisms
 
-When a fresh deployment encounters an existing fleet, the Store is empty and
-every repo qualifies as stale. The current StaleSweeper would issue
-`StaleRepos(batchSize=200, …)` → enqueue 200 → repeat next tick → enqueue 200 →
-… eventually catching up.
+Two distinct concerns sit underneath "don't burn the API budget":
 
-That pacing is correct in shape but breaks down because the **discovery step**
-(populating the Store) happens via the legacy Sweeper, which doesn't pace —
-it dumps all 3000 repos in one tick.
-
-The fix: split discovery from enqueueing.
-
-```
-Discovery (slow, controlled):
-    ListInstallations() → ListInstallationRepos() → for each repo not in Store: INSERT row with
-    last_checked_at = NOW() - rand(0, freshness*2)
-
-StaleSweeper (existing):
-    StaleRepos(freshness, …) returns repos whose last_checked_at is older than freshness.
-    The jittered initial last_checked_at staggers the cold-start enqueue across multiple
-    sweep ticks.
-```
-
-The randomised initial `last_checked_at` means cold start enqueues a fraction of
-the fleet per tick, naturally pacing against rate-limit budgets. Example with
-freshness=24h, 3000 repos, sweep_interval=1h:
-
-| Sweep tick | Repos with last_checked_at > 24h old | Enqueued (approx.) |
+| Concern | Timescale | Mechanism |
 |---|---|---|
-| 1 | ~125 (those in [24h, 26h] jitter band) | 125 |
-| 2 | next 125 | 125 |
-| … | … | … |
-| 24 | last 125 | 125 |
-| 25 | repos reconciled in tick 1 are now stale → cycle repeats | 125 |
+| Avoid enqueueing more work per tick than the installation's current rate-limit budget can absorb | Within a single sweep tick | **Budget-aware enqueueing** (Layer 1) — reads `RateLimitRemaining`, deducts an estimated cost per repo, gates further enqueues when budget would dip below a configured reserve |
+| Avoid having every repo go stale on the same tick (post-cold-start synchronisation) | Across multiple sweep ticks | **Jittered initial `last_checked_at`** (Layer 2) — spreads first-observation timestamps so stale candidates trickle in over time instead of arriving in lockstep |
 
-Steady-state is reached in 24 sweep ticks (24 hours at 1h cadence). Worst-case
-API consumption is ~125 repos × 10 calls = 1250 API calls per tick, well within
-even a single installation's 5000/hr budget.
+Layer 1 is the primary throughput control. Layer 2 is the smoothing-over-time
+mechanism that avoids synchronisation effects. Both are cheap; both are easy to
+observe via Prometheus metrics; they layer cleanly.
+
+### Layer 1 — Budget-aware enqueueing (primary)
+
+Each installation has a `BudgetTracker`:
+
+```go
+type BudgetTracker struct {
+    installationID int64
+    limit          int           // hourly cap (5000 non-enterprise; 12500 GHEC)
+    remaining      int           // live counter, decremented after each Enqueue
+    resetAt        time.Time     // GitHub-reported reset time
+    reserve        float64       // fraction to NOT touch (default 0.20)
+    costPerRepo    int           // estimated API calls per reconcile (default 10)
+}
+
+func (bt *BudgetTracker) SpendableForEnqueue() int {
+    if time.Now().After(bt.resetAt) {
+        bt.RefreshFromAPI()  // pulls fresh remaining + reset from GitHub
+    }
+    reserveCount := int(float64(bt.limit) * bt.reserve)
+    spendable := bt.remaining - reserveCount
+    if spendable <= 0 { return 0 }
+    return spendable / bt.costPerRepo
+}
+```
+
+The Scheduler leader (StaleSweeper + Discoverer) consults the tracker before
+every Enqueue decision:
+
+```go
+// In StaleSweeper.SweepStale
+candidates, _ := s.store.StaleRepos(ctx, freshness, policyVersion, batchSize)
+budgets := map[int64]int{}                                  // available slots per installation
+for _, c := range candidates {
+    if budgets[c.InstallationID] == 0 {
+        budgets[c.InstallationID] = s.trackers[c.InstallationID].SpendableForEnqueue()
+    }
+    if budgets[c.InstallationID] <= 0 {
+        metrics.EnqueueGatedByBudget.WithLabelValues(strconv.FormatInt(c.InstallationID, 10)).Inc()
+        continue
+    }
+    s.queue.Enqueue(ctx, jobFromRepo(c))
+    budgets[c.InstallationID]--
+    s.trackers[c.InstallationID].remaining -= s.trackers[c.InstallationID].costPerRepo
+}
+```
+
+**Key properties:**
+
+- **Aggressive within bounds.** The leader spends all available budget down to
+  the reserve floor every tick. No artificial "go slow at the start" behaviour
+  beyond what the budget itself enforces.
+- **Reactive to actual state.** The tracker refreshes from
+  `Client.RateLimitRemaining` on tick start (or when `resetAt` elapses), so
+  webhook-triggered consumption that happened between ticks is observed.
+- **Costed in advance.** `costPerRepo` is an estimate; actual consumption is
+  observed on the next refresh. Estimation error self-corrects within one tick.
+- **Single integer per installation.** Trivial to surface as a metric and to
+  reason about.
+
+**Default reserve fraction: 0.20.** Holds back 20% of the installation's hourly
+budget for webhook-triggered work and unforeseen consumption. Tunable via:
+
+| Knob | Default | Meaning |
+|---|---|---|
+| `discovery.reserveFraction` | `0.20` | Fraction of `limit` kept untouched |
+| `discovery.estimatedCostPerRepo` | `10` | API calls assumed per reconcile (override after observing real consumption via metrics) |
+
+**Worked example — 25 GHEC orgs × 3000 repos at cold start:**
+
+| Stage | Per-install budget | Discovery enqueues per tick | Wall-clock to drain |
+|---|---|---|---|
+| Tick 1 | 12500 remaining, reserve 2500 → 10000 spendable / 10 = 1000 repos | min(1000, repos_for_install) | — |
+| Across 25 installs uniformly | 1000 per install × 25 = 25000 total | — | — |
+| 3000 stale candidates / 25 = 120 per install | All 3000 enqueued in tick 1 (budget allows) | — | 1 tick (≤1 hour) |
+
+At the GHEC budget level, the rate limit isn't actually the binding constraint
+for a steady-state 3000-repo fleet — the deployment can absorb the cold-start
+spike comfortably. The budget mechanism is most valuable for non-enterprise
+installations (5000/hr cap, where 3000 repos × 10 calls = 30000 calls would
+exceed the budget by 6x without pacing).
+
+### Layer 2 — Jittered initial `last_checked_at` (secondary)
+
+Even with budget gating in place, two failure modes remain:
+
+1. **Synchronisation collapse.** Without jitter, all 3000 repos have
+   `last_checked_at = NOW()` at discovery time. 24 hours later, all 3000
+   become stale on the same tick. Layer 1 gates enqueueing to fit within
+   budget — but every subsequent tick the SAME 3000 repos are stale until the
+   leader works through them. The cycle then repeats in lockstep.
+2. **Worker-pool burst peaks.** When budget is generous (GHEC), Layer 1
+   allows 1000-repo enqueues per tick. The worker pool then peaks at the same
+   moment every tick across installations. Spread out by jitter, the peaks
+   smear and the worker pool stays uniformly busy.
+
+The jitter writes a randomised initial `last_checked_at`:
+
+```go
+initialLastChecked := time.Now().Add(-time.Duration(rand.Int63n(int64(2*s.freshness))))
+```
+
+This places the timestamp uniformly in `[now - 2*freshness, now]`. Over time,
+repos cycle through stale and freshly-reconciled states at staggered cadences.
+The result is smooth steady-state load instead of tick-synchronised bursts.
+
+**Worked example with both layers — 25 orgs × 3000 repos, GHEC, freshness 24h,
+sweep_interval 1h:**
+
+| Sweep tick | Repos qualifying as stale | Budget allows | Enqueued |
+|---|---|---|---|
+| 1 (cold start) | ~750 (those with jitter in [24h, 48h] band) | 25000 | 750 |
+| 2 | ~125 (next jitter band slice + tick-1 repos still in flight) | 24900 | 125 |
+| 3 | ~125 | 24900 | 125 |
+| … | … | … | … |
+| 48 | ~125 | 24900 | 125 |
+| 49 | tick-1 repos rolling back into stale | 24900 | ~125 |
+| Steady state | uniform ~125/tick | budget always plentiful | always ≤ budget |
+
+Without Layer 2 (no jitter): tick 1 sees 3000 stale; Layer 1 budget enqueues
+1000 (still over the 750 jittered case but under the 3000 unbounded case);
+ticks 2-3 also see 3000 stale (the worker pool hasn't drained them yet);
+eventual steady state oscillates around 3000-stale-per-day spikes.
+
+Jitter alone (Layer 2 without Layer 1) doesn't help with non-enterprise rate
+limits where even 750 repos × 10 calls = 7500 calls exceeds the 5000/hr budget.
+
+Together, the two layers form a leaky bucket: jitter limits the **inflow rate**
+to the stale set; budget limits the **drain rate** from stale to queue.
+
+### Cross-replica coordination
+
+StaleSweeper and Discoverer are scheduled via `scheduler.Scheduler.Schedule(...)`.
+With the Valkey-backed scheduler (`scheduler.backend=valkey`), SETNX leader
+election ensures only one replica runs the scheduled handler per tick. This
+means budget tracking is naturally single-leader — no cross-replica
+coordination needed for the enqueue decision.
+
+Workers across all replicas drain the queue and make API calls; each call
+implicitly decrements the GitHub-side rate-limit counter. The Scheduler
+leader's `BudgetTracker.RefreshFromAPI` on the next tick observes the actual
+consumption (the GitHub API returns the live `X-RateLimit-Remaining` header).
+
+Multi-replica scenario where the leader changes mid-tick (rare — the SETNX
+lease lasts longer than a tick): the new leader rebuilds its `BudgetTracker`
+state from a fresh API call on its first tick. The brief gap between leader
+loss and re-acquisition means one tick may be missed, not over-spent. Safe by
+default.
 
 ### Discovery-only Sweeper mode
 
@@ -280,11 +404,16 @@ discovery.
 
 ### `internal/config/`
 
-Two new env vars:
+New env vars:
 
 - `DISCOVERY_INTERVAL` — Go duration string, default `1h`.
 - `DISCOVERY_ENABLED` — bool, default `true` when `STORE_BACKEND=postgres`,
   `false` otherwise.
+- `DISCOVERY_RESERVE_FRACTION` — float, default `0.20`. Fraction of each
+  installation's hourly rate-limit budget kept untouched by Layer 1 budget
+  gating.
+- `DISCOVERY_ESTIMATED_COST_PER_REPO` — int, default `10`. Estimated API calls
+  per reconcile, used by `BudgetTracker.SpendableForEnqueue`.
 
 ### `internal/store/`
 
@@ -299,6 +428,8 @@ to write Store rows when the Postgres backend is active. Same idempotent
 
 ### `internal/metrics/`
 
+Discovery loop:
+
 - `repo_guardian_repo_discovered_total{installation_id}` — counts newly
   discovered repos.
 - `repo_guardian_discovery_duration_seconds` — histogram of Discover loop
@@ -307,6 +438,27 @@ to write Store rows when the Postgres backend is active. Same idempotent
   counts the ListInstallations / ListInstallationRepos / Get API calls each
   Discover tick makes.
 
+Budget tracker (Layer 1):
+
+- `repo_guardian_api_budget_remaining{installation_id}` — Gauge mirroring the
+  latest `RateLimitRemaining` value the leader observed.
+- `repo_guardian_api_budget_spendable{installation_id}` — Gauge of
+  `(remaining - reserve) / costPerRepo` — i.e., how many repos the leader can
+  enqueue right now.
+- `repo_guardian_api_budget_reserve_fraction{installation_id}` — Gauge of the
+  configured reserve fraction (constant per installation under normal config;
+  exposed for dashboarding).
+- `repo_guardian_enqueue_gated_by_budget_total{installation_id}` — Counter
+  incremented each time a stale candidate is skipped because the budget
+  tracker returned 0 spendable slots. Operator alarm signal — sustained
+  non-zero means the deployment is rate-limit-bound.
+- `repo_guardian_api_budget_refresh_total{installation_id, outcome}` — Counter
+  with `outcome="ok"` for successful refreshes and `outcome="error"` for
+  failed refreshes (network, auth, etc.).
+- `repo_guardian_api_budget_utilisation{installation_id}` — Gauge of
+  `1 - (remaining / limit)`. Useful for dashboards showing how aggressively the
+  deployment is using the available budget.
+
 ### Chart values
 
 ```yaml
@@ -314,6 +466,9 @@ discovery:
   # NEW. Only effective when store.backend=postgres.
   enabled: true
   interval: "1h"
+  # Layer 1 — budget-aware enqueueing
+  reserveFraction: 0.20            # 20% of per-install limit kept untouched
+  estimatedCostPerRepo: 10         # tune from `api_budget_utilisation` metrics
 ```
 
 The values are no-ops when `store.backend=memory` (existing legacy Sweeper path
@@ -470,6 +625,60 @@ process (e.g., a CronJob) or remain in-pod as a goroutine?
   the multi-replica case.
 - (b) Separate CronJob. Better isolation but adds a deployment surface and
   needs its own creds + image + chart resources.
+- other:
+
+**(g)** Layer 1 reserve-fraction default.
+
+- **(a) = `0.20` (recommended).** Holds back 20% of each installation's hourly
+  budget for webhook-triggered work and unforeseen consumption. Comfortable
+  margin for typical fleets.
+- (b) `0.10`. More aggressive use of available budget; smaller margin for
+  webhook bursts.
+- (c) `0.30`. More conservative; leaves more budget for webhook surges at the
+  cost of slower steady-state catch-up after long downtime.
+- (d) Dynamic — derive from observed webhook QPS per installation. Adds state
+  but adapts to actual operator usage patterns. Future enhancement.
+- other:
+
+**(h)** Layer 1 estimated cost per repo.
+
+- **(a) = `10` API calls per repo (recommended).** Matches the empirical
+  per-reconcile cost in `docs/operations/scaling.md` (4 file checks + branch
+  / PR ops if actionable + rate-limit probe). Configurable via
+  `DISCOVERY_ESTIMATED_COST_PER_REPO` so operators can re-calibrate from
+  observed `api_budget_utilisation` metrics.
+- (b) Auto-tune from observed consumption. Track actual cost per reconcile in
+  Postgres; periodically refresh `costPerRepo` from the rolling average.
+  Cleaner adaptive behaviour but adds Store schema and statistics complexity.
+- (c) Hard-code with no operator knob. Simpler but worse for operators whose
+  reconcilers do more work (e.g., aggressive label sync against thousands of
+  labels).
+- other:
+
+**(i)** Layer 1 refresh cadence — when does the BudgetTracker call
+`Client.RateLimitRemaining`?
+
+- **(a) = Per sweep tick at minimum, plus on `resetAt` elapsed (recommended).**
+  The leader refreshes its trackers once per tick before enqueueing.
+  Cheap (one API call per installation per tick) and gives accurate budget
+  visibility. The `resetAt` elapse triggers a refresh outside the tick
+  cadence to pick up the hourly budget refill cleanly.
+- (b) Refresh only on `resetAt` elapsed. Cheaper but stale between refreshes;
+  webhook consumption isn't observed until the hour rolls.
+- (c) Refresh after every Enqueue. Most accurate but pathological — N calls
+  per tick. Rejected.
+- other:
+
+**(j)** Layer 1 vs Layer 2 — should the chart allow disabling jitter (Layer 2)
+once Layer 1 is in place?
+
+- **(a) = Keep both always on (recommended).** They address different failure
+  modes (within-tick burst vs cross-tick synchronisation); the cost of
+  jitter is negligible (one `rand.Int63n` per discovered repo). Removing
+  one creates a sharp edge in deployment behaviour without operational
+  upside.
+- (b) Make Layer 2 opt-out via `discovery.jitterEnabled: false`. Lets
+  operators experiment in test environments.
 - other:
 
 ## References

--- a/docs/design/0017-stale-sweep-cutover-and-repository-discovery.md
+++ b/docs/design/0017-stale-sweep-cutover-and-repository-discovery.md
@@ -20,6 +20,7 @@ created: 2026-06-22
   - [Non-Goals](#non-goals)
 - [Background](#background)
 - [Detailed Design](#detailed-design)
+  - [Per-reconcile Store update — the missing half](#per-reconcile-store-update--the-missing-half)
   - [Pacing — two layered mechanisms](#pacing--two-layered-mechanisms)
   - [Layer 1 — Budget-aware enqueueing (primary)](#layer-1--budget-aware-enqueueing-primary)
   - [Layer 2 — Jittered initial last_checked_at (secondary)](#layer-2--jittered-initial-last_checked_at-secondary)
@@ -55,6 +56,11 @@ deployment encounters an existing fleet of repos.
 
 ### Goals
 
+- **Fix the freshness gate.** Today's workers don't write `last_checked_at` back
+  to Store after reconciling, so StaleSweeper re-enqueues every aged repo on
+  every tick forever (steady-state thrash). Wire `Store.UpdateRepoState` into
+  the worker post-`engine.CheckRepo` path. This is the gating fix for the
+  whole design.
 - Eliminate redundant enqueueing on the Postgres backend. After cutover, each
   sweep tick enqueues only stale repos, not every repo.
 - Cold-start a deployment against an existing 3000-repo fleet without burning the
@@ -62,8 +68,8 @@ deployment encounters an existing fleet of repos.
 - Keep discovery of new repos working without depending exclusively on webhooks
   (operators may have webhook delivery gaps, mis-configured installations, or
   brand-new installations with no historical webhooks).
-- Preserve existing memory-backend behaviour: memory mode has no Store and
-  continues to use the legacy Sweeper unchanged.
+- Preserve existing memory-backend behaviour: memory mode gets a no-op Store
+  implementation; the legacy Sweeper continues to enqueue per tick.
 - Bounded blast radius from misconfigured discovery: if discovery breaks, in-flight
   reconciliation continues; only new-repo onboarding is affected.
 
@@ -129,6 +135,89 @@ bootstraps.
   the (small) stale subset. Worker pool processes 2x the work it needs to.
 
 ## Detailed Design
+
+### Per-reconcile Store update — the missing half
+
+The IMPL-0011 architecture treats `repo_state.last_checked_at` as the source of
+truth for "when was this repo last reconciled." StaleSweeper queries against
+that column. But **the workers don't currently update it**:
+
+- `internal/worker/worker.go` doesn't import `internal/store/`.
+- `engine.CheckRepo` doesn't accept a `Store` parameter.
+- `Store.UpdateRepoState` is defined but is called by zero non-test code paths.
+
+Consequences:
+
+- **Webhook-triggered reconciles don't refresh the timestamp.** A push event
+  arrives, the worker reconciles the repo, completes successfully — and the
+  Store still says the repo was last checked at whatever `last_checked_at`
+  Discoverer wrote on first observation. The next StaleSweeper tick treats the
+  repo as still stale and enqueues it again.
+- **Steady-state thrashing.** Once a repo's jittered `last_checked_at` ages
+  past `freshness`, it stays stale forever — every sweep tick re-enqueues it
+  because no completion path moves the timestamp forward. The freshness gate
+  is effectively a no-op after one cycle.
+- **Policy-version invalidation doesn't roll forward.** When the operator
+  changes the policy and `policy.Version()` returns a new hash, StaleSweeper
+  is supposed to re-enqueue every repo (matching the `policy_version != $new`
+  predicate). But after that re-enqueue, the Store row's `policy_version`
+  field never updates because workers don't write to the Store. The "every
+  tick" thrash persists across all 3000 repos until manual intervention.
+
+This is a correctness bug, not an optimisation. The DESIGN-0017 cutover
+**cannot be completed** until the worker writes back. Closing this gap is
+the highest-priority piece of this design.
+
+**Worker write-back contract:**
+
+After every successful `engine.CheckRepo`, the worker calls
+`Store.UpdateRepoState`:
+
+```go
+// In internal/worker/worker.go processJob, after engine.CheckRepo returns nil
+err := p.store.UpdateRepoState(ctx, &store.RepoState{
+    InstallationID: j.InstallationID,
+    Owner:          j.Owner,
+    Repo:           j.Repo,
+    LastCheckedAt:  ptr(time.Now()),
+    PolicyVersion:  p.policyVersion,
+})
+if err != nil {
+    log.Warn("UpdateRepoState failed; StaleSweeper will re-enqueue",
+        "owner", j.Owner, "repo", j.Repo, "error", err)
+    metrics.StoreWriteBackErrorsTotal.WithLabelValues(j.Owner).Inc()
+    // Do NOT return the error — the reconcile succeeded; the Store write
+    // is best-effort. Worst case: this repo gets re-checked next sweep.
+}
+```
+
+**Behaviour on reconcile failure:**
+
+If `engine.CheckRepo` returns an error, the worker does NOT call
+`UpdateRepoState`. Leaving the old timestamp means StaleSweeper will pick the
+repo up again at the next eligible window — which is the correct retry
+semantic. Updating `last_checked_at` on failure would suppress retries.
+
+**Trigger field:**
+
+The job's `Trigger` field (`scheduler`, `webhook`, `push`) is preserved on
+the Store row as a metric label only, not as state. The Store doesn't
+distinguish "which trigger most recently reconciled this repo" because the
+freshness gate doesn't care — a successful reconcile is a successful
+reconcile.
+
+**Why this resolves the user-visible bug:**
+
+After this design lands:
+
+- Webhook push → worker reconciles → Store updated → next StaleSweeper
+  correctly skips the repo for the next `freshness` window.
+- Sweep tick reconciles → Store updated → next sweep tick skips the repo
+  similarly.
+- Failed reconcile → Store NOT updated → next sweep retries → bounded retry
+  loop driven by `freshness` and rate-limit reserve, with no thrashing.
+- Policy version change → all repos re-enqueue → workers reconcile and write
+  the new version → freshness gate works normally for the next cycle.
 
 ### Pacing — two layered mechanisms
 
@@ -417,8 +506,47 @@ New env vars:
 
 ### `internal/store/`
 
-`Store` interface unchanged. The discovery path uses existing `Get` and `Upsert`
-methods.
+`Store` interface unchanged. The discovery path and the per-reconcile
+write-back path both use existing `GetRepoState` / `UpdateRepoState` methods.
+
+### `internal/worker/`
+
+The Pool gains a `Store` dependency:
+
+```go
+type Pool struct {
+    queue          queue.Queue
+    engine         *checker.Engine
+    ghClient       ghclient.Client
+    store          store.Store          // NEW
+    policyVersion  string               // NEW — populated from policy.Version() at startup
+    logger         *slog.Logger
+    workers        int
+    // ...
+}
+
+func New(q queue.Queue, engine *checker.Engine, ghClient ghclient.Client,
+         st store.Store, policyVersion string,
+         workers int, logger *slog.Logger) *Pool {
+    return &Pool{
+        queue:         q,
+        engine:        engine,
+        ghClient:      ghClient,
+        store:         st,
+        policyVersion: policyVersion,
+        workers:       workers,
+        logger:        logger,
+    }
+}
+```
+
+`processJob` writes `last_checked_at` back to Store on successful reconcile;
+skips the write on reconcile error (preserves retry semantic — see
+[Per-reconcile Store update](#per-reconcile-store-update--the-missing-half)).
+
+For memory-backend deployments (where there is no Store), the constructor
+accepts a no-op Store implementation that returns immediately from
+`UpdateRepoState`. No special-casing in `processJob`.
 
 ### `internal/webhook/`
 
@@ -427,6 +555,15 @@ to write Store rows when the Postgres backend is active. Same idempotent
 `Get`+conditional `Upsert` pattern.
 
 ### `internal/metrics/`
+
+Worker write-back (Per-reconcile Store update):
+
+- `repo_guardian_store_writeback_total{installation_id, outcome="ok"|"error"}`
+  — counts UpdateRepoState calls from the worker after each reconcile.
+  `outcome="error"` means the reconcile succeeded but the Store write
+  failed; alarm signal if sustained.
+- `repo_guardian_store_writeback_duration_seconds` — histogram of the
+  UpdateRepoState call latency.
 
 Discovery loop:
 
@@ -525,11 +662,31 @@ No schema changes. The `repo_state` table is extended in usage:
 
 ## Migration / Rollout Plan
 
+### Phase 0 — Worker write-back (prerequisite)
+
+Land the per-reconcile Store update first. This is the gating step — none of
+the subsequent phases work correctly without it because the freshness gate
+in StaleSweeper depends on workers writing back.
+
+- Wire `Store` into `internal/worker/Pool`; thread `policyVersion` through
+  from `cmd/repo-guardian/main.go`.
+- `processJob` calls `UpdateRepoState` after every successful `engine.CheckRepo`.
+- Failed reconciles do NOT write — preserves retry semantics.
+- Memory-backend deployments get a no-op Store implementation; no behavioural
+  change.
+- Land with budget/jitter Layers 1+2 simultaneously to avoid a window where
+  the freshness gate is half-fixed. They're additive in scope but
+  inseparable in effect.
+- Validate via the new `store_writeback_total{outcome="ok"}` counter — should
+  rise in lockstep with `repos_checked_total`.
+
 ### Phase 1 — Land Discoverer alongside legacy Sweeper
+
+After Phase 0 is stable in production:
 
 - Implement `Discoverer.Discover` and new env vars; ship at default
   `DISCOVERY_ENABLED=false` for both backends.
-- Existing deployments unaffected.
+- Existing deployments unaffected; legacy Sweeper continues to bootstrap.
 
 ### Phase 2 — Opt-in cutover
 
@@ -679,6 +836,38 @@ once Layer 1 is in place?
   upside.
 - (b) Make Layer 2 opt-out via `discovery.jitterEnabled: false`. Lets
   operators experiment in test environments.
+- other:
+
+**(k)** Worker write-back failure semantics — what should happen when
+`engine.CheckRepo` succeeds but `Store.UpdateRepoState` fails?
+
+- **(a) = Log + count + continue (recommended).** The reconcile succeeded
+  externally (PR created, file written, comment posted). The Store write is
+  best-effort. If it fails, next StaleSweeper tick re-enqueues; the
+  reconcile is idempotent so the duplicate work is wasted but not
+  incorrect. Alarm via `store_writeback_total{outcome="error"}` rate.
+- (b) Return the write-back error from `processJob`. The queue marks the job
+  failed; reaper requeues it after `JOB_ACK_TIMEOUT`. Cleaner retry but
+  causes a duplicate reconcile (the external work already happened on the
+  first attempt).
+- (c) Retry the write inline with backoff. Complicates the worker hot path
+  for an unlikely failure mode.
+- other:
+
+**(l)** Write-back on partial reconcile success — `engine.CheckRepo` is a
+single returned-error operation today, but internally it composes multiple
+sub-steps (file checks, PR creation, reconciler runs). Should partial
+internal failures (e.g., custom_properties reconciler errored) still trigger
+write-back?
+
+- **(a) = Yes — write-back if `engine.CheckRepo` returns nil; the engine
+  decides what counts as success (recommended).** Keeps the worker simple
+  and treats the engine as a black box. The engine's existing error
+  semantics already handle partial failures (returning nil for "good
+  enough" success or err for "retry").
+- (b) Add a granular write-back interface where the engine returns a
+  per-step status. Worker writes individual step timestamps. Adds complex
+  state to Store rows. Premature.
 - other:
 
 ## References

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -46,4 +46,7 @@ docz create design "Your Design Title"
 | DESIGN-0012 | Persistent reconcile state and multi-replica coordination | Implemented | 2026-05-02 | Donald Gifford | [0012-persistent-reconcile-state-and-multi-replica-coordination.md](0012-persistent-reconcile-state-and-multi-replica-coordination.md) |
 | DESIGN-0013 | Customizable PR templates and extensible template ConfigMap | Implemented | 2026-05-03 | Donald Gifford | [0013-customizable-pr-templates-and-extensible-template-configmap.md](0013-customizable-pr-templates-and-extensible-template-configmap.md) |
 | DESIGN-0014 | Remove legacy engine path and deprecated overlays | Implemented | 2026-05-28 | Donald Gifford | [0014-remove-legacy-engine-path-and-deprecated-overlays.md](0014-remove-legacy-engine-path-and-deprecated-overlays.md) |
+| DESIGN-0015 | Per-installation Valkey queue partitioning | Draft | 2026-06-22 | Donald Gifford | [0015-per-installation-valkey-queue-partitioning.md](0015-per-installation-valkey-queue-partitioning.md) |
+| DESIGN-0016 | Separate Postgres read and write endpoints | Draft | 2026-06-22 | Donald Gifford | [0016-separate-postgres-read-and-write-endpoints.md](0016-separate-postgres-read-and-write-endpoints.md) |
+| DESIGN-0017 | Stale-sweep cutover and repository discovery | Draft | 2026-06-22 | Donald Gifford | [0017-stale-sweep-cutover-and-repository-discovery.md](0017-stale-sweep-cutover-and-repository-discovery.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/operations/aws.md
+++ b/docs/operations/aws.md
@@ -204,15 +204,31 @@ the only change is the AWS Secrets Manager key (typically
 `elasticache/repo-guardian/auth`) and the template assembling the
 `rediss://` URL.
 
-## Sharding and noisy orgs
+## Partitioning, sharding, and the noisy-org problem
 
 This is the question most operators bring up after running
 repo-guardian against a real fleet: one large GitHub org has
 hundreds of actionable repos every sweep, and its work backs up
 the queue so the smaller orgs wait. The instinct is to reach for
-Valkey cluster mode (sharding).
+Valkey cluster mode (sharding). That instinct is wrong — the
+right tool is application-level **partitioning**, not Valkey
+sharding.
 
-That instinct is wrong for repo-guardian as it ships today.
+The two terms get conflated. They're different things at different
+layers:
+
+| Term | Definition | Layer | Helps the noisy-org problem? |
+|---|---|---|---|
+| **Sharding** | Valkey cluster mode splits the *key space* across N shards by hash slot | Valkey server | No — single-key queue → single shard |
+| **Partitioning** | Single logical queue split into *multiple keys* by a business dimension (installation, priority) | Application code | Yes — that's the whole point |
+
+Sharding moves the work for different *keys* onto different
+servers. Partitioning creates *multiple keys* in the first place.
+You need partitioning to have anything to shard, but partitioning
+alone (on a single Valkey node) already solves the fairness
+problem. Sharding is a separate axis that buys you per-key
+throughput parallelism once you have enough keys to make it
+worthwhile.
 
 ### Why Valkey sharding does NOT help
 
@@ -243,7 +259,85 @@ There's also a code-level gap: `cmd/repo-guardian/main.go` builds a
 detect cluster topology and pick the right client type. Not done
 today.
 
-### What actually helps with the noisy-org problem today
+### Partitioning (the actual answer, code change required)
+
+Strict per-installation fairness needs the queue split into multiple
+keys — one per installation — so workers can schedule across them
+intentionally rather than draining a single FIFO. This is the real
+fix; it's also the one that requires code changes.
+
+**Proposed key layout:**
+
+```
+repo-guardian:queue:install-{id}:jobs        LIST  (work for installation {id})
+repo-guardian:queue:install-{id}:inflight    ZSET  (jobID → dispatch_ts)
+repo-guardian:queue:installations            SET   (registry of known installation IDs)
+```
+
+`Enqueue` picks the key from `job.InstallationID`:
+
+```
+LPUSH repo-guardian:queue:install-{job.InstallationID}:jobs <job-json>
+SADD  repo-guardian:queue:installations {job.InstallationID}    -- idempotent registry
+```
+
+**Worker scheduling strategies** — three workable shapes, listed
+in increasing complexity:
+
+| Strategy | How it works | Pros | Cons |
+|---|---|---|---|
+| **A. `BLPOP` across all keys** | Worker reads `SMEMBERS installations`, calls `BLPOP key1 key2 … keyN timeout` — Valkey returns from whichever has work | Trivial code; natural fairness for ready work; no extra state | No per-installation concurrency cap (a noisy org can still grab every worker); `BLPOP` key-list scales but degrades at thousands |
+| **B. Round-robin with per-installation concurrency cap** | Maintain `repo-guardian:queue:install-{id}:in_flight_count`; worker iterates installations in round-robin order, skips any at cap | Strict fairness; bounds noisy org's parallelism; predictable | More state; needs an atomic check-and-incr Lua script |
+| **C. Weighted random by depth + rate-limit headroom** | Worker picks an installation at random, weighted by `(queue_depth × rate_limit_remaining)` | Adapts dynamically to rate limits; statistically fair | Most state; needs depth + headroom snapshots; harder to reason about |
+
+Recommended starting point: **A with a soft cap** — `BLPOP`-many
+plus a configurable per-installation concurrency limit (e.g.,
+`min(workerCount, ceil(workerCount/N))`). Combines simplicity
+with bounded blast radius.
+
+**Implementation surface:**
+
+| File | Change |
+|---|---|
+| `internal/queue/Queue` (interface) | `Enqueue` unchanged externally; internally selects key by `job.InstallationID`. `Subscribe` accepts an installation-registry watch so workers discover new installations as they appear. |
+| `internal/queue/valkey/valkey.go` | LUA scripts updated to operate on per-installation keys. `Reaper` iterates `SMEMBERS installations` to scan every in-flight ZSET. |
+| `internal/queue/memory/` | Per-installation buffered channels with round-robin `select`. |
+| `internal/worker/pool.go` | Schedule strategy plug — A initially, with hooks for B/C later. |
+| `internal/metrics/metrics.go` | `queue_depth` becomes `queue_depth{installation_id}` GaugeVec. `queue_dispatched_total` gains the same label. |
+| `charts/repo-guardian/values.yaml` | New knobs: `queue.partitioning.enabled` (default false during rollout), `queue.partitioning.perInstallationCap`. |
+
+Effort estimate: ~1 sprint week for one engineer (refactor +
+tests + metrics + integration test against ElastiCache). The
+queue interface stays binary-compatible — opt-in via the new
+chart value.
+
+**What partitioning gives you:**
+
+- Strict per-installation work scheduling (no noisy-org starvation)
+- Per-installation queue-depth metrics — you can see at a glance
+  which installations are backed up
+- Bounded blast radius when one installation's token goes stale —
+  others keep draining
+- A foundation for installation-aware HPA (`queue_depth{installation_id}`
+  → custom-metric autoscaling) later
+
+**When to invest:** the `staleSweep` + `workerCount` mitigations
+below give *eventual fairness* — every org's work clears within a
+sweep cycle, just not in strict round-robin. That's sufficient for
+most fleets. Reach for partitioning when:
+
+- One installation routinely has > 5x the queue depth of any other
+- Smaller orgs' webhook-triggered reconciles regularly wait > 5
+  minutes behind a sweep burst
+- You need per-org SLA reporting
+
+Until one of those triggers fires: tune the values below, not the
+topology. File an INV requesting per-installation queue
+partitioning when you cross the threshold.
+
+### What helps today (without code changes)
+
+The mitigations referenced above:
 
 | Lever | Where | Effect |
 |---|---|---|
@@ -252,25 +346,9 @@ today.
 | `config.workerCount` higher | values.yaml | Drains bursts faster. 30 workers × 3 replicas = 90 concurrent processors. Even a 500-job burst clears in <30 sec at 3 sec/repo. |
 | Vertical-scale Valkey | ElastiCache instance class | A larger single shard sustains more ops/sec. Almost certainly not the bottleneck, but cheap to bump if it is. |
 
-The combination above gives **eventual fairness** — every org's
-work gets done within a sweep cycle, just not strict round-robin.
-For most operators that's sufficient.
-
-### What a real fix looks like (roadmap, not config)
-
-Strict per-org fairness requires partitioning the queue by
-installation/org so workers grab from multiple queues in
-round-robin. That's a code change to `internal/queue/`:
-
-- Multiple keys (`repo-guardian:queue:install-12345:jobs`,
-  `:install-67890:jobs`, …)
-- Worker pool with round-robin / work-stealing across keys
-- Reaper updated to scan all in-flight ZSETs
-
-This is INV/IMPL territory. If you hit the noisy-org problem hard
-enough that the eventual-fairness mitigations aren't sufficient,
-file an INV requesting per-org queue partitioning and we'll scope
-it. Until then: tune the values, not the topology.
+The combination gives **eventual fairness** — every org's work
+gets done within a sweep cycle, just not strict round-robin. For
+most operators that's sufficient.
 
 ## End-to-end example
 

--- a/docs/operations/aws.md
+++ b/docs/operations/aws.md
@@ -127,7 +127,8 @@ direct admin connections.
 - **No reader/writer split.** `StaleRepos` is read-heavy and could
   go to an Aurora reader endpoint, but the chart has one DSN slot.
   Today everything goes through the writer (or Proxy fronting the
-  writer). Bigger code change tracked separately — not blocking.
+  writer). Design lives at
+  [DESIGN-0016: Separate Postgres read and write endpoints](../design/0016-separate-postgres-read-and-write-endpoints.md).
 - **Secrets Manager rotation gap.** If AWS rotates the DB password
   via Secrets Manager → ESO re-syncs the k8s Secret → but the
   binary's open pgxpool connections still use the OLD password
@@ -332,8 +333,9 @@ most fleets. Reach for partitioning when:
 - You need per-org SLA reporting
 
 Until one of those triggers fires: tune the values below, not the
-topology. File an INV requesting per-installation queue
-partitioning when you cross the threshold.
+topology. The full design lives at
+[DESIGN-0015: Per-installation Valkey queue partitioning](../design/0015-per-installation-valkey-queue-partitioning.md)
+— promote it to IMPL when you cross the threshold.
 
 ### What helps today (without code changes)
 

--- a/docs/operations/aws.md
+++ b/docs/operations/aws.md
@@ -1,0 +1,335 @@
+# Running repo-guardian on AWS
+
+The chart defaults install Postgres via CloudNativePG (CNPG) and Valkey
+as a baked StatefulSet. On AWS those primitives have native managed
+equivalents — RDS / Aurora Postgres and ElastiCache for Valkey. This
+guide covers wiring the chart at those services, plus the
+"one-noisy-org" workload-isolation question that comes up at
+enterprise scale.
+
+The chart already supports external Postgres and external Valkey via
+`store.postgres.mode=external` and `queue.valkey.mode=external`. Both
+modes read connection strings from operator-supplied k8s Secrets;
+nothing in the binary is AWS-aware. The work is in provisioning the
+managed services and plumbing their credentials into k8s.
+
+For prior reading: `docs/operations/scaling.md` covers the sizing
+math for multi-org GHEC fleets — this doc covers how to land that
+sizing on AWS infrastructure specifically.
+
+## Postgres on AWS
+
+### Option matrix
+
+| Service | Best for | Notes |
+|---|---|---|
+| **RDS Postgres** (provisioned) | Predictable steady-state workloads | Cheapest per-hour for known load. Manual instance-class sizing. Multi-AZ for HA. |
+| **RDS Postgres Serverless v2** | Spiky / unpredictable workloads | ACU-based autoscaling. Scale-to-zero possible (0.5 ACU floor without scale-to-zero enabled). Sweet spot for repo-guardian if you want auto-pause during the long quiet windows between weekly sweeps. |
+| **Aurora Postgres** | HA + read scaling | Storage-replicated cluster with separate reader/writer endpoints. Best fault tolerance. Reader endpoint can offload `StaleRepos` queries — but the chart doesn't surface separate reader/writer DSNs today (see Gaps below). |
+
+All three speak vanilla Postgres protocol, so the binary's
+`internal/store/postgres/` works unchanged. The decision is
+operational, not architectural.
+
+### Connection pooling: use RDS Proxy
+
+For any of the three Postgres variants, put **RDS Proxy** in front
+of it. RDS Proxy is AWS's managed PgBouncer-equivalent:
+
+- Transaction-mode pooling reduces backend connection count
+- Holds DB credentials internally and handles rotation transparently
+- Survives instance failovers without dropping client connections
+- ~5ms RTT added — irrelevant at repo-guardian's QPS
+- Required practice for Serverless v2 (scaling events cause
+  connection storms otherwise)
+
+The binary connects to the Proxy endpoint, not the DB instance
+endpoint. The Proxy maintains the actual pool of backend
+connections. This replaces the CNPG `pooler` block from the
+homelab pattern.
+
+### Credentials via External Secrets Operator
+
+The recommended flow:
+
+```
+AWS Secrets Manager (DB credentials)
+   ↓ ESO ExternalSecret
+k8s Secret (`repo-guardian-store-dsn`, key `STORE_DSN`)
+   ↓ chart references via existingSecret
+repo-guardian Pod
+```
+
+Example `ExternalSecret`:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: repo-guardian-store-dsn
+  namespace: repo-guardian
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: repo-guardian-store-dsn
+    template:
+      data:
+        STORE_DSN: "postgres://{{ .username }}:{{ .password }}@{{ .endpoint }}:5432/{{ .dbname }}?sslmode=require"
+  data:
+    - secretKey: username
+      remoteRef:
+        key: rds/repo-guardian/master
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: rds/repo-guardian/master
+        property: password
+    - secretKey: endpoint
+      remoteRef:
+        key: rds/repo-guardian/master
+        property: endpoint
+    - secretKey: dbname
+      remoteRef:
+        key: rds/repo-guardian/master
+        property: dbname
+```
+
+The endpoint in the DSN should be the **RDS Proxy endpoint**, not
+the DB instance/cluster endpoint.
+
+### Chart values for external Postgres
+
+```yaml
+store:
+  backend: postgres
+  postgres:
+    mode: external
+    existingSecret: repo-guardian-store-dsn   # k8s Secret name
+    existingSecretKey: STORE_DSN              # key inside the Secret
+    maxConns: 10                              # per-replica pool cap
+```
+
+With 3 replicas × `maxConns=10` = 30 client connections into RDS
+Proxy. RDS Proxy's `MaxConnectionsPercent` defaults to 100% of the
+DB's `max_connections`; set it to 50-75% to leave headroom for
+direct admin connections.
+
+### Gaps and workarounds
+
+- **No IAM authentication.** The binary expects a static DSN; IAM
+  tokens expire every 15 minutes and the binary has no refresh
+  loop. Workaround: use password auth via Secrets Manager. RDS
+  Proxy can use IAM internally between Proxy and DB even if clients
+  use password auth, so you still get IAM at the DB level.
+- **No reader/writer split.** `StaleRepos` is read-heavy and could
+  go to an Aurora reader endpoint, but the chart has one DSN slot.
+  Today everything goes through the writer (or Proxy fronting the
+  writer). Bigger code change tracked separately — not blocking.
+- **Secrets Manager rotation gap.** If AWS rotates the DB password
+  via Secrets Manager → ESO re-syncs the k8s Secret → but the
+  binary's open pgxpool connections still use the OLD password
+  until they hit a transient failure and reconnect. RDS Proxy
+  eliminates this because the Proxy holds the DB creds; clients
+  talk to the Proxy with their own (static) creds.
+
+## ElastiCache for Valkey
+
+### Pick Valkey, not Redis
+
+AWS announced ElastiCache for Valkey in late 2024. It is the
+forward-compatible managed option:
+
+- API-compatible with Redis 7.2; existing `go-redis` clients work
+  unchanged
+- Roughly 33% cheaper than ElastiCache for Redis at equivalent
+  shape (per AWS's own pricing posts)
+- Avoids the Redis BSL / SSPL relicensing situation that motivated
+  the Linux Foundation Valkey fork
+
+Both queue and scheduler backends use the same client connection
+under the hood (`scheduler.backend=valkey` requires
+`queue.backend=valkey`), so a single ElastiCache cluster serves
+both.
+
+### Cluster mode: pick **disabled**
+
+ElastiCache for Valkey offers two cluster topologies:
+
+| Mode | Topology | Use case |
+|---|---|---|
+| **Cluster mode disabled** | Single shard with primary + N replicas | **Recommended** for repo-guardian |
+| **Cluster mode enabled** | N shards with M replicas each, key-space partitioned by hash slot | NOT useful for repo-guardian today (see "Sharding and noisy orgs" below) |
+
+A single Valkey shard sustains 80-100k ops/sec. repo-guardian's
+queue traffic at 3000 repos × 25 orgs is in the low hundreds of
+ops/sec at peak burst, so one shard is comfortably oversized. Pick:
+
+- 1 primary + 1 replica for HA
+- `cache.t4g.small` or `cache.m7g.large` depending on memory budget
+  (queue + ZSET + reaper lock fit in single-digit MB; the smallest
+  node class is plenty)
+- Enable in-transit encryption (TLS)
+- Enable an AUTH token
+
+### Chart values for external Valkey
+
+```yaml
+queue:
+  backend: valkey
+  valkey:
+    mode: external
+    existingSecret: repo-guardian-queue-dsn
+    existingSecretKey: QUEUE_VALKEY_DSN
+    jobAckTimeout: "5m"
+    reaperInterval: "30s"
+
+scheduler:
+  backend: valkey                          # MANDATORY for multi-replica
+```
+
+The DSN format for ElastiCache:
+
+```
+rediss://default:<auth-token>@<primary-endpoint>:6379/0
+```
+
+`rediss://` (with the extra `s`) is the TLS variant — match it to
+your in-transit-encryption setting.
+
+The same `ExternalSecret` pattern from the Postgres section applies;
+the only change is the AWS Secrets Manager key (typically
+`elasticache/repo-guardian/auth`) and the template assembling the
+`rediss://` URL.
+
+## Sharding and noisy orgs
+
+This is the question most operators bring up after running
+repo-guardian against a real fleet: one large GitHub org has
+hundreds of actionable repos every sweep, and its work backs up
+the queue so the smaller orgs wait. The instinct is to reach for
+Valkey cluster mode (sharding).
+
+That instinct is wrong for repo-guardian as it ships today.
+
+### Why Valkey sharding does NOT help
+
+ElastiCache cluster mode partitions Valkey's key space by hash
+slot, routing each key to one of N shards. The benefit is per-key
+throughput parallelism — different keys land on different shards
+and serve traffic in parallel.
+
+repo-guardian's queue uses **a small number of single keys**:
+
+- `repo-guardian:queue:jobs` — the work LIST
+- `repo-guardian:queue:inflight` — the ZSET of dispatched jobs
+- `repo-guardian:scheduler:leader` — the SETNX-held leader lock
+
+Every queue operation touches the same key (`jobs`). Sharding sends
+all queue traffic to one shard regardless of how many shards exist.
+The other shards sit idle. You pay for them and gain nothing.
+
+(Strictly: hash tags can force multiple keys onto the same shard
+when multi-key Lua scripts need them together. We do use multi-key
+operations — LIST + ZSET coordinated atomically. So even if we
+sharded, we'd need the LIST and ZSET on the same shard, which
+defeats the purpose.)
+
+There's also a code-level gap: `cmd/repo-guardian/main.go` builds a
+`redis.NewClient` (single-node) from the parsed DSN, not a
+`redis.NewClusterClient`. Cluster mode would require the wiring to
+detect cluster topology and pick the right client type. Not done
+today.
+
+### What actually helps with the noisy-org problem today
+
+| Lever | Where | Effect |
+|---|---|---|
+| `staleSweep.rateLimitReserve` | values.yaml | The reserve gate skips repos when an installation drops below the reserve threshold. Already throttles the noisy org's sweep enqueues against the SAME installation's webhook-triggered work. |
+| `staleSweep.batchSize` smaller | values.yaml | Spreads the noisy org's enqueues across more sweep ticks instead of dumping 500 jobs in one tick. The queue depth stays lower; smaller orgs aren't buried. |
+| `config.workerCount` higher | values.yaml | Drains bursts faster. 30 workers × 3 replicas = 90 concurrent processors. Even a 500-job burst clears in <30 sec at 3 sec/repo. |
+| Vertical-scale Valkey | ElastiCache instance class | A larger single shard sustains more ops/sec. Almost certainly not the bottleneck, but cheap to bump if it is. |
+
+The combination above gives **eventual fairness** — every org's
+work gets done within a sweep cycle, just not strict round-robin.
+For most operators that's sufficient.
+
+### What a real fix looks like (roadmap, not config)
+
+Strict per-org fairness requires partitioning the queue by
+installation/org so workers grab from multiple queues in
+round-robin. That's a code change to `internal/queue/`:
+
+- Multiple keys (`repo-guardian:queue:install-12345:jobs`,
+  `:install-67890:jobs`, …)
+- Worker pool with round-robin / work-stealing across keys
+- Reaper updated to scan all in-flight ZSETs
+
+This is INV/IMPL territory. If you hit the noisy-org problem hard
+enough that the eventual-fairness mitigations aren't sufficient,
+file an INV requesting per-org queue partitioning and we'll scope
+it. Until then: tune the values, not the topology.
+
+## End-to-end example
+
+Full chart values for a 3000-repo × 25-org GHEC fleet on AWS:
+
+```yaml
+replicaCount: 3
+
+config:
+  workerCount: 15
+  scheduleInterval: "12h"
+
+staleSweep:
+  freshness: "24h"
+  batchSize: 500
+  rateLimitReserve: 0.15
+
+store:
+  backend: postgres
+  postgres:
+    mode: external
+    existingSecret: repo-guardian-store-dsn
+    existingSecretKey: STORE_DSN
+    maxConns: 10
+
+queue:
+  backend: valkey
+  valkey:
+    mode: external
+    existingSecret: repo-guardian-queue-dsn
+    existingSecretKey: QUEUE_VALKEY_DSN
+    jobAckTimeout: "5m"
+    reaperInterval: "30s"
+
+scheduler:
+  backend: valkey
+```
+
+Companion AWS resources (provisioned via Terraform, CDK, or
+manually):
+
+| Resource | Purpose | Sizing |
+|---|---|---|
+| Aurora Postgres cluster | Store backend | `db.r6g.large` writer + 1 reader; storage auto-scaling enabled |
+| RDS Proxy | Connection pool | Fronts the Aurora writer endpoint; `MaxConnectionsPercent=50` |
+| ElastiCache Valkey | Queue + scheduler | `cache.t4g.small` primary + 1 replica, cluster mode disabled, TLS + AUTH token enabled |
+| Secrets Manager: `rds/repo-guardian/master` | DB credentials | Auto-rotation on a 30-day schedule |
+| Secrets Manager: `elasticache/repo-guardian/auth` | Valkey AUTH token | Manual rotation (ElastiCache doesn't auto-rotate) |
+| ESO ClusterSecretStore: `aws-secrets-manager` | Bridges Secrets Manager → k8s | IRSA-based access; one IAM role for the namespace |
+| EKS namespace `repo-guardian` | Pod placement | Private subnets, NAT egress to github.com |
+| VPC endpoints | Secrets Manager + STS + ECR | Optional but reduces NAT cost at scale |
+
+Security-group rules to remember:
+
+- EKS node SG → RDS Proxy SG on 5432
+- EKS node SG → ElastiCache SG on 6379
+- RDS Proxy SG → Aurora SG on 5432
+
+The IRSA role for the repo-guardian ServiceAccount needs:
+`secretsmanager:GetSecretValue` on the two secrets above. Nothing
+else AWS-side — the binary speaks plain Postgres + plain
+Valkey/Redis protocol once it has the DSNs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,9 @@ nav:
         - 'DESIGN-0012: Persistent reconcile state and multi-replica coordination': design/0012-persistent-reconcile-state-and-multi-replica-coordination.md
         - 'DESIGN-0013: Customizable PR templates and extensible template ConfigMap': design/0013-customizable-pr-templates-and-extensible-template-configmap.md
         - 'DESIGN-0014: Remove legacy engine path and deprecated overlays': design/0014-remove-legacy-engine-path-and-deprecated-overlays.md
+        - 'DESIGN-0015: Per-installation Valkey queue partitioning': design/0015-per-installation-valkey-queue-partitioning.md
+        - 'DESIGN-0016: Separate Postgres read and write endpoints': design/0016-separate-postgres-read-and-write-endpoints.md
+        - 'DESIGN-0017: Stale-sweep cutover and repository discovery': design/0017-stale-sweep-cutover-and-repository-discovery.md
     - Implementation Plans:
         - Overview: impl/README.md
         - 'IMPL-0001: Repo Guardian Implementation Plan': impl/0001-repo-guardian-implementation-plan.md
@@ -43,7 +46,7 @@ nav:
         - 'INV-0004: Forge interface and package refactor for Forgejo backend': investigation/0004-forge-interface-and-package-refactor-for-forgejo-backend.md
         - 'INV-0005: Stale PRs when file rules become satisfied on main': investigation/0005-stale-prs-when-file-rules-become-satisfied-on-main.md
         - 'INV-0006: Per-org GitHub App credentials': investigation/0006-per-org-github-app-credentials.md
-        - 'INV-0007: GitLab forge backend support': investigation/0007-gitlab-forge-backend-support.md
+        - 'INV-0007: GitLab provider backend support': investigation/0007-gitlab-forge-backend-support.md
     - Plans:
         - Overview: plan/README.md
     - RFCs:
@@ -52,12 +55,12 @@ nav:
         - 'RFC-0002: HCL-driven Policy Engine for repo-guardian': rfc/0002-hcl-driven-policy-engine-for-repo-guardian.md
     - Repo Guardian - Executive Summary: SUMMARY.md
     - Operations:
-        - AWS deployment (RDS/Aurora + ElastiCache for Valkey): operations/aws.md
         - Chart 0.5.0 migration runbook (IMPL-0011): operations/chart-0.5.0-migration.md
         - Chart 0.6.0 / appVersion 1.7.0 — PR convergence migration: operations/pr-convergence-migration.md
         - ECR publish setup (maintainer-side): operations/ecr-publish-setup.md
-        - Homelab CNPG cutover: operations/cnpg-homelab-cutover.md
+        - Homelab CNPG cutover runbook: operations/cnpg-homelab-cutover.md
         - Postgres schema operations: operations/migrations.md
+        - Running repo-guardian on AWS: operations/aws.md
         - Scaling repo-guardian: operations/scaling.md
         - Template migration guide (chart 0.3.x → 0.4.0): operations/template-migration.md
 plugins:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
         - 'RFC-0002: HCL-driven Policy Engine for repo-guardian': rfc/0002-hcl-driven-policy-engine-for-repo-guardian.md
     - Repo Guardian - Executive Summary: SUMMARY.md
     - Operations:
+        - AWS deployment (RDS/Aurora + ElastiCache for Valkey): operations/aws.md
         - Chart 0.5.0 migration runbook (IMPL-0011): operations/chart-0.5.0-migration.md
         - Chart 0.6.0 / appVersion 1.7.0 — PR convergence migration: operations/pr-convergence-migration.md
         - ECR publish setup (maintainer-side): operations/ecr-publish-setup.md


### PR DESCRIPTION
## Summary

Started as the AWS deployment guide; expanded to a coherent multi-replica-scaling docs bundle covering operations + three forward-looking DESIGN docs that close out IMPL-0011's unfinished migration window.

## What's in it

### Operations docs

- **`docs/operations/aws.md`** — new operator guide for AWS-managed alternatives:
  - Postgres option matrix (RDS / Serverless v2 / Aurora) behind RDS Proxy
  - External Secrets Operator wiring for both Postgres + Valkey DSNs
  - ElastiCache for Valkey (cluster-mode-disabled recommended; Valkey > Redis)
  - **Partitioning vs sharding** — clarifies the terms with a definitions table; explains why Valkey cluster-mode sharding does NOT fix the noisy-org problem; expands the partitioning answer with key layout, three worker-scheduling strategies, per-file implementation surface, effort estimate
  - End-to-end values block + AWS resource inventory for 3k × 25 GHEC

### DESIGN docs (Status: Draft)

- **`docs/design/0015-per-installation-valkey-queue-partitioning.md`** — splits the single global queue into per-installation LIST + ZSET pairs (hash-tagged for future cluster-mode compatibility). Recommends BLPOP-many worker scheduling with a soft per-installation concurrency cap. Opt-in via `queue.valkey.partitioning.enabled` chart value.
- **`docs/design/0016-separate-postgres-read-and-write-endpoints.md`** — adds a second pgxpool reader pool routed at the CNPG `<cluster>-ro` service or Aurora reader endpoint. `StaleRepos` and `Get` classified read; `Upsert`/`Touch` classified write. Aliases `ro=rw` when no separate read DSN is configured (backward-compatible). Reader-unavailable fallback to writer with metric.
- **`docs/design/0017-stale-sweep-cutover-and-repository-discovery.md`** — resolves the IMPL-0011 migration window where legacy Sweeper and StaleSweeper both fire every tick (legacy dumping all 3000 repos into the queue makes StaleSweeper's selectivity moot). New Discoverer goroutine populates Store rows with jittered `last_checked_at`; StaleSweeper picks them up at its natural pace. Webhook-driven discovery is primary; periodic Discover at 1h is the safety net.

## Why DESIGN-0017 is in here

The operator raised a "cold-start full sweep seems like a perf bug" concern during the AWS doc review. Verified against `cmd/repo-guardian/main.go:169,193`: the legacy `Sweeper.ReconcileAll` and IMPL-0011's `StaleSweeper.SweepStale` are both scheduled at the SAME interval. The legacy path enqueues every repo on every tick; StaleSweeper's filtering is wasted. The IMPL-0011 sweep.go header comment explicitly says "the two coexist during the IMPL-0011 migration window" — the window never closed. DESIGN-0017 closes it.

## Test plan

- [x] All three DESIGN docs render cleanly with TOCs
- [x] Each DESIGN uses the project's letter-keyed Open Questions format (`(a)=recommendation`, `(b)+=alts`)
- [x] All code references verified against current source (`cmd/repo-guardian/main.go`, `internal/checker/sweep.go`, `internal/scheduler/sweep.go`, `internal/queue/valkey/valkey.go`)
- [x] All chart values referenced exist in `charts/repo-guardian/values.yaml`
- [x] aws.md cross-links into DESIGN-0015 and DESIGN-0016 where their content is referenced
- [x] mkdocs nav updated (via `docz create design`)
- [x] No code changes; no chart bump

## What's NOT in this PR

- IMPL docs for any of the three DESIGNs. These stay Draft pending operator review of the Open Questions sections.
- Code changes. All three DESIGNs are planning artifacts; no implementation until operator promotes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)