### PR TITLE
chore(docker): set HEALTHCHECK NONE explicitly on distroless base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,12 @@ EXPOSE 8080 9090
 
 USER nonroot:nonroot
 
+# No Dockerfile HEALTHCHECK: the distroless/static base ships no
+# shell, curl, or wget, so an HTTP probe directive can't run inside
+# the image. Production runs on k8s where the Helm chart configures
+# livenessProbe/readinessProbe against /healthz and /readyz directly.
+# Setting NONE explicitly so Docker doesn't sit in `health: starting`
+# forever when run via plain `docker run`.
+HEALTHCHECK NONE
+
 ENTRYPOINT ["/repo-guardian"]


### PR DESCRIPTION
## Summary

The runtime base (`gcr.io/distroless/static-debian12:nonroot`) has no shell, no curl, no wget — so an HTTP-probe `HEALTHCHECK CMD curl ...` directive can't run inside the image. Production runs on k8s where the chart already configures `livenessProbe` and `readinessProbe` against `/healthz` and `/readyz` directly.

Set `HEALTHCHECK NONE` explicitly so:
- Plain `docker run` consumers don't sit in `health: starting` indefinitely.
- The "no Dockerfile-level check, that's intentional" decision is documented inline for future readers.

If we ever want an in-image check, the cleanest path is a `health` subcommand on the binary so `HEALTHCHECK CMD ["/repo-guardian", "health"]` works without losing the distroless base.

## Test plan

- [x] `docker build` succeeds
- [x] `docker inspect ... --format '{{json .Config.Healthcheck}}'` reports `{"Test":["NONE"]}`

## Label

`dont-release` — Dockerfile-only change, no Go code, no chart change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)