### PR TITLE
fix(chart): operator-supplied password for baked Postgres/Valkey (GitOps-safe)

### DIFF
--- a/charts/repo-guardian/Chart.yaml
+++ b/charts/repo-guardian/Chart.yaml
@@ -4,5 +4,5 @@ apiVersion: v2
 name: repo-guardian
 description: GitHub App that automates repository onboarding and compliance
 type: application
-version: 1.0.0-rc.3
+version: 1.0.0-rc.4
 appVersion: "1.9.0"

--- a/charts/repo-guardian/README.md
+++ b/charts/repo-guardian/README.md
@@ -13,7 +13,7 @@ SLSA Level 3 provenance attestations.
 ```bash
 helm install repo-guardian \
   oci://ghcr.io/donaldgifford/charts/repo-guardian \
-  --version 1.0.0-rc.2 \
+  --version 1.0.0-rc.4 \
   --namespace repo-guardian \
   --create-namespace \
   -f values.yaml
@@ -28,7 +28,7 @@ aws ecr get-login-password --region <region> | \
 
 helm install repo-guardian \
   oci://<account>.dkr.ecr.<region>.amazonaws.com/repo-guardian-chart \
-  --version 1.0.0-rc.2 \
+  --version 1.0.0-rc.4 \
   --namespace repo-guardian \
   --create-namespace \
   -f values.yaml
@@ -64,7 +64,7 @@ secrets:
 ```bash
 helm install repo-guardian \
   oci://ghcr.io/donaldgifford/charts/repo-guardian \
-  --version 1.0.0-rc.2 \
+  --version 1.0.0-rc.4 \
   --namespace repo-guardian \
   --create-namespace \
   -f values.yaml
@@ -192,7 +192,7 @@ cosign verify \
     '^https://github.com/donaldgifford/repo-guardian/.+' \
   --certificate-oidc-issuer \
     'https://token.actions.githubusercontent.com' \
-  ghcr.io/donaldgifford/charts/repo-guardian:1.0.0-rc.2
+  ghcr.io/donaldgifford/charts/repo-guardian:1.0.0-rc.4
 ```
 
 ### SLSA provenance
@@ -203,7 +203,7 @@ cosign verify-attestation --type slsaprovenance \
     '^https://github.com/slsa-framework/slsa-github-generator/.+' \
   --certificate-oidc-issuer \
     'https://token.actions.githubusercontent.com' \
-  ghcr.io/donaldgifford/charts/repo-guardian:1.0.0-rc.2
+  ghcr.io/donaldgifford/charts/repo-guardian:1.0.0-rc.4
 ```
 
 The provenance attestation records the build workflow path, source
@@ -422,12 +422,14 @@ incoming webhook.
 | prometheusRule.alerts | object | `{}` | Per-alert overrides: each key under `alerts.<name>` accepts `for`, `severity`, `threshold`, and `enabled`. See the rendered PrometheusRule template for the canonical alert names. |
 | prometheusRule.enabled | bool | `false` | Create PrometheusRule with starter alerts. |
 | prometheusRule.labels | object | `{}` | Additional labels (e.g., to match Prometheus operator `ruleSelector`). |
-| queue | object | `{"backend":"valkey","size":1000,"valkey":{"baked":{"authPasswordLength":32,"image":"valkey/valkey:9.1","podSecurityContext":{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999},"storageClassName":"","storageSize":"1Gi"},"existingSecret":"","existingSecretKey":"QUEUE_VALKEY_DSN","jobAckTimeout":"5m","mode":"baked","reaperInterval":"60s"}}` | Work queue for reconcile jobs. The in-memory backend was removed in IMPL-0016 (chart 1.0); valkey is the only supported value. |
+| queue | object | `{"backend":"valkey","size":1000,"valkey":{"baked":{"authPasswordLength":32,"existingSecret":"","existingSecretKey":"VALKEY_PASSWORD","image":"valkey/valkey:9.1","podSecurityContext":{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999},"storageClassName":"","storageSize":"1Gi"},"existingSecret":"","existingSecretKey":"QUEUE_VALKEY_DSN","jobAckTimeout":"5m","mode":"baked","reaperInterval":"60s"}}` | Work queue for reconcile jobs. The in-memory backend was removed in IMPL-0016 (chart 1.0); valkey is the only supported value. |
 | queue.backend | string | `"valkey"` | Backend implementation. Only "valkey" is supported. |
 | queue.size | deprecated | `1000` | Buffered channel size; ignored since the in-memory backend was removed in IMPL-0016. Retained for values-schema backwards compatibility; will be deleted in a future chart-major release. |
