### PR TITLE
fix(ci): grant actions:read to nested publish workflow calls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,10 +81,15 @@ jobs:
     name: Publish to GHCR
     needs: bump-version
     uses: ./.github/workflows/ghcr.yml
+    # actions: read is required by the nested SLSA generator jobs inside
+    # ghcr.yml. Caller-job permissions are a hard ceiling for nested
+    # reusable workflows — omitting it fails the whole run at startup
+    # (zero jobs created) before anything executes.
     permissions:
       contents: read
       packages: write
       id-token: write
+      actions: read
     with:
       tag: ${{ needs.bump-version.outputs.tag }}
       dry_run: false
@@ -100,9 +105,13 @@ jobs:
     # standalone testing regardless of this gate.
     if: vars.ECR_PUBLISH_ENABLED == 'true'
     uses: ./.github/workflows/ecr.yml
+    # actions: read — same nested-SLSA requirement as publish-ghcr.
+    # The uses: graph is validated at startup even though this job is
+    # gated off by the if: condition.
     permissions:
       contents: read
       id-token: write
+      actions: read
     with:
       tag: ${{ needs.bump-version.outputs.tag }}
       dry_run: false


### PR DESCRIPTION
## Summary

**Every `release.yml` run since the per-registry publish split (June 7) has failed with `startup_failure` and zero jobs** — discovered while verifying the release for #141.

Root cause: the SLSA generator jobs nested inside `ghcr.yml` and `ecr.yml` declare `actions: read`, but the caller jobs `publish-ghcr` / `publish-ecr` in `release.yml` never granted it. For nested reusable workflows, the caller job's `permissions` block is a hard ceiling — a nested job requesting more fails workflow-graph validation at startup, before any job is created. The `publish-ecr` call fails validation too even though it's gated off by `if:` (the `uses:` graph resolves regardless).

Why it went unnoticed: direct `workflow_dispatch` of `ghcr.yml` has no caller ceiling, so the manual chart publishes (1.0.0-rc.x) all worked while every push-triggered release silently died.

## Impact

No binary release has shipped since June 6. The `patch`-labeled merges #136 (queue at-least-once fix), #137 (crypto/rand), and #141 (x/crypto bump) never released. This PR carries the `patch` label, so its merge cuts the release containing all of them.

## Fix

Add `actions: read` to both publish caller jobs' permissions in `release.yml`, with comments explaining the nested-ceiling rule.

## Verification

- `actionlint` clean (note: actionlint cannot catch cross-workflow permission ceilings — that's why CI was green all along)
- Real verification is the merge itself: the next push-triggered release run must create jobs and cut the tag. I'll watch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)