### PR TITLE
chore: swap math/rand to crypto/rand for discovery jitter

### DIFF
--- a/internal/scheduler/discoverer.go
+++ b/internal/scheduler/discoverer.go
@@ -16,9 +16,10 @@ package scheduler
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"log/slog"
-	"math/rand"
+	"math/big"
 	"strconv"
 	"time"
 
@@ -41,7 +42,6 @@ type Discoverer struct {
 	skipForks    bool
 	skipArchived bool
 	freshness    time.Duration
-	rng          *rand.Rand
 }
 
 // DiscovererOptions bundles Discoverer constructor inputs. Option-
@@ -80,8 +80,20 @@ func NewDiscoverer(opts DiscovererOptions) *Discoverer {
 		skipForks:    opts.SkipForks,
 		skipArchived: opts.SkipArchived,
 		freshness:    opts.Freshness,
-		rng:          rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec // non-crypto: just jitter
 	}
+}
+
+// randomJitter returns a uniform random duration in [0, span) using
+// crypto/rand. On the practically-never reader-failure path returns 0,
+// which collapses to no jitter — fail-safe because jitter is a
+// load-spreading optimization, not a correctness requirement.
+func randomJitter(span time.Duration) time.Duration {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(span)))
+	if err != nil {
+		return 0
+	}
+
+	return time.Duration(n.Int64())
 }
 
 // Discover runs one discovery iteration. Suitable for driving via
@@ -173,7 +185,7 @@ func (d *Discoverer) discoverInstallation(ctx context.Context, install *ghclient
 // repo) tuple with a jittered initial LastCheckedAt. Returns true
 // when a new row was created.
 func (d *Discoverer) upsertRepo(ctx context.Context, installationID int64, owner, repo string) bool {
-	jitter := time.Duration(d.rng.Int63n(int64(2 * d.freshness)))
+	jitter := randomJitter(2 * d.freshness)
 	seedTime := time.Now().UTC().Add(-jitter)
 
 	state := &store.RepoState{

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -17,9 +17,10 @@ package webhook
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"log/slog"
-	"math/rand"
+	"math/big"
 	"net/http"
 	"strings"
 	"time"
@@ -40,10 +41,6 @@ type Handler struct {
 	stateStore    store.Store
 	policyVersion string
 	freshness     time.Duration
-	// rng is the source for discovery-jitter. Per-Handler so tests
-	// can seed it deterministically; the production path receives
-	// the default time-seeded source.
-	rng *rand.Rand
 }
 
 // NewHandler creates a new webhook Handler.
@@ -68,8 +65,20 @@ func NewHandler(
 		stateStore:    stateStore,
 		policyVersion: policyVersion,
 		freshness:     freshness,
-		rng:           rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec // non-crypto: just jitter
 	}
+}
+
+// randomJitter returns a uniform random duration in [0, span) using
+// crypto/rand. On the practically-never reader-failure path returns 0,
+// which collapses to no jitter — fail-safe because jitter is a
+// load-spreading optimization, not a correctness requirement.
+func randomJitter(span time.Duration) time.Duration {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(span)))
+	if err != nil {
+		return 0
+	}
+
+	return time.Duration(n.Int64())
 }
 
 // ServeHTTP implements http.Handler for GitHub webhook events.
@@ -237,7 +246,7 @@ func (h *Handler) discover(ctx context.Context, installationID int64, owner, rep
 		return
 	}
 
-	jitter := time.Duration(h.rng.Int63n(int64(2 * h.freshness)))
+	jitter := randomJitter(2 * h.freshness)
 	seedTime := time.Now().UTC().Add(-jitter)
 
 	state := &store.RepoState{


### PR DESCRIPTION
## Summary

The two discovery-jitter sites (`Discoverer.upsertRepo` and `Handler.discover`) previously used `math/rand` with a time-seeded source and a `//nolint:gosec` exemption. Swapped to `crypto/rand` via a small per-file `randomJitter` helper that returns a uniform duration in `[0, span)`. Fail-safe on the practically-never reader-failure path (returns 0 → no jitter).

- No behaviour change in steady state — jitter distribution is still uniform across the same window.
- Satisfies gosec G404 without `//nolint:gosec` exemptions.
- Drops the per-Handler / per-Discoverer `rng` field plus its seeding ceremony.

## Test plan

- [x] `make fmt`
- [x] `make lint` — clean, no nolint directives needed
- [x] `make test` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)