-| queue.valkey | object | `{"baked":{"authPasswordLength":32,"image":"valkey/valkey:9.1","podSecurityContext":{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999},"storageClassName":"","storageSize":"1Gi"},"existingSecret":"","existingSecretKey":"QUEUE_VALKEY_DSN","jobAckTimeout":"5m","mode":"baked","reaperInterval":"60s"}` | Valkey-specific configuration. Ignored when backend != valkey. |
-| queue.valkey.baked | object | `{"authPasswordLength":32,"image":"valkey/valkey:9.1","podSecurityContext":{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999},"storageClassName":"","storageSize":"1Gi"}` | Baked Valkey-only configuration. |
+| queue.valkey | object | `{"baked":{"authPasswordLength":32,"existingSecret":"","existingSecretKey":"VALKEY_PASSWORD","image":"valkey/valkey:9.1","podSecurityContext":{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999},"storageClassName":"","storageSize":"1Gi"},"existingSecret":"","existingSecretKey":"QUEUE_VALKEY_DSN","jobAckTimeout":"5m","mode":"baked","reaperInterval":"60s"}` | Valkey-specific configuration. Ignored when backend != valkey. |
+| queue.valkey.baked | object | `{"authPasswordLength":32,"existingSecret":"","existingSecretKey":"VALKEY_PASSWORD","image":"valkey/valkey:9.1","podSecurityContext":{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999},"storageClassName":"","storageSize":"1Gi"}` | Baked Valkey-only configuration. |
 | queue.valkey.baked.authPasswordLength | int | `32` | Generated AUTH password length (random alphanumeric). |
+| queue.valkey.baked.existingSecret | string | `""` | Operator-supplied Secret holding the Valkey password. Same GitOps rationale as store.postgres.baked.existingSecret. When set, the chart skips its generated password Secret; the baked Valkey reads the password from this Secret and the app assembles QUEUE_VALKEY_DSN at runtime via $(VALKEY_PASSWORD). URL-safe (alphanumeric) password required. |
+| queue.valkey.baked.existingSecretKey | string | `"VALKEY_PASSWORD"` | Key inside existingSecret holding the password. |
 | queue.valkey.baked.image | string | `"valkey/valkey:9.1"` | Pinned image. Bump intentionally. |
 | queue.valkey.baked.podSecurityContext | object | `{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999}` | Pod securityContext. Runs Valkey as the image's built-in non-root user (uid/gid 999) so the entrypoint skips its root-only chown of /data (which fails on clusters/storage that forbid chown); fsGroup makes kubelet set volume group ownership instead. Set to `{}` to restore the image default (root entrypoint + chown). |
 | queue.valkey.baked.storageClassName | string | `""` | StorageClass name. Empty → cluster default. |
@@ -466,10 +468,12 @@ incoming webhook.
 | staleSweep.batchSize | int | `200` | Cap on rows returned per StaleRepos query. |
 | staleSweep.freshness | string | `"24h"` | Maximum age of a stored last_checked_at before the sweep requeues. Default 24h. Effective only with store.backend=postgres. |
 | staleSweep.rateLimitReserve | float | `0.1` | Fraction of an installation's GitHub rate-limit budget reserved against the stale-sweep enqueue path. |
