### PR TITLE
chore(deps): consolidate open dependabot + renovate updates

### DIFF
--- a/.github/workflows/changelog-update.yml
+++ b/.github/workflows/changelog-update.yml
@@ -23,7 +23,7 @@ jobs:
     name: Regenerate root CHANGELOG and open PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       workflows: ${{ steps.filter.outputs.workflows }}
       alerts: ${{ steps.filter.outputs.alerts }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -60,7 +60,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.helm == 'true' || needs.changes.outputs.workflows == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -84,7 +84,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.alerts == 'true' || needs.changes.outputs.workflows == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up mise
         uses: jdx/mise-action@v3
@@ -98,7 +98,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.workflows == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -125,7 +125,7 @@ jobs:
       security-events: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -144,7 +144,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.go == 'true' || needs.changes.outputs.workflows == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -167,7 +167,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -212,7 +212,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.helm == 'true' || needs.changes.outputs.workflows == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Set up Helm
         uses: azure/setup-helm@v5
         with:
@@ -230,7 +230,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.helm == 'true' || needs.changes.outputs.workflows == 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: azure/setup-helm@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         run: make test-coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -84,7 +84,7 @@ jobs:
       published: ${{ steps.digest.outputs.published }}
       registry: ${{ needs.aws-auth.outputs.registry }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag }}
 
@@ -187,7 +187,7 @@ jobs:
       published: ${{ steps.push.outputs.published }}
       registry: ${{ needs.aws-auth.outputs.registry }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
 
-      - uses: sigstore/cosign-installer@v3
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -192,7 +192,7 @@ jobs:
           fetch-depth: 0
 
       - uses: azure/setup-helm@v5
-      - uses: sigstore/cosign-installer@v3
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -169,7 +169,7 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: ${{ needs.aws-auth.outputs.registry }}/repo-guardian
       digest: ${{ needs.image.outputs.digest }}
@@ -305,7 +305,7 @@ jobs:
       id-token: write
       contents: read
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: ${{ needs.aws-auth.outputs.registry }}/repo-guardian-chart
       digest: ${{ needs.chart.outputs.digest }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           python-version: 3.x
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: ~/.cache

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -136,7 +136,7 @@ jobs:
       packages: write
       contents: read
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: ghcr.io/donaldgifford/repo-guardian
       digest: ${{ needs.image.outputs.digest }}
@@ -266,7 +266,7 @@ jobs:
       packages: write
       contents: read
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: ghcr.io/donaldgifford/charts/repo-guardian
       digest: ${{ needs.chart.outputs.digest }}

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
 
-      - uses: sigstore/cosign-installer@v3
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Login to GHCR
         uses: docker/login-action@v4
@@ -157,7 +157,7 @@ jobs:
           fetch-depth: 0
 
       - uses: azure/setup-helm@v5
-      - uses: sigstore/cosign-installer@v3
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Login to GHCR (docker config — for cosign and helm)
         uses: docker/login-action@v4

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -52,7 +52,7 @@ jobs:
       digest: ${{ steps.bake.outputs.digest }}
       published: ${{ steps.bake.outputs.published }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag }}
 
@@ -152,7 +152,7 @@ jobs:
       digest: ${{ steps.push.outputs.digest }}
       published: ${{ steps.push.outputs.published }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -16,7 +16,7 @@ jobs:
     name: Check Dependency Licenses
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       tag: ${{ steps.bump.outputs.version }}
       skipped: ${{ steps.bump.outputs.skipped }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
     needs: bump-version
     if: needs.bump-version.outputs.skipped != 'true'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ needs.bump-version.outputs.tag }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,7 +16,7 @@ jobs:
       security-events: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/mise.toml
+++ b/mise.toml
@@ -61,7 +61,7 @@ syft = "latest"
 
 # helm
 # renovate: datasource=github-releases depName=helm/helm
-helm = "3.19.0"
+helm = "4.2.2"
 # renovate: datasource=github-releases depName=helm/chart-testing
 helm-ct = "latest"
 # renovate: datasource=github-releases depName=databus23/helm-diff


### PR DESCRIPTION
## Summary

Consolidates the **safe** open dependabot and renovate-operator-bot PRs into one branch — one commit per bot PR. Both bots auto-close their PRs once main contains the target versions.

**Scope change:** the postgres and valkey image bumps (#107, #108, #119, #121) were deliberately pulled OUT of this PR. Those need version alignment across the whole repo (chart baked image, CNPG image, docker-compose, testcontainers pins) plus integration-test proof — they land in a dedicated follow-up branch.

| Commit | Bot PR(s) | Change |
|---|---|---|
| `chore(deps): bump actions/cache from 4 to 5` | #54 | gh-pages.yml |
| `chore(deps): update slsa-framework/slsa-github-generator action to v2.1.0` | #106 | ecr.yml + ghcr.yml (×4) — **deviation, see below** |
| `chore(deps): update codecov/codecov-action action to v7` | #115 + #131 | ci.yml — same change proposed by both bots, one commit resolves both |
| `chore(deps): update dependency helm to v4` | #116 | mise.toml 3.19.0 → 4.2.2 |
| `chore(deps): update sigstore/cosign-installer action to v4` | #120 | ecr.yml + ghcr.yml (digest-pinned v4.1.2) |
| `chore(deps): bump actions/checkout from 6 to 7` | #130 | all 8 workflows |

**Already satisfied on main, no commit needed:** #56 (setup-python v6) and #57 (setup-helm v5) — dependabot will close them on its next check (or close manually).

**Deferred to the postgres/valkey follow-up branch:** #107, #108, #119, #121.

## Deviations from bot diffs

- **#106 (SLSA generator):** renovate pinned the reusable workflow to a commit SHA. slsa-github-generator trusted builders must be referenced by a `@vX.Y.Z` tag — the builder verifies its own ref at runtime and digest refs fail the provenance job. Applied `@v2.1.0` as a tag instead. If renovate re-attempts the digest pin, we should add a packageRule exception for `slsa-framework/slsa-github-generator`.

## Operational flags

- **helm 4.2.2 (local toolchain only):** verified locally — `make helm-lint`, `make helm-unittest` (75/75), `make helm-docs`, `make helm-test` all pass under helm 4. CI installs helm separately via azure/setup-helm.

## Test plan

- [x] `make helm-lint` / `make helm-unittest` / `make helm-docs` / `make helm-test` under helm 4.2.2
- [x] `actionlint` — no issues on new action versions (one pre-existing shellcheck info on an untouched line)
- [x] No stragglers: grep confirms no remaining references to the old versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)