### PR TITLE
fix(ci): ghcr image job outputs referenced the wrong step id

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -49,8 +49,12 @@ jobs:
     runs-on: ubuntu-latest
     if: inputs.tag != ''
     outputs:
-      digest: ${{ steps.bake.outputs.digest }}
-      published: ${{ steps.bake.outputs.published }}
+      # digest/published are written by the Capture-image-digest step
+      # (id: digest), NOT the bake step — bake only outputs metadata.
+      # Referencing the wrong step id left these empty and silently
+      # skipped image-slsa on every publish (ecr.yml had it right).
+      digest: ${{ steps.digest.outputs.digest }}
+      published: ${{ steps.digest.outputs.published }}
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## Summary

Found while verifying the v1.8.2 republish: the digest-capture and cosign-sign steps now succeed (the #145 fix works), but `SLSA provenance (image)` still skipped. The `image` job's outputs referenced `steps.bake.outputs.digest/published` — but bake only outputs `metadata`; those values are written by the `Capture image digest` step (`id: digest`). Job outputs were therefore always empty, so `image-slsa`'s `if: needs.image.outputs.published == 'true'` never fired.

Consequence: **no GHCR image has ever had SLSA provenance attached since the per-registry split** — silently, because a skipped job isn't a failure. `ecr.yml` referenced `steps.digest` correctly; this aligns `ghcr.yml`.

## After merge

Re-dispatch `ghcr.yml` with `tag=v1.8.2` one more time — image re-publishes (roll-forward), signs, and this time `image-slsa` fires and attaches provenance.

`dont-release` — workflow-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)