-| store | object | `{"backend":"postgres","postgres":{"baked":{"image":"postgres:18.4","podSecurityContext":{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999},"resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}},"storageClassName":"","storageSize":"10Gi"},"cnpg":{"imageName":"ghcr.io/cloudnative-pg/postgresql:18.4","instances":1,"pooler":{"enabled":false,"instances":1,"monitoring":{"enablePodMonitor":false},"pgbouncer":{"defaultPoolSize":25,"maxClientConnections":100,"parameters":{},"poolMode":"transaction"},"service":{"annotations":{},"enabled":false,"labels":{"bgp.cilium.io/advertise-service":"default","bgp.cilium.io/ip-pool":"default"},"type":"LoadBalancer"},"type":"rw"},"storage":{"size":"10Gi","storageClass":""}},"existingSecret":"","existingSecretKey":"STORE_DSN","maxConns":16,"mode":"baked"}}` | Persistent state store (per-repo reconcile state). See DESIGN-0012 §Backend modes. The in-memory backend was removed in IMPL-0016 (chart 1.0); postgres is the only supported value. |
+| store | object | `{"backend":"postgres","postgres":{"baked":{"existingSecret":"","existingSecretKey":"POSTGRES_PASSWORD","image":"postgres:18.4","podSecurityContext":{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999},"resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}},"storageClassName":"","storageSize":"10Gi"},"cnpg":{"imageName":"ghcr.io/cloudnative-pg/postgresql:18.4","instances":1,"pooler":{"enabled":false,"instances":1,"monitoring":{"enablePodMonitor":false},"pgbouncer":{"defaultPoolSize":25,"maxClientConnections":100,"parameters":{},"poolMode":"transaction"},"service":{"annotations":{},"enabled":false,"labels":{"bgp.cilium.io/advertise-service":"default","bgp.cilium.io/ip-pool":"default"},"type":"LoadBalancer"},"type":"rw"},"storage":{"size":"10Gi","storageClass":""}},"existingSecret":"","existingSecretKey":"STORE_DSN","maxConns":16,"mode":"baked"}}` | Persistent state store (per-repo reconcile state). See DESIGN-0012 §Backend modes. The in-memory backend was removed in IMPL-0016 (chart 1.0); postgres is the only supported value. |
 | store.backend | string | `"postgres"` | Backend implementation. Only "postgres" is supported. |
