### PR TITLE
fix(ci): pass bake metadata via env to avoid shell injection in digest capture

### DIFF
--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -130,8 +130,13 @@ jobs:
       - name: Capture image digest
         id: digest
         if: steps.bake.conclusion == 'success' && inputs.dry_run != true
+        # Metadata is passed via env, NOT interpolated into the script:
+        # the bake metadata JSON can contain quotes/parens that break
+        # shell syntax when inlined (broke the v1.8.2 release run).
+        env:
+          BAKE_METADATA: ${{ steps.bake.outputs.metadata }}
         run: |
-          digest=$(echo '${{ steps.bake.outputs.metadata }}' | jq -r '.release."containerimage.digest"')
+          digest=$(jq -r '.release."containerimage.digest"' <<< "${BAKE_METADATA}")
           if [ -z "${digest}" ] || [ "${digest}" = "null" ]; then
             echo "ERROR: failed to capture image digest from bake metadata"
             exit 1

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -96,8 +96,13 @@ jobs:
       - name: Capture image digest
         id: digest
         if: steps.bake.conclusion == 'success' && inputs.dry_run != true
+        # Metadata is passed via env, NOT interpolated into the script:
+        # the bake metadata JSON can contain quotes/parens that break
+        # shell syntax when inlined (broke the v1.8.2 release run).
+        env:
+          BAKE_METADATA: ${{ steps.bake.outputs.metadata }}
         run: |
-          digest=$(echo '${{ steps.bake.outputs.metadata }}' | jq -r '.release."containerimage.digest"')
+          digest=$(jq -r '.release."containerimage.digest"' <<< "${BAKE_METADATA}")
           if [ -z "${digest}" ] || [ "${digest}" = "null" ]; then
             echo "ERROR: failed to capture image digest from bake metadata"
             exit 1


### PR DESCRIPTION
## Summary

Final piece of the release-pipeline repair. The v1.8.2 release run (first successful startup since June 7) got through bump-version + goreleaser + image push, then died at **Capture image digest**:

```
sh: line 103: syntax error near unexpected token `('
```

Cause: the step inlined `${{ steps.bake.outputs.metadata }}` into the shell script inside single quotes. The bake metadata JSON can contain characters that terminate the quoting, turning the JSON into shell syntax. It worked on the June 30 manual dispatch by luck — this run's metadata happened to contain a breaking character.

Fix: pass the metadata through `env:` (`BAKE_METADATA`) and read it with `jq ... <<< "${BAKE_METADATA}"` — environment values are never shell-parsed. Applied to both `ghcr.yml` and `ecr.yml` (same step shape from the per-registry split).

## State of v1.8.2

- Git tag + GitHub release + signed binaries: ✅ published by the run
- `ghcr.io/donaldgifford/repo-guardian:1.8.2`: ⚠️ pushed but **unsigned, no SLSA provenance** (sign + SLSA steps skipped when digest capture failed)
- Chart: untouched (idempotent skip)

After this merges, re-dispatch `ghcr.yml` with `tag=v1.8.2` to re-publish the image with cosign signature + SLSA provenance (roll-forward, same tag).

`dont-release` — workflow-only change; no reason to cut v1.8.3 for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)