### PR TITLE
fix(queue): preserve at-least-once contract when ZADD-to-in-flight fails

### DIFF
--- a/internal/queue/valkey/valkey.go
+++ b/internal/queue/valkey/valkey.go
@@ -77,6 +77,13 @@ const (
 // low while still feeling responsive on shutdown.
 const brpopTimeout = 5 * time.Second
 
+// recoveryTimeout caps the LPUSH used to re-enqueue a payload whose
+// post-BRPOP ZADD to in-flight failed. Detached from the caller's
+// ctx because the caller's cancellation is usually what triggered
+// the recovery in the first place — we still need the recovery to
+// succeed against Valkey.
+const recoveryTimeout = 5 * time.Second
+
 // requeueScript atomically removes a member from the in-flight ZSET
 // and pushes it back onto the jobs list. KEYS[1]=in-flight,
 // KEYS[2]=jobs; ARGV[1]=member.
@@ -231,12 +238,17 @@ func (q *Queue) brpopOnce(ctx context.Context) (string, error) {
 // processPayload claims, decodes, and dispatches a single job
 // payload. Decode failures are dropped (no point requeueing
 // undecodable garbage); handler failures leave the job in-flight.
+//
+// If ZADD to in-flight fails after BRPOP already removed the payload
+// from queue:jobs (e.g. because the caller's ctx was cancelled
+// mid-claim), the payload is LPUSHed back to queue:jobs using a
+// detached context so the at-least-once contract is preserved.
 func (q *Queue) processPayload(ctx context.Context, payload string, handler func(context.Context, queue.Job) error) {
 	if err := q.client.ZAdd(ctx, q.opts.InFlightKey, redis.Z{
 		Score:  float64(time.Now().UnixNano()),
 		Member: payload,
 	}).Err(); err != nil {
-		q.logger.WarnContext(ctx, "valkey ZADD in-flight failed; job may be lost", "error", err)
+		q.recoverPayload(ctx, payload, err)
 
 		return
 	}
@@ -276,6 +288,39 @@ func (q *Queue) processPayload(ctx context.Context, payload string, handler func
 	}
 
 	metrics.QueueAckedTotal.WithLabelValues("success").Inc()
+}
+
+// recoverPayload re-LPUSHes a payload that was BRPOPed but failed to
+// claim (ZADD to in-flight failed, typically because the subscriber's
+// ctx was cancelled mid-claim). Uses a detached context with a short
+// timeout so the recovery succeeds even when the caller's ctx is
+// already cancelled — the alternative is silently losing the job and
+// violating the at-least-once contract.
+//
+// If the recovery LPUSH also fails the job IS lost; the log captures
+// both errors so an operator can root-cause.
+func (q *Queue) recoverPayload(ctx context.Context, payload string, claimErr error) {
+	// Detached on purpose: the caller's ctx is usually what triggered
+	// the recovery (BRPOP succeeded, then ctx-cancelled before ZADD).
+	// Using ctx here would propagate the same cancellation and lose
+	// the job.
+	recoveryCtx, cancel := context.WithTimeout(context.Background(), recoveryTimeout)
+	defer cancel()
+
+	//nolint:contextcheck // recoveryCtx is intentionally detached from caller ctx
+	rerr := q.client.LPush(recoveryCtx, q.opts.JobsKey, payload).Err()
+	if rerr != nil {
+		q.logger.WarnContext(ctx, "valkey ZADD failed and LPUSH recovery failed; job lost",
+			"zadd_error", claimErr,
+			"lpush_error", rerr,
+		)
+
+		return
+	}
+
+	q.logger.WarnContext(ctx, "valkey ZADD in-flight failed; payload re-enqueued for retry",
+		"error", claimErr,
+	)
 }
 
 // Close releases queue resources. The underlying redis client is NOT

--- a/internal/scheduler/valkey/valkey_integration_test.go
+++ b/internal/scheduler/valkey/valkey_integration_test.go
@@ -176,15 +176,12 @@ func TestLeaderElection_TwoPods(t *testing.T) {
 
 	var (
 		fires    atomic.Int32
-		fireCh   = make(chan string, 16)
 		interval = 200 * time.Millisecond
 	)
 
-	handler := func(pod string) func(context.Context) error {
+	handler := func(_ string) func(context.Context) error {
 		return func(_ context.Context) error {
 			fires.Add(1)
-			fireCh <- pod
-
 			return nil
 		}
 	}
@@ -201,13 +198,7 @@ func TestLeaderElection_TwoPods(t *testing.T) {
 	// captures the lock it'll hold it for the duration of this run, so
 	// we expect roughly one fire per LockTTL window — i.e. ≤ 2 fires
 	// rather than 14 (2 pods × 7 ticks).
-	deadline := time.Now().Add(1500 * time.Millisecond)
-
-	for time.Now().Before(deadline) {
-		time.Sleep(50 * time.Millisecond)
-	}
-
-	close(fireCh)
+	time.Sleep(1500 * time.Millisecond)
 
 	count := int(fires.Load())
 	if count == 0 {


### PR DESCRIPTION
## Summary

Two bugs surfaced by `make test-integration`, shipped together:

1. **Production at-least-once bug in `internal/queue/valkey`.** After BRPOP succeeded, a ZADD to the in-flight ZSET could fail (typically when the subscriber's ctx was cancelled mid-claim). The payload was already gone from `queue:jobs` and the old code simply logged + dropped it — violating the at-least-once contract. Fix: new `recoverPayload` helper LPUSHes the payload back using a detached 5s context, so recovery succeeds even when the caller's ctx is cancelled. If the recovery LPUSH itself fails the job is lost, but both errors are logged for root-cause.
2. **Data race in `TestLeaderElection_TwoPods`.** `close(fireCh)` raced with scheduler tick callbacks writing to the channel. The channel was never actually read; removed it entirely and simplified the deadline loop to a single `time.Sleep`.

Reaper test was failing 3/3 before the fix and is stable 3/3 after. Full `make test-integration` now passes with zero data races.

## Test plan

- [x] `make test-integration` — green, no data races
- [x] `make fmt`
- [x] `make lint`
- [x] `make test`
- [x] `TestValkey_ReaperRequeues` runs 3/3 stable
- [x] `TestLeaderElection_TwoPods` runs 3/3 stable

## Notes

- `//nolint:contextcheck` on the recovery LPush is intentional — the whole point of the recovery is that the caller's ctx is cancelled, so we must NOT inherit it. Rationale documented inline.
- Bumped via `patch` label — this is a real production fix to the at-least-once contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)