-| store.postgres | object | `{"baked":{"image":"postgres:18.4","podSecurityContext":{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999},"resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}},"storageClassName":"","storageSize":"10Gi"},"cnpg":{"imageName":"ghcr.io/cloudnative-pg/postgresql:18.4","instances":1,"pooler":{"enabled":false,"instances":1,"monitoring":{"enablePodMonitor":false},"pgbouncer":{"defaultPoolSize":25,"maxClientConnections":100,"parameters":{},"poolMode":"transaction"},"service":{"annotations":{},"enabled":false,"labels":{"bgp.cilium.io/advertise-service":"default","bgp.cilium.io/ip-pool":"default"},"type":"LoadBalancer"},"type":"rw"},"storage":{"size":"10Gi","storageClass":""}},"existingSecret":"","existingSecretKey":"STORE_DSN","maxConns":16,"mode":"baked"}` | Postgres-specific configuration. Ignored when backend != postgres. |
-| store.postgres.baked | object | `{"image":"postgres:18.4","podSecurityContext":{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999},"resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}},"storageClassName":"","storageSize":"10Gi"}` | Baked Postgres-only configuration. |
+| store.postgres | object | `{"baked":{"existingSecret":"","existingSecretKey":"POSTGRES_PASSWORD","image":"postgres:18.4","podSecurityContext":{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999},"resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}},"storageClassName":"","storageSize":"10Gi"},"cnpg":{"imageName":"ghcr.io/cloudnative-pg/postgresql:18.4","instances":1,"pooler":{"enabled":false,"instances":1,"monitoring":{"enablePodMonitor":false},"pgbouncer":{"defaultPoolSize":25,"maxClientConnections":100,"parameters":{},"poolMode":"transaction"},"service":{"annotations":{},"enabled":false,"labels":{"bgp.cilium.io/advertise-service":"default","bgp.cilium.io/ip-pool":"default"},"type":"LoadBalancer"},"type":"rw"},"storage":{"size":"10Gi","storageClass":""}},"existingSecret":"","existingSecretKey":"STORE_DSN","maxConns":16,"mode":"baked"}` | Postgres-specific configuration. Ignored when backend != postgres. |
+| store.postgres.baked | object | `{"existingSecret":"","existingSecretKey":"POSTGRES_PASSWORD","image":"postgres:18.4","podSecurityContext":{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999},"resources":{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}},"storageClassName":"","storageSize":"10Gi"}` | Baked Postgres-only configuration. |
+| store.postgres.baked.existingSecret | string | `""` | Operator-supplied Secret holding the Postgres password. When set, the chart does NOT generate its own password Secret; the baked StatefulSet reads the password from this Secret and the app assembles STORE_DSN at runtime via $(POSTGRES_PASSWORD). Use this for GitOps/ArgoCD: the chart's default `lookup`-based password preservation returns nothing under `helm template`, so the generated password rotates on every sync and drifts from the already-initialised data directory (auth failures). Password must be URL-safe (alphanumeric) — it is interpolated into the DSN URL. |
+| store.postgres.baked.existingSecretKey | string | `"POSTGRES_PASSWORD"` | Key inside existingSecret holding the password. |
 | store.postgres.baked.image | string | `"postgres:18.4"` | Pinned image. Bump intentionally. |
 | store.postgres.baked.podSecurityContext | object | `{"fsGroup":999,"fsGroupChangePolicy":"OnRootMismatch","runAsGroup":999,"runAsNonRoot":true,"runAsUser":999}` | Pod securityContext. Runs Postgres as the image's built-in non-root user (uid/gid 999) so the entrypoint skips its root-only chown of PGDATA (which fails on clusters/storage that forbid chown, e.g. restrictive admission policies or NFS root_squash); fsGroup makes kubelet set volume group ownership instead. Set to `{}` to restore the image default (root entrypoint + chown). |
 | store.postgres.baked.resources | object | `{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resource requests/limits for the Postgres container. |

--- a/charts/repo-guardian/templates/deployment.yaml
+++ b/charts/repo-guardian/templates/deployment.yaml
@@ -126,11 +126,25 @@ spec:
             {{- if eq .Values.store.backend "postgres" }}
             - name: STORE_POSTGRES_MAX_CONNS
               value: {{ .Values.store.postgres.maxConns | quote }}
+            {{- if and (eq .Values.store.postgres.mode "baked") .Values.store.postgres.baked.existingSecret }}
+            # Baked Postgres with an operator-supplied password: assemble
+            # STORE_DSN at runtime from $(POSTGRES_PASSWORD) so the chart
+            # never needs the password at template time (GitOps-safe).
+            # POSTGRES_PASSWORD must precede STORE_DSN for $(...) expansion.
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.store.postgres.baked.existingSecret }}
+                  key: {{ .Values.store.postgres.baked.existingSecretKey | default "POSTGRES_PASSWORD" }}
+            - name: STORE_DSN
+              value: "postgres://repoguardian:$(POSTGRES_PASSWORD)@{{ include "repo-guardian.postgresFullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:5432/repoguardian?sslmode=disable"
+            {{- else }}
             - name: STORE_DSN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "repo-guardian.storeSecretName" . }}
                   key: {{ include "repo-guardian.storeSecretKey" . }}
+            {{- end }}
             - name: RECONCILE_FRESHNESS
               value: {{ .Values.staleSweep.freshness | quote }}
             - name: STALE_SWEEP_BATCH_SIZE
@@ -147,11 +161,23 @@ spec:
             - name: DISCOVERY_ESTIMATED_COST_PER_REPO
               value: {{ .Values.discovery.estimatedCostPerRepo | quote }}
             {{- if eq .Values.queue.backend "valkey" }}
+            {{- if and (eq .Values.queue.valkey.mode "baked") .Values.queue.valkey.baked.existingSecret }}
+            # Baked Valkey with an operator-supplied password: assemble
+            # QUEUE_VALKEY_DSN at runtime from $(VALKEY_PASSWORD).
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.queue.valkey.baked.existingSecret }}
+                  key: {{ .Values.queue.valkey.baked.existingSecretKey | default "VALKEY_PASSWORD" }}
+            - name: QUEUE_VALKEY_DSN
+              value: "redis://:$(VALKEY_PASSWORD)@{{ include "repo-guardian.valkeyFullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:6379/0"
+            {{- else }}
             - name: QUEUE_VALKEY_DSN
               valueFrom:
                 secretKeyRef:
                   name: {{ include "repo-guardian.queueSecretName" . }}
                   key: {{ include "repo-guardian.queueSecretKey" . }}
+            {{- end }}
             - name: JOB_ACK_TIMEOUT
               value: {{ .Values.queue.valkey.jobAckTimeout | quote }}
             - name: REAPER_INTERVAL

--- a/charts/repo-guardian/templates/queue-valkey-secret.yaml
+++ b/charts/repo-guardian/templates/queue-valkey-secret.yaml
@@ -1,7 +1,12 @@
-{{- if and (eq .Values.queue.backend "valkey") (eq .Values.queue.valkey.mode "baked") -}}
+{{- if and (eq .Values.queue.backend "valkey") (eq .Values.queue.valkey.mode "baked") (not .Values.queue.valkey.baked.existingSecret) -}}
 {{/*
 Secret for the baked Valkey deployment. Uses `lookup` to preserve the
 existing password across `helm upgrade`.
+
+NOTE: `lookup` returns nothing under `helm template` (ArgoCD, kustomize
++helm, --dry-run). GitOps deployments should set
+queue.valkey.baked.existingSecret to an operator-managed password Secret
+instead — this template is then skipped.
 */}}
 {{- $name := include "repo-guardian.valkeyFullname" . -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $name -}}

--- a/charts/repo-guardian/templates/queue-valkey.yaml
+++ b/charts/repo-guardian/templates/queue-valkey.yaml
@@ -41,8 +41,13 @@ spec:
             - name: VALKEY_PASSWORD
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.queue.valkey.baked.existingSecret }}
+                  name: {{ .Values.queue.valkey.baked.existingSecret }}
+                  key: {{ .Values.queue.valkey.baked.existingSecretKey | default "VALKEY_PASSWORD" }}
+                  {{- else }}
                   name: {{ include "repo-guardian.valkeyFullname" . }}
                   key: VALKEY_PASSWORD
+                  {{- end }}
           ports:
             - containerPort: 6379
               name: valkey

--- a/charts/repo-guardian/templates/store-postgres-secret.yaml
+++ b/charts/repo-guardian/templates/store-postgres-secret.yaml
@@ -1,8 +1,14 @@
-{{- if and (eq .Values.store.backend "postgres") (eq .Values.store.postgres.mode "baked") -}}
+{{- if and (eq .Values.store.backend "postgres") (eq .Values.store.postgres.mode "baked") (not .Values.store.postgres.baked.existingSecret) -}}
 {{/*
 Secret for the baked Postgres deployment. Uses `lookup` to preserve
 the existing password across `helm upgrade` so we don't rotate
 credentials on every chart deploy.
+
+NOTE: `lookup` returns nothing under `helm template` (ArgoCD, kustomize
++helm, --dry-run), so this self-generated password rotates on every
+render in a GitOps pipeline and drifts from the initialized data dir.
+GitOps deployments should set store.postgres.baked.existingSecret to an
+operator-managed password Secret instead — this template is then skipped.
 */}}
 {{- $name := include "repo-guardian.postgresFullname" . -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $name -}}

--- a/charts/repo-guardian/templates/store-postgres.yaml
+++ b/charts/repo-guardian/templates/store-postgres.yaml
@@ -37,6 +37,17 @@ spec:
           env:
             - name: POSTGRES_DB
               value: repoguardian
+            {{- if .Values.store.postgres.baked.existingSecret }}
+            # Operator-supplied password (GitOps-safe): username is a
+            # constant, password comes from the external Secret.
+            - name: POSTGRES_USER
+              value: repoguardian
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.store.postgres.baked.existingSecret }}
+                  key: {{ .Values.store.postgres.baked.existingSecretKey | default "POSTGRES_PASSWORD" }}
+            {{- else }}
             - name: POSTGRES_USER
               valueFrom:
                 secretKeyRef:
@@ -47,6 +58,7 @@ spec:
                 secretKeyRef:
                   name: {{ include "repo-guardian.postgresFullname" . }}
                   key: POSTGRES_PASSWORD
+            {{- end }}
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata
           volumeMounts:

--- a/charts/repo-guardian/tests/backend_shapes_test.yaml
+++ b/charts/repo-guardian/tests/backend_shapes_test.yaml
@@ -246,6 +246,78 @@ tests:
         template: templates/queue-valkey.yaml
         documentIndex: 0
 
+  - it: baked with operator-supplied password sources it externally and skips the chart Secret
+    # GitOps-safe path (fix for the lookup-under-helm-template password
+    # rotation): no chart-generated password Secret, StatefulSet + app
+    # both read the operator's Secret, DSN assembled at runtime.
+    set:
+      store.postgres.baked.existingSecret: my-pg-secret
+      queue.valkey.baked.existingSecret: my-vk-secret
+    release:
+      namespace: rg-ns
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/store-postgres-secret.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/queue-valkey-secret.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_USER
+            value: repoguardian
+        template: templates/store-postgres.yaml
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-pg-secret
+                key: POSTGRES_PASSWORD
+        template: templates/store-postgres.yaml
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VALKEY_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-vk-secret
+                key: VALKEY_PASSWORD
+        template: templates/queue-valkey.yaml
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: STORE_DSN
+            value: "postgres://repoguardian:$(POSTGRES_PASSWORD)@RELEASE-NAME-repo-guardian-postgres.rg-ns.svc.cluster.local:5432/repoguardian?sslmode=disable"
+        template: templates/deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: QUEUE_VALKEY_DSN
+            value: "redis://:$(VALKEY_PASSWORD)@RELEASE-NAME-repo-guardian-valkey.rg-ns.svc.cluster.local:6379/0"
+        template: templates/deployment.yaml
+
+  - it: baked existingSecretKey overrides the default password key
+    set:
+      store.postgres.baked.existingSecret: my-pg-secret
+      store.postgres.baked.existingSecretKey: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-pg-secret
+                key: password
+        template: templates/store-postgres.yaml
+        documentIndex: 0
+
   # Schema rejection lives in values.schema.json; helm-unittest can't
   # easily exercise it because the plugin doesn't surface
   # schema-validation errors as catchable failures. Schema rejection

--- a/charts/repo-guardian/values.yaml
+++ b/charts/repo-guardian/values.yaml
@@ -233,6 +233,18 @@ store:
     baked:
       # -- Pinned image. Bump intentionally.
       image: postgres:18.4
+      # -- Operator-supplied Secret holding the Postgres password. When
+      # set, the chart does NOT generate its own password Secret; the
+      # baked StatefulSet reads the password from this Secret and the app
+      # assembles STORE_DSN at runtime via $(POSTGRES_PASSWORD). Use this
+      # for GitOps/ArgoCD: the chart's default `lookup`-based password
+      # preservation returns nothing under `helm template`, so the
+      # generated password rotates on every sync and drifts from the
+      # already-initialised data directory (auth failures). Password must
+      # be URL-safe (alphanumeric) — it is interpolated into the DSN URL.
+      existingSecret: ""
+      # -- Key inside existingSecret holding the password.
+      existingSecretKey: POSTGRES_PASSWORD
       # -- Persistent volume size.
       storageSize: 10Gi
       # -- StorageClass name. Empty → cluster default.
@@ -331,6 +343,15 @@ queue:
     baked:
       # -- Pinned image. Bump intentionally.
       image: valkey/valkey:9.1
+      # -- Operator-supplied Secret holding the Valkey password. Same
+      # GitOps rationale as store.postgres.baked.existingSecret. When set,
+      # the chart skips its generated password Secret; the baked Valkey
+      # reads the password from this Secret and the app assembles
+      # QUEUE_VALKEY_DSN at runtime via $(VALKEY_PASSWORD). URL-safe
+      # (alphanumeric) password required.
+      existingSecret: ""
+      # -- Key inside existingSecret holding the password.
+      existingSecretKey: VALKEY_PASSWORD
       # -- Persistent volume size.
       storageSize: 1Gi
       # -- StorageClass name. Empty → cluster default.


### PR DESCRIPTION
## Problem

Baked Postgres/Valkey preserve their generated password with `lookup` (`store-postgres-secret.yaml`, `queue-valkey-secret.yaml`). **`lookup` returns nothing under `helm template`** — which is exactly how ArgoCD / kustomize+helm render. So in a GitOps pipeline the password is regenerated on *every* sync, the Secret + DSN rotate, but Postgres only honours `POSTGRES_PASSWORD` on **first init** and keeps the original password in its data dir. Result:

```
FATAL: password authentication failed for user "repoguardian"
```

Valkey masks the same bug (it re-reads `requirepass` from env on every start, so server + DSN rotate together); Postgres persists the password and fails hard. This is what bit the homelab ArgoCD deploy.

## Fix

Add `store.postgres.baked.existingSecret` (+ `existingSecretKey`, default `POSTGRES_PASSWORD`) and the Valkey twin (`existingSecretKey` default `VALKEY_PASSWORD`). When set:

- the chart **skips** its self-generated password Secret entirely (no `lookup`, nothing to rotate),
- the baked StatefulSet reads the password from the operator's Secret (username stays the constant `repoguardian`),
- the app assembles `STORE_DSN` / `QUEUE_VALKEY_DSN` **at runtime** via Kubernetes `$(POSTGRES_PASSWORD)` / `$(VALKEY_PASSWORD)` env interpolation — so the chart never needs the password value at template time.

Unset (the default) preserves the current self-generate behaviour **byte-for-byte** — no breaking change for `helm install` users.

### Usage (GitOps, e.g. via a 1Password-managed Secret)

```yaml
store:
  postgres:
    mode: baked
    baked:
      existingSecret: repo-guardian-pg    # Secret with key POSTGRES_PASSWORD
