### PR TITLE
docs(examples): add guardian-enterprise.hcl for Enterprise App topology

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,7 @@ your Helm values under `policy.config`.
 | [`guardian-full.hcl`](guardian-full.hcl) | Kitchen sink — all rule types, assertions, reconcilers, ignore lists, settings, branch protection. |
 | [`guardian-multi-org.hcl`](guardian-multi-org.hcl) | Strict-mode multi-org example in a single file. Top-level `scope { }` + per-rule scopes (universal `["*"]` and per-org subsets). |
 | [`guardian-multi-org/`](guardian-multi-org/) | Same as above, split across `scope.hcl`, `shared.hcl`, `prod-only.hcl`, `staging-only.hcl`. Point `GUARDIAN_CONFIG` at the directory. |
+| [`guardian-enterprise.hcl`](guardian-enterprise.hcl) | Enterprise App topology: one App installed across every org in the enterprise, but the policy enumerates which orgs to reconcile. Per-org rule scoping for diverging policies. Repos from unconfigured enterprise orgs are silently skipped (visible via `repo_guardian_out_of_scope_total{level="policy"}`). |
 
 ### Usage
 

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -130,6 +130,54 @@ func TestExampleHCL_MultiOrg(t *testing.T) {
 	}
 }
 
+func TestExampleHCL_Enterprise(t *testing.T) {
+	cfg, err := policy.Load(filepath.Join(examplesDir(), "guardian-enterprise.hcl"))
+	if err != nil {
+		t.Fatalf("Load guardian-enterprise.hcl: %v", err)
+	}
+
+	if cfg.Scope == nil {
+		t.Fatal("expected top-level scope to engage strict mode")
+	}
+
+	if len(cfg.Scope.Orgs) != 3 {
+		t.Errorf("Scope.Orgs count = %d, want 3", len(cfg.Scope.Orgs))
+	}
+
+	// Two universal-scope baseline rules (codeowners + dependabot) and one
+	// org-specific rule pair (renovate workflow + config for myent-product).
+	if len(cfg.FileRules) != 4 {
+		t.Errorf("FileRules count = %d, want 4", len(cfg.FileRules))
+	}
+
+	if len(cfg.SettingRules) != 1 {
+		t.Errorf("SettingRules count = %d, want 1 (platform vuln-alerts)", len(cfg.SettingRules))
+	}
+
+	if len(cfg.BranchProtectionRules) != 1 {
+		t.Errorf("BranchProtectionRules count = %d, want 1 (platform main)", len(cfg.BranchProtectionRules))
+	}
+
+	// Strict mode: every rule must declare its own scope.
+	for _, r := range cfg.FileRules {
+		if r.Scope == nil {
+			t.Errorf("FileRule %q missing scope (strict mode)", r.Name)
+		}
+	}
+
+	for _, r := range cfg.SettingRules {
+		if r.Scope == nil {
+			t.Errorf("SettingRule %q missing scope (strict mode)", r.Name)
+		}
+	}
+
+	for _, r := range cfg.BranchProtectionRules {
+		if r.Scope == nil {
+			t.Errorf("BranchProtectionRule %q missing scope (strict mode)", r.Name)
+		}
+	}
+}
+
 func TestExampleHCL_MultiOrgDirectory(t *testing.T) {
 	cfg, err := policy.Load(filepath.Join(examplesDir(), "guardian-multi-org"))
 	if err != nil {

--- a/examples/guardian-enterprise.hcl
+++ b/examples/guardian-enterprise.hcl
@@ -1,0 +1,160 @@
+// guardian-enterprise.hcl — GitHub Enterprise App, installed on every org
+// in the enterprise, run against only the configured subset.
+//
+// Topology:
+//   - One GitHub App at the enterprise level (single auth, GITHUB_APP_ID +
+//     private key).
+//   - The App is installed on every org in the enterprise (operator-side
+//     concern via the Enterprise admin UI).
+//   - repo-guardian receives webhooks + discovery rows for every install.
+//   - This policy enumerates which orgs to actually reconcile, and each
+//     configured org gets its own per-rule scope so policies can diverge.
+//
+// Why this shape and not legacy mode (no top-level scope):
+//   - Legacy mode would apply every rule to every repo across every org
+//     the App is installed on, with no way to vary policy per-org. Fine
+//     for small enterprises with one policy; insufficient when one team
+//     wants stricter branch protection than another.
+//   - Strict mode gives you per-org carveouts AND the discipline that
+//     every rule must explicitly declare its scope. New rules added by
+//     a teammate can't accidentally bleed into orgs you didn't intend.
+//
+// Efficiency note:
+//   Repos from unconfigured orgs still create `repo_state` rows (via
+//   discovery + webhooks) and get briefly processed before the scope
+//   gate skips them. The engine increments
+//   `repo_guardian_out_of_scope_total{level="policy"}` for visibility.
+//   For an enterprise with hundreds of orgs and only a few configured,
+//   this is wasteful — track the metric and file a feature request for
+//   discovery-time scope gating if it becomes load-bearing.
+
+guardian {
+  // Owner of any PRs we create. Override per-rule if you need to.
+  org = "myent-platform"
+}
+
+// Top-level scope: ONLY the orgs we want repo-guardian to reconcile.
+// Add orgs here as teams onboard. Orgs the App is installed on but
+// NOT listed here will be silently skipped (visible via
+// repo_guardian_out_of_scope_total{level="policy"}).
+scope {
+  orgs = [
+    "myent-platform",   // platform / infra org — strictest baseline
+    "myent-product",    // product engineering — baseline + Renovate
+    "myent-sandbox",    // experimentation org — relaxed rules
+  ]
+}
+
+// =========================================================================
+// Shared baseline — applies to every configured org.
+// =========================================================================
+// Use the literal ["*"] at the rule level to mean "every org in the
+// top-level scope." This is the idiom that survives org additions without
+// touching every rule.
+
+rule "file" "codeowners" {
+  paths    = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
+  target   = ".github/CODEOWNERS"
+  template = "codeowners"
+
+  scope {
+    orgs = ["*"]
+  }
+}
+
+rule "file" "dependabot" {
+  paths    = [".github/dependabot.yml", ".github/dependabot.yaml"]
+  target   = ".github/dependabot.yml"
+  template = "dependabot"
+
+  scope {
+    orgs = ["*"]
+  }
+}
+
+// =========================================================================
+// Platform org — stricter requirements.
+// =========================================================================
+// Branch protection only applies to the platform org's repos. Product and
+// sandbox orgs are NOT in this rule's scope.
+
+rule "branch_protection" "main_required" {
+  branch                = "main"
+  require_pr            = true
+  required_approvals    = 2
+  dismiss_stale_reviews = true
+  enforce_admins        = true
+
+  scope {
+    orgs = ["myent-platform"]
+  }
+}
+
+// Vulnerability alerts must be on for platform repos.
+rule "setting" "vulnerability_alerts" {
+  property = "vulnerability_alerts_enabled"
+  expected = true
+  remediate = true
+
+  scope {
+    orgs = ["myent-platform"]
+  }
+}
+
+// =========================================================================
+// Product org — baseline + Renovate workflow.
+// =========================================================================
+
+rule "file" "renovate_workflow" {
+  paths    = [".github/workflows/renovate.yml"]
+  target   = ".github/workflows/renovate.yml"
+  template = "renovate-workflow"
+
+  scope {
+    orgs = ["myent-product"]
+  }
+
+  reconcile "workflow_sync" {
+    watch = true
+  }
+}
+
+rule "file" "renovate_config" {
+  paths    = ["renovate.json", ".github/renovate.json"]
+  target   = "renovate.json"
+  template = "renovate-config"
+  check    = "contains"
+
+  scope {
+    orgs = ["myent-product"]
+  }
+
+  assertion {
+    yaml_path = "extends"
+    contains  = "github>myent-product/renovate-config"
+    message   = "renovate.json must extend the shared org preset"
+  }
+}
+
+// =========================================================================
+// Sandbox org — opt out of strict rules.
+// =========================================================================
+// No rules with scope.orgs = ["myent-sandbox"] means: only the universal
+// (["*"]) baseline rules apply to sandbox. No branch protection, no
+// vuln-alerts enforcement, no Renovate. The org is in scope (so we'll
+// still reconcile its repos) but the policy is intentionally minimal.
+
+// =========================================================================
+// Notes on growing this file:
+// =========================================================================
+//   - To onboard a new org: add it to top-level scope.orgs. Universal
+//     rules (["*"]) automatically apply.
+//   - To add an org-specific rule: declare scope.orgs = ["<org>"] on the
+//     rule. Universal rules continue to apply.
+//   - To opt an org out of a universal rule: the simplest path is to
+//     split the rule into two with explicit subsets (e.g., ["myent-prod",
+//     "myent-staging"]) instead of ["*"]. Re-introducing the universal
+//     bypasses the carveout, which the engine doesn't prevent.
+//   - For very large directory-style configs, split into a directory of
+//     HCL files (one per org or per concern) and point GUARDIAN_CONFIG
+//     at the directory. See examples/guardian-multi-org/ for the pattern.


### PR DESCRIPTION
## Summary

Adds an HCL example demonstrating the **Enterprise App** topology — one GitHub App installed across every org in an enterprise, but with the policy explicitly enumerating which orgs repo-guardian should reconcile. Each configured org can have its own per-rule scoping for diverging policies.

## Pattern

- Top-level `scope { orgs = [...] }` enumerates the orgs we actually reconcile.
- Shared baseline rules use `scope { orgs = ["*"] }` to apply to every configured org.
- Per-org rules use `scope { orgs = ["specific-org"] }` to vary policy (branch protection on platform, Renovate on product, opt-in minimal for sandbox).
- Repos from enterprise orgs NOT listed in top-level scope are silently skipped via the strict-mode `policyScopeAllows` gate.

## Works without code changes today

Confirmed against the live HCL loader via `TestExampleHCL_Enterprise`. The engine's strict-mode scope gates do the right thing. One efficiency caveat documented in the file's preamble: discovery + webhook write-back still touches every install, then the scope gate short-circuits at engine time. Out-of-scope skips are observable via `repo_guardian_out_of_scope_total{level="policy"}`. Fine for small/medium enterprises; tracked as a future feature request if a 500-org enterprise with 5 configured orgs makes the wasted budget load-bearing.

## Test plan

- [x] `go test ./examples/...` passes (new `TestExampleHCL_Enterprise` validates scope, rule counts, strict-mode rule-scope-required invariant)
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)