### PR TITLE
docs(usage): getting-started walkthrough + policy reference

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,11 @@
 
 Welcome to the documentation for repo-guardian.
 
+New here? Start with the [Getting Started walkthrough](usage/getting-started.md)
+for what repo-guardian is, what it can (and can't) do, and how to roll it out —
+then keep the [Policy Reference](usage/policy-reference.md) open while writing
+your `guardian.hcl`.
+
 ## Document Types
 
 - [RFCs](rfc/README.md)

--- a/docs/usage/getting-started.md
+++ b/docs/usage/getting-started.md
@@ -1,0 +1,325 @@
+# Getting Started with repo-guardian
+
+A walkthrough for onboarding new users and teams. Read it top to bottom, or
+present it section by section — each heading is a self-contained "slide."
+For the exhaustive policy schema, see the [Policy Reference](policy-reference.md).
+
+## What is repo-guardian?
+
+**repo-guardian is a GitHub App that keeps every repository in your
+organization compliant with your baseline — automatically, continuously, and
+via pull requests your teams review like any other change.**
+
+You declare *what a healthy repository looks like* in a single HCL policy
+file. repo-guardian watches every repository the App is installed on and:
+
+- **opens PRs** to add missing or drifted configuration files (CODEOWNERS,
+  Dependabot, Renovate, `catalog-info.yaml`, …) rendered from templates,
+- **checks and optionally remediates** repository settings (wikis, merge
+  strategies, vulnerability alerts, …) and branch protection rulesets,
+- **syncs metadata** — e.g. Backstage `catalog-info.yaml` ownership into
+  GitHub custom properties so downstream tools (Wiz, dashboards, CODEOWNERS
+  tooling) can attribute repos to teams,
+- **converges**: when a rule becomes satisfied (someone adds the file by
+  hand), repo-guardian cleans up after itself — refreshes or auto-closes its
+  own PR instead of leaving stale noise.
+
+## The problem it solves
+
+In an org with hundreds or thousands of repositories, configuration drift is
+not a possibility — it's a guarantee:
+
+- New repos get created without CODEOWNERS, so review routing and audit
+  attribution silently break.
+- Dependabot/Renovate configs are copy-pasted once and never updated; half
+  the fleet runs a two-year-old workflow.
+- "Please enable vulnerability alerts on your repos" emails get sent
+  quarterly and actioned never.
+- Ownership metadata lives in a spreadsheet (or nowhere), so security
+  findings can't be routed to a team.
+
+The usual fixes don't scale: wiki checklists rely on humans remembering,
+one-shot scripts fix today's fleet but not next week's new repos, and
+org-level GitHub settings can't create *files* in repositories.
+
+repo-guardian's answer: **policy as code, enforcement as pull requests.**
+The policy is reviewed and versioned like any other code. The enforcement is
+a PR the owning team sees, understands, and merges — not a silent overwrite.
+
+## How it works
+
+```
+                          ┌───────────────────────────────┐
+  GitHub webhooks ───────▶│                               │
+  (repo created,          │   Work queue (Valkey)         │      GitHub API
+   App installed,         │      │                        │   ┌─────────────────┐
+   push to default        │      ▼                        │   │ open/update PRs │
+   branch)                │   Worker pool ──▶ Checker ────┼──▶│ repo settings   │
+                          │   (policy engine)             │   │ rulesets        │
+  Discovery (hourly) ────▶│      │                        │   │ custom props    │
+  Stale sweep ───────────▶│      ▼                        │   │ labels          │
+  (re-check repos older   │   Reconcilers                 │   └─────────────────┘
+   than freshness window) │   (post-check actions)        │
+                          └───────────────────────────────┘
+                           State: Postgres (per-repo check state)
+```
+
+Four things put a repository on the queue:
+
+1. **Webhooks** — the App is installed, a repo is created, or a repo is added
+   to the installation. New repos are checked within seconds.
+2. **Push events** — a push to the default branch that touches a *watched*
+   file (e.g. the Renovate workflow) triggers an immediate re-check.
+3. **Stale sweep** — a leader-elected scheduler periodically re-enqueues any
+   repo whose last check is older than the freshness window (default 24h),
+   or whose last check ran under an older policy version. Change the policy →
+   the whole fleet converges on the next sweep.
+4. **Discovery** — an hourly enumeration of installations catches anything
+   webhooks missed (e.g. repos that existed before the App was installed).
+
+For each repo, the checker evaluates every rule in the policy, bundles all
+actionable file rules into **one PR on one deterministic branch**
+(`repo-guardian/add-missing-files`), and runs any attached reconcilers.
+Everything is idempotent: re-checking a repo with an open PR updates that PR
+in place rather than opening a second one.
+
+## What it can do
+
+**Files** — three check modes, escalating in strictness:
+
+| Mode | Meaning | Example |
+|------|---------|---------|
+| `exists` | File must be present at one of the listed paths | CODEOWNERS anywhere GitHub honors it |
+| `contains` | File must exist **and** pass content assertions (regex, YAML-path) | `renovate.json` must extend the org preset |
+| `exact` | File must match the rendered template exactly | The org-standard Renovate workflow, byte-for-byte (YAML compared semantically) |
+
+Missing or non-compliant files produce a PR with the templated default
+content. Templates are Go `text/template` with per-repo variables and
+helpers — see [Templates in two minutes](#templates-in-two-minutes).
+
+**Repository settings** — 8 properties checked and optionally remediated
+directly via the API (no PR — settings aren't files): vulnerability alerts,
+default branch, issues, wiki, delete-branch-on-merge, and the three merge
+strategies. Each rule chooses `remediate = true` (fix it) or `false` (report
+only, visible in logs and metrics).
+
+**Branch protection** — declarative rules (require PR, approval count,
+dismiss stale reviews, status checks, linear history) checked and optionally
+remediated via the GitHub rulesets API.
+
+**Metadata and post-check reconcilers** — four built-ins that run after a
+rule's file checks pass:
+
+- `custom_properties` — parse Backstage `catalog-info.yaml`, sync ownership
+  and Jira metadata to GitHub custom properties (direct API mode, or a
+  PR-delivered GitHub Action for orgs that want changes reviewed).
+- `label_sync` — manage the repo's label set from a YAML file (create,
+  recolor, rename, optionally delete extras).
+- `branch_protection` — manage rulesets from a YAML file in the repo.
+- `workflow_sync` — lightweight observability for watched workflow files;
+  pairs with push events for instant drift detection.
+
+**PR experience** — fully templatable titles, bodies, and labels with
+three-level inheritance (process defaults → per-rule → per-reconciler).
+A sticky, edit-in-place "reconcile log" comment on every guardian PR shows
+per-rule status. When every rule a PR addresses becomes satisfied on the
+default branch, the PR is auto-closed and its branch deleted (opt-out
+available for compliance workflows that require human close-out).
+
+**Targeting** — glob-based ignore lists (global and per-rule), skip-forks and
+skip-archived toggles, and per-org scoping: one policy file can serve 20
+orgs, with shared rules scoped to `["*"]` and org-specific rules scoped to
+subsets.
+
+**Operations** — dry-run mode (log everything, change nothing), 40+
+Prometheus metrics with per-org labels, starter alert rules, rate-limit
+budgeting per installation (the sweep backs off before you hit GitHub's
+limits), and multi-replica HA via Postgres state + Valkey queue and leader
+election.
+
+## What it doesn't do
+
+Setting these expectations up front avoids the most common misunderstandings:
+
+- **GitHub only (today).** GitLab and Forgejo backends have been
+  investigated (INV-0002/0004/0007) but not built. One binary serves one
+  GitHub App; that App can span many orgs.
+- **It proposes, humans dispose — for files.** File compliance always
+  arrives as a PR. repo-guardian never commits to the default branch and
+  never merges its own PRs. (Settings and branch-protection remediation are
+  the exception — those are direct API writes, and each rule opts in via
+  `remediate = true`.)
+- **Central policy only.** There is one policy per deployment, owned by the
+  platform team. Repos cannot override rules with an in-repo dotfile — by
+  design; exemptions are ignore-list entries in the reviewed, versioned
+  policy, not per-repo opt-outs.
+- **Not a scanner.** It checks the configuration files and settings you
+  declare rules for. It does not scan code, secrets, or dependencies — it's
+  the thing that makes sure your *scanners' config files* exist everywhere.
+- **Not a blocking gate.** It won't stop a merge or fail a check on
+  non-compliance. It nags via PRs and reports via metrics. Pair it with
+  branch protection (which it can configure!) if you need hard gates.
+- **Templates are content defaults, not per-repo intelligence.** A generated
+  CODEOWNERS is a sensible starting point with per-repo variables filled in —
+  the owning team still reviews and adjusts it in the PR.
+- **One App credential.** All orgs are served by the same GitHub App key
+  (per-org credentials investigated in INV-0006, deferred).
+
+## The policy: a five-minute tour
+
+Everything repo-guardian does is driven by one HCL file (or a directory of
+them), pointed to by `GUARDIAN_CONFIG`. A representative policy:
+
+```hcl
+guardian {
+  dry_run       = false
+  skip_forks    = true
+  skip_archived = true
+}
+
+# Repos no rule should ever touch (glob patterns).
+ignore {
+  repos = ["myorg/terraform-*", "myorg/archive-*"]
+}
+
+# Process-wide PR text. Every rule inherits this unless it overrides.
+defaults {
+  pr {
+    title  = "chore: repo-guardian baseline for {{ .Repo }}"
+    labels = ["automated", "guardian"]
+  }
+}
+
+# Simplest rule: the file just has to exist somewhere GitHub honors it.
+rule "file" "codeowners" {
+  check    = "exists"
+  paths    = ["CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"]
+  target   = ".github/CODEOWNERS"   # where the PR creates it if missing
+  template = "codeowners"           # which template renders the content
+}
+
+# Content-checked rule: exists AND extends the org preset.
+rule "file" "renovate_config" {
+  check    = "contains"
+  paths    = ["renovate.json", ".github/renovate.json"]
+  target   = "renovate.json"
+  template = "renovate"
+
+  assertion {
+    pattern = "github>myorg/renovate-config"
+    message = "renovate.json must extend the org preset"
+  }
+}
+
+# File rule + reconciler: after catalog-info checks pass, sync its
+# ownership metadata to GitHub custom properties.
+rule "file" "catalog_info" {
+  check    = "contains"
+  paths    = ["catalog-info.yaml", "catalog-info.yml"]
+  target   = "catalog-info.yaml"
+  template = "catalog-info"
+
+  assertion {
+    yaml_path = "spec.owner"
+    non_empty = true
+    message   = "spec.owner must be set"
+  }
+
+  reconcile "custom_properties" {
+    mode  = "api"
+    watch = true   # pushes touching this file trigger instant re-checks
+  }
+}
+
+# Settings are checked and (here) fixed directly — no PR.
+rule "setting" "vuln_alerts" {
+  property  = "vulnerability_alerts_enabled"
+  expected  = true
+  remediate = true
+}
+
+# Branch protection via the rulesets API.
+rule "branch_protection" "main" {
+  branch             = "main"
+  require_pr         = true
+  required_approvals = 1
+  remediate          = true
+}
+```
+
+The mental model:
+
+- **`rule` blocks are the policy.** Three types: `file`, `setting`,
+  `branch_protection`. Each is independently enabled, ignorable, and
+  scopeable.
+- **`assertion` blocks make `contains` rules precise** — regex over the raw
+  file, or structural checks against a YAML path.
+- **`reconcile` blocks attach behaviors** that run after a file rule's
+  checks pass.
+- **`pr` blocks control what humans see**, with inheritance so you write the
+  boilerplate once.
+- **If you provide an HCL file, it replaces the built-in defaults
+  entirely** — you declare everything you want. No file at all gives you the
+  built-in starter policy (CODEOWNERS + Dependabot enabled; Renovate rules
+  present but disabled).
+
+Ready-to-adapt policies live in [`examples/`](https://github.com/donaldgifford/repo-guardian/tree/main/examples),
+from `guardian-minimal.hcl` to a multi-org enterprise layout.
+
+## Templates in two minutes
+
+The file content that lands in PRs comes from templates: five embedded
+defaults (CODEOWNERS, Dependabot, Renovate config + workflow, catalog-info)
+that operators can override or extend by mounting files into `TEMPLATE_DIR`
+(the Helm chart exposes this as a simple `templates.files` values map).
+
+Templates are Go `text/template` over per-repo variables:
+
+```text
+# {{ .Repo }} is owned by the platform team
+* @{{ .Owner }}/platform-team
+```
+
+PR titles and bodies are templates too, with extras like `{{ .Files }}` (the
+list of paths in the PR) and Backstage catalog fields for catalog-aware
+rules. A curated helper set (`env`, `default`, `join`, `lower`, `upper`,
+`title`) covers common needs — e.g. Jira-prefixed PR titles via
+`{{ env "JIRA_PROJECT" | default "PLAT" }}`. Full details in the
+[Policy Reference](policy-reference.md#template-reference).
+
+## Rolling it out (demo script)
+
+The safe on-ramp, and a natural live-demo sequence:
+
+1. **Install the GitHub App** on one org, scoped to a couple of test repos.
+   The App needs a public HTTPS webhook endpoint.
+2. **Deploy the Helm chart** (`oci://ghcr.io/donaldgifford/charts/repo-guardian`)
+   with `DRY_RUN=true`. Out of the box the chart brings its own Postgres and
+   Valkey. Note: the `DRY_RUN` env var wins over the policy file — handy as
+   an operator safety catch.
+3. **Watch the logs** — dry-run logs every PR it *would* open and every
+   setting it *would* change. This is where the policy gets tuned: add
+   ignore patterns, adjust paths, fix assertions.
+4. **Flip dry-run off.** Delete a CODEOWNERS from a test repo, push to a
+   watched file, or wait for the sweep — then walk through the PR it opens:
+   templated content, labels, the sticky reconcile-log comment.
+5. **Show convergence**: hand-add the missing file on the default branch and
+   re-check — repo-guardian auto-closes its own PR and deletes its branch.
+6. **Scale out**: widen the App installation, add orgs to the policy `scope`,
+   and let discovery + the stale sweep bring the fleet in gradually — the
+   rate-limit budget gate paces enqueues so a 2,000-repo onboarding doesn't
+   burn the API budget in one tick.
+
+## Where to go next
+
+- **[Policy Reference](policy-reference.md)** — every block, attribute,
+  default, and validation rule in the HCL policy.
+- **[`examples/`](https://github.com/donaldgifford/repo-guardian/tree/main/examples)** — runnable policies from
+  minimal to multi-org enterprise.
+- **[Adding a New Rule](../ADDING_RULES.md)** — extend repo-guardian itself
+  with new rule types or reconcilers.
+- **[Helm chart README](https://github.com/donaldgifford/repo-guardian/tree/main/charts/repo-guardian)**
+  — deployment shapes (baked/CNPG/external Postgres, Valkey modes),
+  values, and security posture.
+- **[Operations docs](../operations/scaling.md)** — scaling, metrics,
+  alerts, and migration runbooks.

--- a/docs/usage/policy-reference.md
+++ b/docs/usage/policy-reference.md
@@ -1,0 +1,549 @@
+# Policy Reference (guardian.hcl)
+
+The complete specification of repo-guardian's HCL policy surface: every
+block, attribute, type, default, and validation rule. For a guided
+introduction, start with [Getting Started](getting-started.md).
+
+Source of truth: `internal/policy/` (`types.go`, `defaults.go`, `loader.go`,
+`validate.go`). This document tracks the code; when in doubt, the loader wins.
+
+## Loading and precedence
+
+- **Location** — set `GUARDIAN_CONFIG` to a single `.hcl` file **or a
+  directory** of `.hcl` files (all files are parsed and merged; the
+  multi-file layout in `examples/guardian-multi-org/` is the canonical
+  split).
+- **Merge order** — `built-in defaults → HCL file → environment variable
+  overrides`. Env vars are applied last and always win (see
+  [Environment overrides](#environment-variable-overrides)).
+- **Rules are replace, not merge** — if your HCL declares *any* rule, the
+  built-in file rules are replaced entirely. Declare everything you want.
+  With no HCL config at all, the built-in defaults apply (see
+  [Built-in defaults](#built-in-defaults)).
+- **Strict-mode exception** — when a top-level `scope {}` block is present
+  and you declare no rules, the loader does **not** fall back to built-in
+  rules (the "every rule declares its scope" contract couldn't hold).
+- **Validation is fail-fast** — all violations are collected and reported
+  together at startup; the process exits non-zero on any error.
+
+## Grammar overview
+
+```hcl
+guardian    { ... }                    # operational settings (0 or 1)
+ignore      { repos = [...] }          # global ignore list (0 or 1)
+scope       { orgs = [...] }           # org universe; presence = strict mode (0 or 1)
+defaults    { pr { ... } }             # process-wide PR template defaults (0 or 1)
+
+rule "file" "<name>" {                 # file compliance rule (0+)
+  ...
+  assertion { ... }                    # content assertions (0+, contains mode only)
+  pr        { ... }                    # PR template + search terms (0 or 1)
+  ignore    { repos = [...] }          # per-rule ignore (0 or 1)
+  scope     { orgs = [...] }           # per-rule scope (required in strict mode)
+  reconcile "<type>" {                 # post-check reconcilers (0+)
+    ...
+    pr { ... }                         # per-reconciler PR template (0 or 1)
+  }
+}
+
+rule "setting" "<name>" { ... }            # repo setting rule (0+)
+rule "branch_protection" "<name>" { ... }  # branch protection rule (0+)
+```
+
+Rule blocks are routed on their first label: `"file"`, `"setting"`, or
+`"branch_protection"`. The second label is the rule's unique name — a
+duplicate `type:name` pair fails validation.
+
+## `guardian {}` — operational settings
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `dry_run` | bool | `false` | Log intended actions without creating PRs or writing to GitHub. |
+| `schedule_interval` | string (Go duration) | `"168h"` | Cadence of the scheduled stale sweep. |
+| `worker_count` | int | `5` | Concurrent repo-check workers. Must be > 0. |
+| `queue_size` | int | `1000` | Work queue buffer size. Must be > 0. |
+| `log_level` | string | `"info"` | One of `debug`, `info`, `warn`, `error`. |
+| `skip_forks` | bool | `true` | Skip forked repositories. |
+| `skip_archived` | bool | `true` | Skip archived repositories. |
+| `rate_limit_threshold` | float | `0.10` | Fraction of remaining rate-limit budget at which pre-emptive throttling begins. Must be in [0.0, 1.0]. |
+| `webhook_ip_allowlist` | bool | `true` | Enable the GitHub webhook IP allowlist middleware (see `SECURITY.md`). |
+| `webhook_ip_allowlist_fail_open` | bool | `false` | Allow webhook requests when the allowlist can't be fetched. |
+| `trust_proxy_headers` | bool | `false` | Read client IP from `X-Forwarded-For` (required behind Tailscale Funnel or similar proxies). |
+| `auto_close_pr` | bool | `true` | Auto-close a guardian PR (and delete its branch) when every rule it addresses is satisfied on the default branch. Set `false` to keep PRs open for manual close-out. **Note:** currently only the `AUTO_CLOSE_PR` env var is honored — the HCL attribute is accepted but not applied by the loader (known gap). |
+
+Unknown attributes in `guardian {}` are silently ignored — double-check
+spelling, the loader will not error on a typo'd attribute name here.
+
+## `ignore {}` — ignore lists
+
+```hcl
+ignore {
+  repos = ["myorg/terraform-*", "myorg/.github", "myorg/archive-*"]
+}
+```
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `repos` | list(string) | Glob patterns matched against `owner/name` (Go `path.Match` semantics, input lowercased). |
+
+Appears in two places:
+
+- **Top level** — matching repos are skipped for **all** rules.
+- **Inside any rule** — matching repos are skipped for **that rule only**.
+
+Precedence relative to scope: scope is evaluated first, ignore second. The
+`out_of_scope_total` and `ignored_total` metrics never both increment for
+the same rule on the same repo.
+
+## `scope {}` — org scoping (multi-org)
+
+```hcl
+# Top level: declares the org universe AND engages strict mode.
+scope {
+  orgs = ["prod-org", "staging-org"]
+}
+
+rule "file" "codeowners" {
+  # In strict mode every rule MUST declare its own scope.
+  scope { orgs = ["*"] }   # "*" = every org in the top-level universe
+  ...
+}
+```
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `orgs` | list(string) | Org glob patterns (`path.Match`, lowercased). At rule level, the literal `"*"` means "every in-scope org." |
+
+Two modes:
+
+- **Legacy mode** (no top-level `scope {}`) — every rule applies to every
+  repo the App installation can see. A per-rule `scope` without a top-level
+  `scope` is allowed but logs a warning at load time.
+- **Strict mode** (top-level `scope {}` present) — repos outside the
+  universe are skipped entirely, and **every rule must declare its own
+  `scope {}`** (validated at load). No built-in rule fallback applies in
+  strict mode.
+
+Out-of-scope skips are observable via
+`repo_guardian_out_of_scope_total{level="policy"|"rule"}`.
+
+## `defaults {}` — process-wide PR defaults
+
+```hcl
+defaults {
+  pr {
+    title  = "chore: guardian baseline for {{ .Repo }}"
+    body   = "..."
+    labels = ["automated", "guardian"]
+  }
+}
+```
+
+Contains a single optional `pr {}` block (schema [below](#pr-pull-request-templates)).
+Every rule-level and reconciler-level `pr {}` inherits from it
+field-by-field unless it opts out.
+
+## `rule "file" "<name>" {}` — file rules
+
+```hcl
+rule "file" "codeowners" {
+  enabled  = true                                  # optional, default true
+  check    = "exists"                              # exists | contains | exact
+  paths    = ["CODEOWNERS", ".github/CODEOWNERS"]  # required
+  target   = ".github/CODEOWNERS"                  # required
+  template = "codeowners"                          # required
+}
+```
+
+| Attribute | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | bool | no | `true` | Disabled rules are skipped entirely. |
+| `check` | string | no | `"exists"` | One of `exists`, `contains`, `exact`. |
+| `paths` | list(string) | **yes** | — | Candidate locations checked in order; the rule is satisfied by the first hit (subject to mode). Must be non-empty. |
+| `target` | string | **yes** | — | Path where the PR creates the file when missing. |
+| `template` | string | **yes** | — | Template name (TemplateStore key, no `.tmpl` suffix) used to render the file content. |
+
+Nested blocks: `assertion` (0+), `pr` (0 or 1), `ignore` (0 or 1), `scope`
+(0 or 1), `reconcile` (0+).
+
+### Check modes
+
+| Mode | File present? | Content checked? | Actionable when |
+|------|--------------|------------------|-----------------|
+| `exists` | required | no | No candidate path exists. |
+| `contains` | required | assertions must pass | File missing, or any assertion fails. |
+| `exact` | required | must equal rendered template | File missing or differs from the template. YAML files (`.yml`/`.yaml`) compare semantically (key order and formatting don't matter); everything else compares bytes. |
+
+Declaring `assertion` blocks on a rule whose mode is not `contains` is a
+validation error.
+
+### `assertion {}` — content assertions
+
+Two families, chosen per block: **regex** over the raw file, or
+**YAML-path** structural checks.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `pattern` | string | Regex (Go RE2) that must match somewhere in the file. |
+| `not_pattern` | string | Regex that must **not** match anywhere in the file. |
+| `yaml_path` | string | Dotted path into the parsed YAML document (e.g. `spec.owner`). |
+| `contains` | string | With `yaml_path`: the resolved value must contain this substring. |
+| `equals` | string | With `yaml_path`: the resolved value must equal this string. |
+| `non_empty` | bool | With `yaml_path`: the path must exist and resolve to a non-empty value. |
+| `message` | string (**required**) | Human-readable failure text; appears in logs and PR bodies. |
+
+Validation rules (enforced at load):
+
+- `message` is required.
+- `pattern`/`not_pattern` and `yaml_path` are **mutually exclusive** per
+  block (use multiple `assertion` blocks to combine families).
+- `yaml_path` requires exactly one of `contains`, `equals`, or `non_empty`.
+- Every block must set at least one of `pattern`, `not_pattern`, `yaml_path`.
+
+```hcl
+assertion {
+  pattern = "github>myorg/renovate-config"
+  message = "renovate.json must extend the org preset"
+}
+
+assertion {
+  yaml_path = "spec.owner"
+  contains  = "team"
+  message   = "spec.owner must reference a team"
+}
+
+assertion {
+  not_pattern = "TODO"
+  message     = "no TODO placeholders"
+}
+```
+
+## `rule "setting" "<name>" {}` — repository setting rules
+
+```hcl
+rule "setting" "enable_vuln_alerts" {
+  property  = "vulnerability_alerts_enabled"
+  expected  = true
+  remediate = true
+}
+```
+
+| Attribute | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | bool | no | `true` | Disabled rules are skipped. |
+| `property` | string | **yes** | — | One of the supported properties below. |
+| `expected` | bool or string | **yes** | — | Desired value. Type must match the property (validated at load). |
+| `remediate` | bool | no | `false` | `true`: write the expected value via the API. `false`: report only. |
+
+Nested blocks: `ignore`, `scope`.
+
+Supported properties and their `expected` types:
+
+| Property | Type |
+|----------|------|
+| `vulnerability_alerts_enabled` | bool |
+| `default_branch` | string |
+| `has_issues` | bool |
+| `has_wiki` | bool |
+| `delete_branch_on_merge` | bool |
+| `allow_merge_commit` | bool |
+| `allow_squash_merge` | bool |
+| `allow_rebase_merge` | bool |
+
+Setting remediation is a **direct API write** — settings are not files, so
+there is no PR to review. Use `remediate = false` first to survey the fleet
+via logs/metrics before enabling writes.
+
+## `rule "branch_protection" "<name>" {}` — branch protection rules
+
+```hcl
+rule "branch_protection" "main_protection" {
+  branch                 = "main"
+  require_pr             = true
+  required_approvals     = 1
+  dismiss_stale_reviews  = true
+  require_status_checks  = ["ci/test"]
+  require_linear_history = true
+  enforce_admins         = false
+  remediate              = true
+}
+```
+
+| Attribute | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `enabled` | bool | no | `true` | Disabled rules are skipped. |
+| `branch` | string | **yes** | — | Branch name the ruleset targets. |
+| `require_pr` | bool | no | `false` | Require a pull request before merging. |
+| `required_approvals` | int | no | `0` | Required approving review count. Must be ≥ 0. |
+| `dismiss_stale_reviews` | bool | no | `false` | Dismiss approvals when new commits land. |
+| `require_status_checks` | list(string) | no | `[]` | Status check contexts that must pass. |
+| `enforce_admins` | bool | no | `false` | Apply the rules to administrators too. |
+| `require_linear_history` | bool | no | `false` | Forbid merge commits on the branch. |
+| `remediate` | bool | no | `false` | `true`: create/update the ruleset via the rulesets API. `false`: report only. |
+
+Nested blocks: `ignore`, `scope`. Repos where the target branch doesn't
+exist are handled gracefully (skipped, not errored).
+
+## `reconcile "<type>" {}` — reconcilers
+
+Reconcilers attach to **file rules** and run after the rule's checks pass.
+The block label selects one of four built-in types.
+
+| Attribute | Type | Default | Applies to | Description |
+|-----------|------|---------|------------|-------------|
+| `watch` | bool | `false` | all | Register the rule's paths as watched: a push to the default branch touching them triggers an immediate re-check. |
+| `mode` | string | — | `custom_properties` | `"api"` or `"github-action"` (required for this type). |
+| `delete_extra` | bool | `false` | `label_sync` | Delete repo labels not present in the YAML source. |
+| `pr {}` | block | — | all | Per-reconciler PR template (merges with `defaults.pr` **only** — deliberately skips the rule's `pr`). |
+
+### `custom_properties`
+
+Parses the repo's Backstage `catalog-info.yaml` and syncs ownership/Jira
+metadata to GitHub repository custom properties.
+
+- `mode = "api"` — write properties directly via the API.
+- `mode = "github-action"` — open a PR adding a workflow that sets the
+  properties from within the repo (for orgs that want the change reviewed,
+  or Apps without org-level property permissions).
+
+### `label_sync`
+
+Manages the repo's labels from the YAML file the rule targets:
+
+```yaml
+labels:
+  - name: bug
+    color: d73a4a
+    description: Something isn't working
+  - name: feature            # renames "enhancement" if it exists
+    color: a2eeef
+    renamed_from: enhancement
+```
+
+Creates missing labels, updates color/description drift, applies renames
+via `renamed_from`, and — only when `delete_extra = true` — removes labels
+not listed.
+
+### `branch_protection`
+
+Manages branch protection rulesets from the YAML file the rule targets
+(per-repo, data-driven variant of `rule "branch_protection"`):
+
+```yaml
+rules:
+  - branch: main
+    require_pr: true
+    required_approvals: 2
+    dismiss_stale_reviews: true
+    require_status_checks: ["ci/test"]
+    require_linear_history: true
+```
+
+### `workflow_sync`
+
+Lightweight observability for watched workflow files — logs and counts
+drift events for the rule's paths. Pair with `watch = true` and
+`check = "exact"` for immediate detection when someone edits the
+org-standard workflow.
+
+## `pr {}` — pull request templates
+
+Valid at three scopes: `defaults { pr {} }`, `rule "file" { pr {} }`, and
+`reconcile "<type>" { pr {} }`.
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `search_terms` | list(string) | Substrings used to find an existing open guardian PR for this rule (rule scope only in practice). |
+| `title` | string (template) | PR title template. Parse errors fail policy load with a location-prefixed message. |
+| `body` | string (template) | PR body template. Bodies over 65,000 characters are truncated with an HTML-comment marker appended. |
+| `labels` | list(string) | Labels applied to the PR. `labels = []` is an explicit "no labels" override, distinct from omitting the attribute. |
+| `inherits` | bool | Default `true`. When `true`, fields you leave unset inherit from the parent scope. `false` stops inheritance entirely — unset fields fall through to engine built-ins. |
+
+Resolution rules:
+
+- **Field-by-field merge, child wins.** A rule that sets only `title` gets
+  `body` and `labels` from `defaults.pr`.
+- **Reconciler PRs merge `reconcile.pr → defaults.pr` only** — the enclosing
+  rule's `pr` is deliberately skipped.
+- **Multi-rule bundles** (several file rules landing in one PR): each rule's
+  title is rendered; on conflict the bundle falls back to `defaults.pr.title`
+  (or the built-in title) and logs the ignored titles. Bundle bodies always
+  use `defaults.pr.body` — per-rule bodies are implicitly single-rule.
+
+## Template reference
+
+Policy `pr.title`/`pr.body` strings and all file templates are Go
+`text/template`, compiled at policy-load time.
+
+### Variables — PR templates (`PRVars`)
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `.Owner` | string | Org or user login owning the repo. |
+| `.Repo` | string | Repository name (no owner prefix). |
+| `.DefaultBranch` | string | The repo's default branch. |
+| `.Date` | string | RFC3339 timestamp at render time. |
+| `.Rule.Name` / `.Rule.Target` | string | The firing rule's name and target path (single-rule PRs). |
+| `.Rules` | list | Every firing rule in a bundled PR (`{Name, Target}` each); nil for single-rule PRs. |
+| `.Files` | list(string) | Every file path included in the PR. |
+| `.Reconciler` | string | Reconciler name when the PR was opened by a reconciler; empty otherwise. |
+
+### Variables — file templates (`FileVars`)
+
+`.Owner`, `.Repo`, `.DefaultBranch`, `.Date`, and `.Rule` as above, plus:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `.Org` | string | Convenience alias for the owner login. |
+| `.Catalog` | object or nil | Parsed catalog-info fields for catalog-aware templates: `.Owner`, `.Component`, `.JiraProject`, `.JiraLabel`. **Guard with `{{ if .Catalog }}`** — it is nil for most rules. |
+
+### Helpers
+
+| Helper | Usage | Result |
+|--------|-------|--------|
+| `env` | `{{ env "JIRA_PROJECT" }}` | Value of the process env var, `""` if unset. Never reference secrets — rendered output is public PR text. |
+| `default` | `{{ .Field \| default "fallback" }}` | `fallback` when the value is empty. |
+| `join` | `{{ .Files \| join ", " }}` | Slice joined with the separator. |
+| `lower` / `upper` | `{{ lower .Repo }}` | Case conversion. |
+| `title` | `{{ title "hello world" }}` | Uppercases each word's first ASCII letter (`Hello World`); leaves the rest untouched. |
+
+### Escaping literal `{{ }}` (GitHub Actions templates)
+
+Templates that must emit literal `${{ ... }}` (GHA expressions) wrap them in
+a raw-string action — a bare `${{` anywhere in a template (even a comment)
+is a parse error:
+
+```text
+{{`${{ secrets.GITHUB_TOKEN }}`}}
+```
+
+### Strict validation
+
+`STRICT_TEMPLATES=true` (or `--strict-templates`) validates every compiled
+PR template against a zero-value context at startup — typo'd field names
+fail the boot instead of a render at 2am. File-content templates are not
+strict-validated (legitimate catalog references would false-positive).
+
+## Built-in defaults
+
+With no `GUARDIAN_CONFIG` set, this policy applies:
+
+| Rule | Mode | Enabled | Paths → Target | Notes |
+|------|------|---------|----------------|-------|
+| `codeowners` | exists | ✅ | `CODEOWNERS`, `.github/CODEOWNERS`, `docs/CODEOWNERS` → `.github/CODEOWNERS` | |
+| `dependabot` | exists | ✅ | `.github/dependabot.yml`, `.github/dependabot.yaml` → `.github/dependabot.yml` | |
+| `renovate_config` | contains | ❌ | `renovate.json`, `renovate.json5`, `.renovaterc`, `.renovaterc.json`, `.github/renovate.json`, `.github/renovate.json5` → `renovate.json` | Assertion: must match `github>.*renovate-config`. |
+| `renovate_workflow` | exact | ❌ | `.github/workflows/renovate.yml` | `workflow_sync` reconciler with `watch = true`. |
+| `catalog_info` | exists | only when `CUSTOM_PROPERTIES_MODE` is set | `catalog-info.yaml`, `catalog-info.yml` → `catalog-info.yaml` | `custom_properties` reconciler in the env var's mode (backward compat). |
+
+## Environment variable overrides
+
+Env vars are applied **after** HCL and win. The `guardian {}`-scope
+overrides:
+
+| Env var | Overrides |
+|---------|-----------|
+| `DRY_RUN` | `guardian.dry_run` |
+| `SCHEDULE_INTERVAL` | `guardian.schedule_interval` |
+| `WORKER_COUNT` | `guardian.worker_count` |
+| `QUEUE_SIZE` | `guardian.queue_size` |
+| `LOG_LEVEL` | `guardian.log_level` |
+| `SKIP_FORKS` | `guardian.skip_forks` |
+| `SKIP_ARCHIVED` | `guardian.skip_archived` |
+| `RATE_LIMIT_THRESHOLD` | `guardian.rate_limit_threshold` |
+| `WEBHOOK_IP_ALLOWLIST` | `guardian.webhook_ip_allowlist` |
+| `WEBHOOK_IP_ALLOWLIST_FAIL_OPEN` | `guardian.webhook_ip_allowlist_fail_open` |
+| `TRUST_PROXY_HEADERS` | `guardian.trust_proxy_headers` |
+| `AUTO_CLOSE_PR` | `guardian.auto_close_pr` |
+
+Related policy/template env vars (not `guardian {}` attributes):
+
+| Env var | Effect |
+|---------|--------|
+| `GUARDIAN_CONFIG` | Path to the policy file or directory. |
+| `TEMPLATE_DIR` | Directory of template overrides (default `/etc/repo-guardian/templates`). |
+| `STRICT_TEMPLATES` | Enable strict PR-template validation at startup. |
+| `CUSTOM_PROPERTIES_MODE` | Backward-compat: injects the `catalog_info` built-in rule when no HCL config is present. Ignored when HCL defines file rules. |
+
+Deployment-level configuration (GitHub App credentials, listen addresses,
+store/queue backends, sweep freshness, discovery tuning) is env-var-only
+and documented in the
+[Helm chart README](https://github.com/donaldgifford/repo-guardian/tree/main/charts/repo-guardian)
+and [scaling guide](../operations/scaling.md).
+
+## Validation reference
+
+Startup fails (all errors reported together) when:
+
+- `guardian.worker_count` ≤ 0, `guardian.queue_size` ≤ 0,
+  `guardian.rate_limit_threshold` outside [0.0, 1.0], or
+  `guardian.log_level` not in `debug|info|warn|error`.
+- Any file rule: `check` not in `exists|contains|exact`; empty `paths`,
+  `target`, or `template`; assertions on a non-`contains` rule; any
+  assertion violating the [assertion rules](#assertion-content-assertions).
+- Any setting rule: empty name, unsupported `property`, missing `expected`,
+  or `expected` type not matching the property.
+- Any branch-protection rule: empty name or `branch`,
+  `required_approvals` < 0.
+- Duplicate rule names within a rule type.
+- Any `pr.title`/`pr.body` template that fails to parse.
+- Strict mode: a rule without its own `scope {}` block.
+- A `reconcile "custom_properties"` block whose `mode` is not `api` or
+  `github-action` (fails at engine construction).
+
+## Cookbook
+
+Minimal starting points — full runnable versions in
+[`examples/`](https://github.com/donaldgifford/repo-guardian/tree/main/examples).
+
+**1. Baseline files only** (mirror the built-ins, PRs only, no writes):
+`guardian-minimal.hcl`.
+
+**2. Enforce the org Renovate preset:**
+
+```hcl
+rule "file" "renovate_config" {
+  check    = "contains"
+  paths    = ["renovate.json", ".github/renovate.json"]
+  target   = "renovate.json"
+  template = "renovate"
+  assertion {
+    pattern = "github>myorg/renovate-config"
+    message = "must extend the org preset"
+  }
+}
+```
+
+**3. Catalog-driven ownership → GitHub custom properties:**
+
+```hcl
+rule "file" "catalog_info" {
+  check    = "contains"
+  paths    = ["catalog-info.yaml", "catalog-info.yml"]
+  target   = "catalog-info.yaml"
+  template = "catalog-info"
+  assertion {
+    yaml_path = "spec.owner"
+    non_empty = true
+    message   = "spec.owner must be set"
+  }
+  reconcile "custom_properties" {
+    mode  = "api"
+    watch = true
+  }
+}
+```
+
+**4. Settings hardening, survey first:**
+
+```hcl
+rule "setting" "vuln_alerts"  { property = "vulnerability_alerts_enabled" expected = true  remediate = false }
+rule "setting" "no_wiki"      { property = "has_wiki"                     expected = false remediate = false }
+rule "setting" "tidy_merges"  { property = "delete_branch_on_merge"       expected = true  remediate = false }
+# Watch repo_guardian metrics + logs, then flip remediate = true.
+```
+
+**5. Multi-org strict mode** — shared rules on `["*"]`, org-specific rules
+on subsets: `guardian-multi-org.hcl` (single file) or `guardian-multi-org/`
+(directory layout), and `guardian-enterprise.hcl` for the one-App-many-orgs
+enterprise topology.

--- a/examples/guardian-full.hcl
+++ b/examples/guardian-full.hcl
@@ -14,7 +14,6 @@
 #   exact    — file must match the template exactly
 
 guardian {
-  org               = "myorg"
   log_level         = "info"
   dry_run           = false
   worker_count      = 5

--- a/mkdocs-ghpages.yml
+++ b/mkdocs-ghpages.yml
@@ -2,6 +2,9 @@
 # $schema=https://json.schemastore.org/mkdocs-1.6.json
 nav:
   - Home: index.md
+  - Usage:
+      - Getting Started: usage/getting-started.md
+      - Policy Reference: usage/policy-reference.md
   - ADRs:
       - Overview: adr/README.md
   - Adding a New Rule to Repo Guardian: ADDING_RULES.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,8 @@
 nav:
     - Home: index.md
+    - Usage:
+        - Getting Started: usage/getting-started.md
+        - Policy Reference: usage/policy-reference.md
     - ADRs:
         - Overview: adr/README.md
     - Adding a New Rule to Repo Guardian: ADDING_RULES.md


### PR DESCRIPTION
## Summary

Adds a new `docs/usage/` section — the onboarding/presentation material requested for walking new users through repo-guardian, plus the detailed policy spec.

- **`docs/usage/getting-started.md`** — walkthrough/presentation-style intro: what repo-guardian is, the problem it solves, how it works (trigger sources → queue → checker → reconcilers), a capability tour (files / settings / branch protection / reconcilers / PR experience / targeting / operations), an explicit **what it doesn't do** section, a five-minute HCL policy tour, a template primer, and a dry-run-first rollout sequence that doubles as a live-demo script.
- **`docs/usage/policy-reference.md`** — the complete `guardian.hcl` schema: every block, attribute, type, default, and validation rule (sourced from `internal/policy/` — `types.go`, `defaults.go`, `loader.go`, `validate.go`), reconciler YAML schemas, PR template resolution rules, template contexts + helpers, env-var override table, built-in defaults, and a cookbook. This effectively delivers **INV-0008 Phase 1** (hand-written DSL reference; PR #94).

Also:
- Wired both docs into `mkdocs.yml` + `mkdocs-ghpages.yml` nav (new **Usage** section after Home) and linked from `docs/index.md`.
- Removed the dead `org = "myorg"` attribute from `examples/guardian-full.hcl` — the loader silently ignores unknown `guardian {}` attributes and no `org` field exists.

## Verification

- `mkdocs build` clean for the new docs (fixed two anchor slugs; converted `examples/` links to GitHub URLs since that tree is outside the docs root — no new build warnings added).

## Known gap surfaced while writing the reference

`guardian { auto_close_pr }` is declared in `types.go` with an HCL tag, but `setGuardianAttr` in `internal/policy/loader.go` has no case for it — the HCL attribute is silently dropped; only the `AUTO_CLOSE_PR` env var works. Noted in the reference table; fix is a follow-up (2-line loader case + merge handling + test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)