queue:
  valkey:
    mode: baked
    baked:
      existingSecret: repo-guardian-valkey  # Secret with key VALKEY_PASSWORD
```

Renders:
```
STORE_DSN = postgres://repoguardian:$(POSTGRES_PASSWORD)@<release>-postgres.<ns>.svc.cluster.local:5432/repoguardian?sslmode=disable
QUEUE_VALKEY_DSN = redis://:$(VALKEY_PASSWORD)@<release>-valkey.<ns>.svc.cluster.local:6379/0
```

## Constraints / notes

- Password must be **URL-safe (alphanumeric)** — it's interpolated into the DSN URL. Documented in `values.yaml`.
- `$(VAR)` requires the password env to precede the DSN env in the same container — ordered accordingly and verified in the render.
- Only affects `mode: baked`; `external` (full DSN) and `cnpg` (`<cluster>-app` secret) are untouched.

## Verification

- Both render paths checked: default self-gen (chart Secret + `secretKeyRef` DSN, unchanged) and supplied-password (no chart Secret, StatefulSet + app read the operator Secret, runtime DSN).
- 2 new helm-unittest cases (external-source wiring + custom `existingSecretKey`); **79/79 pass**.
- `helm lint` clean on both paths; README regenerated via `make helm-docs`.
- Chart `1.0.0-rc.3` → `1.0.0-rc.4`.

## Migration for the failing deploy

Create the password Secret, set `baked.existingSecret`, and **delete the existing `data-<release>-postgres-0` PVC** so PGDATA initialises fresh against the stable password (the old data dir still has a rotated-away password burned in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)