### PR TITLE
fix(ci): grant packages:write through the ECR SLSA call chain

### DIFF
--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -165,10 +165,15 @@ jobs:
     name: SLSA provenance (image)
     needs: [aws-auth, image]
     if: needs.image.outputs.published == 'true'
+    # packages: write — the generator's internal job declares it
+    # unconditionally ("upload attestations to ghcr.io"), even though
+    # this call publishes to ECR. Omitting it fails the ENTIRE calling
+    # run (release.yml) at startup via the nested-permissions ceiling.
     permissions:
       id-token: write
       contents: read
       actions: read
+      packages: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: ${{ needs.aws-auth.outputs.registry }}/repo-guardian
@@ -301,10 +306,12 @@ jobs:
     name: SLSA provenance (chart)
     needs: [aws-auth, chart]
     if: needs.chart.outputs.published == 'true'
+    # packages: write — same nested-ceiling requirement as image-slsa.
     permissions:
       id-token: write
       contents: read
       actions: read
+      packages: write
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
     with:
       image: ${{ needs.aws-auth.outputs.registry }}/repo-guardian-chart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,13 +105,16 @@ jobs:
     # standalone testing regardless of this gate.
     if: vars.ECR_PUBLISH_ENABLED == 'true'
     uses: ./.github/workflows/ecr.yml
-    # actions: read — same nested-SLSA requirement as publish-ghcr.
-    # The uses: graph is validated at startup even though this job is
-    # gated off by the if: condition.
+    # actions: read + packages: write — same nested-SLSA requirement as
+    # publish-ghcr (the generator's internal job declares packages: write
+    # unconditionally, even for ECR publishes). The uses: graph is
+    # validated at startup even though this job is gated off by the
+    # if: condition.
     permissions:
       contents: read
       id-token: write
       actions: read
+      packages: write
     with:
       tag: ${{ needs.bump-version.outputs.tag }}
       dry_run: false


### PR DESCRIPTION
## Summary

Second half of the release `startup_failure` fix — #143 (actions: read) was necessary but not sufficient. The run page's actual validation error:

> The nested job 'generator' is requesting 'packages: write', but is only allowed 'packages: none'. — `.github/workflows/ecr.yml`, line 164

The SLSA generator's internal job declares `packages: write` unconditionally (it uploads attestations to ghcr.io even when attesting an ECR artifact). The ECR chain never granted it, and GitHub validates the full nested `uses:` graph at startup — **including jobs gated off by `if:`** — so `publish-ecr` being disabled didn't save us.

## Fix

- `ecr.yml`: add `packages: write` to `image-slsa` and `chart-slsa` job permissions.
- `release.yml`: add `packages: write` to the `publish-ecr` caller ceiling.

## Chain audit

Generator union requirement: `{id-token: write, actions: read, packages: write}` (verified against `generator_container_slsa3.yml@v2.1.0` source).

- GHCR: `publish-ghcr` ceiling ⊇ `ghcr.yml` SLSA jobs ⊇ union ✓
- ECR: `publish-ecr` ceiling ⊇ `ecr.yml` top-level + SLSA jobs ⊇ union ✓

`patch` label again — if this run starts cleanly, it cuts the release carrying #136, #137, #141, #143, and this fix. I'll watch the release run after merge; that's the only real verification (actionlint can't see cross-workflow ceilings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)