### PR TITLE
docs: DESIGN-0020 + IMPL-0019 — absent check mode and conditional file rules

### DIFF
--- a/docs/design/0020-absent-check-mode-and-conditional-file-rules.md
+++ b/docs/design/0020-absent-check-mode-and-conditional-file-rules.md
@@ -1,0 +1,643 @@
+---
+id: DESIGN-0020
+title: "Absent check mode and conditional file rules"
+status: Draft
+author: Donald Gifford
+created: 2026-07-23
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# DESIGN 0020: Absent check mode and conditional file rules
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-07-23
+
+<!--toc:start-->
+- [Overview](#overview)
+- [Goals and Non-Goals](#goals-and-non-goals)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Background](#background)
+  - [Driving use case: Renovate-first orgs](#driving-use-case-renovate-first-orgs)
+  - [What the engine supports today](#what-the-engine-supports-today)
+  - [Existing building blocks](#existing-building-blocks)
+- [Detailed Design](#detailed-design)
+  - [HCL surface](#hcl-surface)
+  - [Semantics matrix](#semantics-matrix)
+  - [Evaluation flow](#evaluation-flow)
+  - [Remediation flow (deletion commits)](#remediation-flow-deletion-commits)
+  - [Convergence: orphans, auto-close, and the inverse orphan](#convergence-orphans-auto-close-and-the-inverse-orphan)
+  - [Validation rules](#validation-rules)
+  - [Metrics](#metrics)
+  - [PR text, commit messages, and the reconcile log](#pr-text-commit-messages-and-the-reconcile-log)
+- [API / Interface Changes](#api--interface-changes)
+- [Data Model](#data-model)
+- [Implementation Phases](#implementation-phases)
+  - [Phase 0 — Policy schema, loader, validation](#phase-0--policy-schema-loader-validation)
+  - [Phase 1 — Engine evaluation: when-gate and absent mode](#phase-1--engine-evaluation-when-gate-and-absent-mode)
+  - [Phase 2 — Remediation: deletion commits, PR wording, convergence](#phase-2--remediation-deletion-commits-pr-wording-convergence)
+  - [Phase 3 — Push-event fast convergence (conditional on OQ 4)](#phase-3--push-event-fast-convergence-conditional-on-oq-4)
+  - [Phase 4 — Documentation and examples](#phase-4--documentation-and-examples)
+- [Testing Strategy](#testing-strategy)
+- [Migration / Rollout Plan](#migration--rollout-plan)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Overview
+
+Add a fourth file-rule check mode, `check = "absent"`, whose remediation is a
+PR that **deletes** the matching file(s), plus a `when {}` gating block that
+makes any file rule conditional on the state of another rule in the same
+policy. Together these express "renovate-first" policies: never add a
+Dependabot config, and actively remove one from any repo that already
+satisfies the Renovate rule.
+
+## Goals and Non-Goals
+
+### Goals
+
+- Express "this file must NOT exist" as a first-class file rule whose
+  remediation is a file-deletion PR on the existing reconcile branch.
+- Express "this rule only applies when another rule is satisfied on the
+  default branch" (cross-file conditionality) without duplicating path
+  lists or assertions between rules.
+- Full convergence parity with existing modes: orphan handling, auto-close,
+  sticky reconcile-log comment, and the drift metrics all behave sensibly
+  for deletion-based rules.
+- Pure policy-schema extension: no new rule *type* (stays `rule "file"`),
+  no engine constructor changes, no new deployment surface.
+
+### Non-Goals
+
+- Conditionality on anything other than sibling file rules (no expressions,
+  no repo-property conditions, no org-level conditions — `scope`/`ignore`
+  already cover the org/repo-name axes).
+- Same-PR atomicity between the gating rule's addition and the gated rule's
+  deletion (see [Convergence](#convergence-orphans-auto-close-and-the-inverse-orphan);
+  the two-sweep eventual-consistency flow is deliberate).
+- Deleting files outside a PR flow (no direct-to-default-branch deletes,
+  matching the existing "everything goes through a reviewable PR" stance).
+- Generalizing `when {}` to setting or branch-protection rules (can follow
+  later; file rules are the only ones with cross-file interplay today).
+
+## Background
+
+### Driving use case: Renovate-first orgs
+
+The org standard is Renovate (`renovate_config` + `renovate_workflow` rules
+in `examples/guardian-full.hcl`). Dependabot and Renovate overlap; running
+both produces duplicate PR noise. The desired policy:
+
+| Repo has renovate config | Repo has dependabot.yml | Desired action |
+|---|---|---|
+| yes | yes | PR removing `.github/dependabot.yml` |
+| yes | no | nothing (converged) |
+| no | either | dependabot rule inert; `renovate_config` rule adds Renovate |
+
+Today's engine cannot express either half:
+
+1. **No deletion remediation.** All three check modes (`exists`,
+   `contains`, `exact` — `internal/policy/types.go:15-25`) remediate by
+   *adding or fixing* a file via `CreateOrUpdateFile`
+   (`engine_policy.go.syncActionableFiles`). Nothing authors a deletion.
+2. **No content-based conditionality.** The only per-rule gates are
+   `scope` (org globs) and `ignore` (repo-name globs). The
+   `ignore { repos = ["myorg/renovate-*"] }` workaround in
+   `guardian-full.hcl` is name-based — it cannot see whether a repo
+   actually contains a renovate config.
+
+### What the engine supports today
+
+Verified against the code (post-IMPL-0017, appVersion 1.9.0):
+
+- `findActionableRules` (`engine_policy.go:221`) iterates
+  `policy.FileRules`, applies scope → ignore gates, then `evaluateRule`
+  which short-circuits on `hasExistingPRForPolicy` (search-terms match)
+  before checking file state via `findExistingFile` (first matching path
+  only).
+- `syncActionableFiles` (`engine_policy.go:582`) renders each actionable
+  rule's template and commits it to the deterministic reconcile branch
+  (`repo-guardian/add-missing-files`) with `chore: add <target>`.
+- `discoverOrphans`/`cleanupOrphans` (`drift.go:71,128`) remove files from
+  the reconcile branch when their rule is no longer actionable — fail-safe
+  per IMPL-0013 Q9 (API error ⇒ treat as still actionable, never delete).
+- `autoClosePR` (`drift.go:305`) closes the PR and deletes the branch when
+  the actionable set is empty.
+- The rule HCL schema requires `target` and `template`
+  (`loader.go:484-491`, `Required: true`) and validation requires both
+  non-empty plus `paths` (`validate.go:96-106`).
+
+### Existing building blocks
+
+The expensive plumbing already exists — this design is mostly wiring:
+
+- `github.Client.DeleteFile(ctx, owner, repo, branch, path, sha, msg)` —
+  shipped in IMPL-0013 Phase 2 for orphan cleanup; exactly the primitive a
+  deletion commit needs.
+- `GetContentsOnBranch(ctx, owner, repo, path, branch) (sha, exists, err)`
+  — provides the blob SHA required by the Contents-API delete.
+- The reconcile branch + PR + labels + sticky-comment machinery is
+  action-agnostic; a branch whose commits are deletions flows through
+  `CreatePullRequest`/`UpdatePullRequest` unchanged.
+- Per-rule `pr {}` templating (DESIGN-0013) gives removal PRs their own
+  title/body/labels without new schema.
+
+## Detailed Design
+
+### HCL surface
+
+```hcl
+# Renovate-first: dependabot config is forbidden wherever Renovate
+# is already set up. Never adds dependabot anywhere.
+rule "file" "no_dependabot" {
+  check = "absent"
+  paths = [".github/dependabot.yml", ".github/dependabot.yaml"]
+
+  # Rule is in force only when the named sibling rule is satisfied
+  # on the default branch (its paths exist AND its assertions pass).
+  # Otherwise this rule is skipped entirely.
+  when {
+    rule_satisfied = "renovate_config"
+  }
+
+  pr {
+    search_terms = ["remove dependabot"]
+    title        = "chore({{ .Repo }}): remove dependabot config (repo uses Renovate)"
+  }
+}
+```
+
+Grammar additions:
+
+- `check = "absent"` — new `CheckMode` constant `CheckAbsent`. The rule is
+  **actionable when any path in `paths` exists** on the default branch.
+  `target` and `template` are meaningless for deletions and are **rejected**
+  if present (see [Validation rules](#validation-rules)); the HCL schema's
+  `Required: true` on both attributes is relaxed to optional, with
+  per-check-mode requiredness enforced in `validateFileRule`.
+- `when { rule_satisfied = "<rule-name>" }` — new optional block on
+  `rule "file"` blocks (any check mode, not just `absent` — see OQ 7).
+  References a sibling file rule by its HCL label. The gate is true when
+  the referenced rule is **satisfied on the default branch**: at least one
+  of its `paths` exists and (for `contains`) its assertions pass / (for
+  `exact`) content matches its template. Gate false ⇒ the gated rule is
+  skipped for this repo on this sweep (not actionable, not an orphan
+  producer, reconcilers skipped).
+
+The referenced-rule form (`rule_satisfied`) is preferred over an inline
+path list (`any_exists = [...]`) because it reuses the sibling rule's
+`paths` *and* its assertions — a repo with a `renovate.json` that doesn't
+extend the org preset is not yet "using Renovate", and a duplicated path
+list is exactly the copy-paste divergence this repo's post-mortems keep
+catching (see OQ 1).
+
+### Semantics matrix
+
+For `no_dependabot` gated on `renovate_config`:
+
+| renovate satisfied on default | dependabot file present | Result |
+|---|---|---|
+| yes | yes | actionable → deletion commit on reconcile branch → PR |
+| yes | no | gate open, nothing to delete → not actionable (converged) |
+| no (missing) | yes | gate closed → rule skipped; `renovate_config` itself is actionable and adds Renovate |
+| no (assertion fails) | any | gate closed → rule skipped; `renovate_config` opens its own fix PR |
+| no | no | gate closed → rule skipped |
+
+The dependabot-only repo converges over **two PR cycles**: sweep 1 opens
+the add-renovate PR; after a human merges it, a later sweep sees the gate
+open and opens the remove-dependabot PR. This is deliberate — the gate
+evaluates the **default branch**, never the reconcile branch, so
+repo-guardian never deletes Dependabot before Renovate is actually live
+and reviewed (see Non-Goals).
+
+### Evaluation flow
+
+Changes concentrate in `findActionableRules` and a new shared helper:
+
+1. **`ruleSatisfiedOnDefault(ctx, client, owner, repo, rule) (bool, error)`**
+   — extracted from the existing `evaluateRule` logic *minus* the
+   `hasExistingPRForPolicy` short-circuit (that short-circuit exists to
+   avoid duplicate PRs; reusing it here would make the gate flip merely
+   because a PR is open, which is wrong). Semantics per check mode:
+   - `exists`: any path in `paths` exists.
+   - `contains`: a path exists AND `EvaluateAssertions` passes.
+   - `exact`: a path exists AND content matches the template.
+   - `absent`: no path exists. (Gating on an absent rule is legal but
+     unusual; defined for completeness.)
+2. **Per-repo-check memoization.** Gate evaluation duplicates API calls
+   the referenced rule's own evaluation already makes (`GetContents` per
+   path, `GetFileContent` for assertions). A small
+   `map[ruleName]satisfiedResult` cache scoped to the single
+   `checkRepoWithPolicy` invocation caps the overhead at one evaluation
+   per referenced rule per repo-check. No cross-repo or cross-sweep
+   caching — repo state changes between checks.
+3. **Gate placement.** In `findActionableRules`, after the scope and
+   ignore gates and before `evaluateRule`. Gate-closed skips increment a
+   new counter (see [Metrics](#metrics)) and log at Info with the
+   referenced rule and its evaluation. Per the file-rule double-iteration
+   contract (CLAUDE.md), `runReconcilers` must apply the same gate
+   **silently** (no counter increment) — forgetting this double-counts.
+4. **Gate error handling — fail closed.** If evaluating the referenced
+   rule errors (API glitch), the gate is treated as **closed** (rule
+   skipped this sweep, Warn log). Rationale: the gated action is
+   typically destructive (deletion); a transient error must never cause a
+   delete PR against a repo whose Renovate state is unknown. This mirrors
+   the IMPL-0013 Q9 fail-safe stance.
+5. **`evaluateAbsent`.** New evaluation arm: walk **all** of `paths`
+   (unlike `findExistingFile`, which stops at the first hit) and collect
+   every existing path. Actionable when the set is non-empty. The
+   collected paths ride along to remediation (a repo can have both
+   `dependabot.yml` and `dependabot.yaml`; deleting only the first leaves
+   the rule permanently actionable — see OQ 5).
+
+### Remediation flow (deletion commits)
+
+`syncActionableFiles` gains an action split per rule:
+
+- **Add/fix modes (existing):** render template → `CreateOrUpdateFile` —
+  unchanged.
+- **Absent mode (new):** for each existing matching path:
+  1. `GetContentsOnBranch(branch)` → blob SHA on the reconcile branch
+     (the branch was cut from default, so the file is there).
+  2. `DeleteFile(branch, path, sha, msg)` with
+     `chore: remove <path> (forbidden by rule "<name>")`.
+  3. Idempotency: if `GetContentsOnBranch` reports the file already absent
+     on the branch (a prior sweep deleted it), skip — mirrors the
+     skip-if-identical arm of `CreateOrUpdateFile` (INV-0003).
+
+Deletions and additions coexist on the same branch/PR naturally (e.g., a
+repo missing CODEOWNERS *and* carrying dependabot+renovate gets one PR
+that adds `.github/CODEOWNERS` and removes `.github/dependabot.yml`).
+
+### Convergence: orphans, auto-close, and the inverse orphan
+
+- **Empty actionable + open PR** — unchanged: `autoClosePR` posts the
+  final sticky comment, closes, deletes the branch. Deleting the branch
+  discards pending deletion commits, which is exactly right (e.g., someone
+  hand-deleted dependabot on main, or removed renovate so the gate
+  closed).
+- **Existing orphan discovery is deletion-blind but safe.**
+  `discoverOrphans` looks for a rule's `Target` file *present* on the
+  branch; an absent rule has no `Target` and its branch state is a
+  *missing* file, so it never matches — no change needed to avoid false
+  positives.
+- **The inverse orphan (new).** In a bundle PR, if the absent rule stops
+  being actionable (gate closed or file gone from main) while another
+  rule keeps the PR open, the branch still carries a stale deletion
+  commit — the PR diff would delete a file the policy no longer wants
+  deleted. Mitigation: `discoverOrphans` grows an absent-rule arm — for a
+  no-longer-actionable absent rule, check each of its `paths` on the
+  branch; where default-branch has the file but the branch does not,
+  **restore** it (`GetFileContent` from default →
+  `CreateOrUpdateFile` on branch, `chore: restore <path> (rule "<name>"
+  no longer applies)`). Same fail-safe stance: any API error ⇒ leave it,
+  Warn, retry next sweep (see OQ 6).
+
+### Validation rules
+
+Added to `validateFileRule` (`internal/policy/validate.go`):
+
+| Condition | Result |
+|---|---|
+| `check = "absent"` + `template` set | error — nothing to render |
+| `check = "absent"` + `target` set | error — deletions operate on `paths` |
+| `check = "absent"` + `assertion` blocks | error — no content to assert |
+| `check = "absent"` + `reconcile` blocks | error — reconcilers consume file content that must not exist |
+| `check != "absent"` + `target`/`template` missing | error — preserves today's contract (requiredness moves from HCL schema to validation) |
+| `when.rule_satisfied` names a nonexistent rule | error, with the list of known rule names |
+| `when.rule_satisfied` names a `setting`/`branch_protection` rule | error — file rules only |
+| `when.rule_satisfied` names a disabled rule | error — a permanently-closed gate is a policy bug, fail loud at load |
+| `when.rule_satisfied` self-reference | error |
+| `when` cycles (A gates on B, B gates on A; any length) | error — detected via DFS over the gate graph at load time |
+| Empty `when {}` block (no `rule_satisfied`) | error |
+
+The check-mode allowlist in `validateFileRule` and the `CheckMode()`
+switch in `types.go` both gain `absent`. Strict-templates validation
+(`ValidatePRTemplates`) is unaffected — absent rules may carry `pr {}`
+blocks and those validate exactly as today.
+
+### Metrics
+
+- New `files_forbidden_present_total{rule_name, org}` CounterVec —
+  incremented when an absent rule is actionable. `files_missing_total`
+  is **not** incremented for absent rules; its name would invert its
+  meaning (see OQ 3).
+- New `rule_gate_closed_total{rule_name, org}` CounterVec — incremented
+  in the primary pass only when a `when` gate skips a rule. Distinct from
+  `OutOfScopeTotal`/`IgnoredTotal` because gate state is repo-content
+  -driven and expected to flip; operators alert on scope/ignore anomalies
+  but *watch* gate counts.
+- `prs_created_total` / `prs_updated_total` / `prs_closed_total` /
+  `pr_orphan_left_total` — unchanged; deletion PRs are just PRs.
+- File restoration (inverse orphan) failures reuse
+  `pr_orphan_left_total{org}` — same "branch content is stale, next sweep
+  retries" meaning.
+
+### PR text, commit messages, and the reconcile log
+
+- **`tmpl.Rule` gains `Action string`** (`"add"` | `"remove"`), populated
+  in `buildPRVars`; `PRVars.Files` continues to list every touched path
+  (additions and deletions). Additive, so `ValidateZero` strict-mode
+  passes and existing operator templates keep rendering unchanged;
+  templates that want per-action wording use `{{ if eq .Rule.Action
+  "remove" }}`.
+- **Fallback body** (`buildPRBodyFromPolicy`) splits the file list into
+  "Added files" and "Removed files" sections; the CODEOWNERS-placeholder
+  note renders only when an add-mode rule is present.
+- **Reconcile-log statuses** (`drift.go`) get absent-aware wording:
+  actionable absent rule → `present on main, pending removal`; satisfied →
+  `absent from main`; gate-closed → `skipped (when-gate closed:
+  <referenced rule> not satisfied)`. The status strings feed the
+  content-hash tag, so new wording changes hashes exactly once per PR —
+  acceptable (single extra comment edit after upgrade).
+- **`hasExistingPRForPolicy` guidance, not code:** an absent rule's
+  `search_terms` must not collide with terms from the era when the same
+  file was being *added* (e.g., bare `"dependabot"` would match an old
+  "add dependabot" PR title and permanently suppress the removal). The
+  docs and example use `"remove dependabot"`.
+
+## API / Interface Changes
+
+- **`internal/policy`**: new `CheckAbsent CheckMode = "absent"`; new
+  `WhenConfig struct { RuleSatisfied string }` + `When *WhenConfig` field
+  on `FileRuleConfig`; `ruleBodySchema` adds the `when` block type and
+  drops `Required: true` from `target`/`template`; new decode + validation
+  paths per above.
+- **`internal/checker`**: `evaluateAbsent`, `ruleSatisfiedOnDefault` (+
+  per-check memo), gate wiring in `findActionableRules` **and**
+  `runReconcilers`, action split in `syncActionableFiles`, absent arm in
+  `discoverOrphans`, wording changes in `buildPRBodyFromPolicy` /
+  reconcile-log builders.
+- **`internal/template`**: `Rule.Action` field (additive).
+- **`internal/metrics`**: two new CounterVecs.
+- **`internal/github`**: no interface changes — `DeleteFile`,
+  `GetContentsOnBranch`, `GetFileContent`, `CreateOrUpdateFile` cover
+  everything. No mockClient-parity sweep needed.
+- **Chart**: no new values; no new alerts required (deletion PRs surface
+  through the existing PR metrics). Chart README/docs only.
+
+## Data Model
+
+No store schema changes. `policy.Version` hashes the JSON-serialized
+config (`version.go:32`); adding the `When` field and new check-mode
+string changes the hash for **every** loaded policy on upgrade, which
+marks all `repo_state` rows drifted and triggers one full re-sweep. This
+is the established behavior for any policy-struct change (same thing
+happened on IMPL-0017's schema additions) and is harmless — but the
+migration doc must state it so a fleet-wide sweep right after upgrade
+isn't mistaken for a bug.
+
+## Implementation Phases
+
+### Phase 0 — Policy schema, loader, validation
+
+Tasks:
+
+- [ ] Add `CheckAbsent` to `types.go` (`CheckMode` const + `CheckMode()`
+      switch) and the `validateFileRule` allowlist.
+- [ ] Add `WhenConfig` type and `When *WhenConfig` field to
+      `FileRuleConfig`.
+- [ ] Relax `target`/`template` to optional in `ruleBodySchema`; add
+      `{Type: "when"}` to its block list; decode via new
+      `decodeWhenBlock` in `loader.go` (wired into `decodeRuleSubBlocks`).
+- [ ] Move `target`/`template` requiredness into `validateFileRule`,
+      conditioned on check mode (absent forbids, others require).
+- [ ] Implement the full validation matrix (template/target/assertions/
+      reconcilers forbidden on absent; referenced-rule existence, type,
+      enabled, self-reference, cycle detection via DFS; empty `when`).
+- [ ] Loader tests: happy-path absent rule, gated rule, every validation
+      error with location-prefixed messages, cycle of length 2 and 3.
+- [ ] `policy.Version` test: adding a `when` block or flipping check mode
+      to absent changes the hash.
+
+Success criteria: `make lint` and `make test` pass; a `guardian.hcl`
+containing the [HCL surface](#hcl-surface) example loads without error;
+each row of the validation matrix has a test asserting its exact error;
+`policy.BuiltinDefaults()` is untouched (no absent rules ship as
+defaults).
+
+### Phase 1 — Engine evaluation: when-gate and absent mode
+
+Tasks:
+
+- [ ] Implement `ruleSatisfiedOnDefault` with the per-repo-check
+      memoization map; unit tests per check mode including the
+      no-PR-short-circuit distinction (gate must evaluate true even when
+      an open PR exists for the referenced rule).
+- [ ] Wire the gate into `findActionableRules` (counter + Info log) and
+      `runReconcilers` (silent), honoring the double-iteration contract.
+- [ ] Fail-closed gate error handling with Warn log; test with an
+      erroring mock client asserting the rule is skipped and no deletion
+      is planned.
+- [ ] Implement `evaluateAbsent` collecting **all** existing matching
+      paths; actionable iff non-empty.
+- [ ] Add `files_forbidden_present_total` and `rule_gate_closed_total`
+      metrics; assert increments via `testutil.ToFloat64` with unique
+      label values (parallel-safe per the established convention).
+- [ ] Verify `FilesMissingTotal` is not incremented for absent rules.
+
+Success criteria: `make lint` and `make test` pass; table-driven engine
+tests cover all five rows of the [semantics matrix](#semantics-matrix)
+using the existing `mockClient` pattern in `internal/checker/engine_test.go`;
+gate evaluation issues at most one content fetch per referenced rule per
+repo-check (asserted via mock call counting).
+
+### Phase 2 — Remediation: deletion commits, PR wording, convergence
+
+Tasks:
+
+- [ ] Action split in `syncActionableFiles`: absent rules delete each
+      collected path on the reconcile branch via
+      `GetContentsOnBranch` + `DeleteFile`, with the already-absent
+      idempotent skip.
+- [ ] `tmpl.Rule.Action` field + `buildPRVars` population; fallback-body
+      Added/Removed sections; CODEOWNERS note gated on add-mode presence.
+- [ ] Inverse-orphan restoration arm in `discoverOrphans`/`cleanupOrphans`
+      per the design, reusing `pr_orphan_left_total` on failure.
+- [ ] Reconcile-log absent-aware status strings.
+- [ ] Multi-sweep convergence tests in `internal/checker/convergence_test.go`
+      following the IMPL-0013 pattern: sweep 1 renovate-add PR → merge →
+      sweep 2 dependabot-remove PR → merge → sweep 3 converged;
+      hand-deleted dependabot → auto-close; gate closes mid-flight →
+      restoration; both `.yml` and `.yaml` present → both deleted.
+- [ ] Stateful-mock fidelity check: the mock's branch-contents state must
+      reflect prior `DeleteFile`/`CreateOrUpdateFile` calls on the same
+      mock, per the list-then-act mock-fidelity rule (CLAUDE.md) — an
+      always-static mock would vacuously pass the idempotency tests.
+
+Success criteria: `make ci` passes; convergence suite demonstrates the
+full renovate-first lifecycle end-to-end against mocks; a bundle PR mixing
+one add-rule and one absent-rule renders both sections and both commit
+kinds; re-running an identical sweep produces zero mutating API calls
+(idempotency, asserted via mock counters).
+
+### Phase 3 — Push-event fast convergence (conditional on OQ 4)
+
+Tasks:
+
+- [ ] Extend watched-path extraction so a rule referenced by any
+      `when.rule_satisfied` contributes its `paths` to the webhook
+      handler's watched set (merging renovate's own add-PR then triggers
+      an immediate re-check instead of waiting for the sweep cadence).
+- [ ] Webhook handler test: push touching `renovate.json` on the default
+      branch enqueues a re-check for a policy where only the *gated* rule
+      watches it.
+- [ ] Confirm no watched-path change when OQ 4 lands as (b); delete this
+      phase from the plan in that case.
+
+Success criteria: `make lint` and `make test` pass; the dependabot-removal
+PR opens on the first post-merge webhook delivery in the handler test, not
+on the next scheduled sweep.
+
+### Phase 4 — Documentation and examples
+
+Tasks:
+
+- [ ] `docs/usage/policy-reference.md`: `absent` check mode section,
+      `when {}` block reference, validation-matrix table, search-terms
+      collision guidance.
+- [ ] `examples/guardian-full.hcl`: replace the name-glob
+      `ignore { repos = ["myorg/renovate-*"] }` workaround on the
+      dependabot rule with the `no_dependabot` + `when` form; keep the
+      old form nearby as a commented alternative; `go test ./examples/...`
+      must pass.
+- [ ] Migration note (upgrade doc or release notes per the
+      `docs/operations/*-migration.md` precedent): policy-hash bump ⇒
+      one-time full re-sweep; reconcile-log hash bump ⇒ one comment edit
+      per open PR; search-terms guidance.
+- [ ] CLAUDE.md architecture notes: absent mode, when-gate fail-closed
+      semantics, inverse-orphan restoration, and the
+      counter-only-in-primary-pass reminder extended to the gate.
+- [ ] `docz update design` / index regeneration; mkdocs strict-mode
+      warning count unchanged from the 14-file baseline.
+
+Success criteria: `make ci` passes; policy-reference renders the full
+semantics matrix; the example file loads in the example test; docs build
+clean.
+
+## Testing Strategy
+
+Unit tests live beside each phase (see per-phase tasks). The
+cross-cutting strategies, named here so phases can reference them:
+
+- **Mock fidelity for list-then-act paths** — deletion idempotency and
+  inverse-orphan restoration are exactly the shape the IMPL-0013 Phase 4
+  post-mortem warns about: the mock's `GetContentsOnBranch` must reflect
+  prior writes to the same mock or the skip-arm assertions are vacuous.
+- **Multi-sweep convergence** — extend `convergence_test.go`, which
+  already models sweep sequences with a stateful mock; the renovate-first
+  lifecycle is a new scenario family, not new infrastructure.
+- **Metric assertions** — unique label values per test
+  (`testutil.ToFloat64` + targeted `Reset()`), per the established
+  parallel-safety convention.
+- **No integration-tag additions** — nothing here touches store/queue/
+  scheduler backends.
+
+## Migration / Rollout Plan
+
+Additive and opt-in: policies that never write `check = "absent"` or
+`when {}` parse and behave identically. Rollout:
+
+1. Ship binary + docs (minor appVersion bump; new HCL surface).
+2. On upgrade, `policy.Version` changes ⇒ one-time full re-sweep
+   (documented; expected).
+3. Operators adopt by editing `guardian.hcl`; recommended first step is
+   `dry_run = true` (or the `DRY_RUN` env) to review planned deletions in
+   logs before letting removal PRs open — deletion is the first
+   destructive remediation the file engine ships, so the migration doc
+   leads with the dry-run recipe.
+4. Rollback = remove the new blocks from HCL (or pin the previous
+   appVersion; unknown check mode fails validation at load, so a
+   downgraded binary with an absent-rule policy fails loudly at startup
+   rather than silently ignoring the rule — this is the desired
+   fail-loud behavior, called out in the migration doc).
+
+## Open Questions
+
+1. **Gate mechanism — what does `when {}` accept?**
+   - (a) **Recommendation:** `rule_satisfied = "<name>"` only. Reuses the
+     referenced rule's paths *and* assertions (a renovate.json that fails
+     the org-preset assertion isn't "using Renovate"); no duplicated path
+     lists to drift. Cycle detection is straightforward on a named graph.
+   - (b) `any_exists = ["path", ...]` only. Simpler engine (no rule graph,
+     no cycles), but duplicates path lists and cannot see assertions —
+     re-introduces the copy-paste divergence class of bug.
+   - (c) Both, mutually exclusive per block. Maximum flexibility, larger
+     validation surface and two behaviors to document.
+   - other:
+
+2. **Does the gate respect the referenced rule's own scope/ignore?**
+   - (a) **Recommendation:** No — content-only evaluation. The referenced
+     rule serves purely as a named bundle of paths+assertions; the gated
+     rule's *own* scope/ignore already control where the gated rule
+     applies. Mixing in the referee's gates makes the gate's value depend
+     on org/repo-name state in ways that are hard to reason about (e.g.,
+     renovate rule ignored on one repo would silently flip the dependabot
+     gate there).
+   - (b) Yes — gate is false wherever the referenced rule is
+     scoped/ignored out. More "consistent" with the referee as a whole
+     rule, but produces the surprising cross-effects above.
+   - other:
+
+3. **Metrics shape for absent-rule actionability?**
+   - (a) **Recommendation:** New `files_forbidden_present_total{rule_name,
+     org}` counter; `files_missing_total` untouched for absent rules. The
+     existing counter's name would mean its opposite; dashboards keying on
+     it (contrib/) stay truthful.
+   - (b) Reuse `files_missing_total` (rule label disambiguates). No new
+     metric, but "missing" counting "present" is a standing operator
+     footgun.
+   - other:
+
+4. **Auto-watch the referenced rule's paths for push-triggered re-checks
+   (Phase 3)?**
+   - (a) **Recommendation:** Yes. Merging the renovate-add PR fires a push
+     touching `renovate.json`; auto-watching means the removal PR opens
+     minutes later instead of at the next weekly sweep. Cost is a slightly
+     larger watched-path set in the webhook handler.
+   - (b) No — sweep-cadence convergence only. Simpler; the two-PR flow
+     already spans a human merge, so hours-to-days latency arguably
+     doesn't matter.
+   - other:
+
+5. **When multiple `paths` entries exist in a repo (e.g., both
+   `dependabot.yml` and `dependabot.yaml`), what does remediation
+   delete?**
+   - (a) **Recommendation:** Every existing matching path, in one PR. The
+     rule's contract is "no file at any of these paths"; deleting only one
+     leaves the rule actionable forever.
+   - (b) First match only (parity with `findExistingFile`), converging
+     over successive PRs. Simpler diff per PR, but N PRs for N variants
+     and a confusing intermediate state.
+   - other:
+
+6. **Stale deletion in a bundle PR (gate closes / file removed on main
+   while another rule keeps the PR open) — restore or leave?**
+   - (a) **Recommendation:** Restore the file on the reconcile branch from
+     default-branch content (the inverse-orphan arm), fail-safe on errors.
+     Leaves the PR diff always equal to current policy intent — the same
+     invariant orphan cleanup enforces for additions.
+   - (b) Leave the stale deletion until the whole PR auto-closes. No new
+     code path, but a reviewer merging the bundle would delete a file the
+     policy no longer targets — a correctness hole, not just cosmetics.
+   - other:
+
+7. **Is `when {}` allowed on non-absent rules?**
+   - (a) **Recommendation:** Yes — the gate is orthogonal to check mode
+     (e.g., "require dependabot config *unless* renovate is satisfied"
+     wants a when-gated `exists` rule as the mirror-image policy). The
+     validation matrix and engine wiring are check-mode-agnostic anyway;
+     restricting it buys nothing.
+   - (b) No — absent-only for the first release; loosen later if asked.
+     Smaller doc surface now, breaking-change-shaped loosening later.
+   - other:
+
+## References
+
+- [DESIGN-0013 — PR templates](0013-customizable-pr-templates.md) — per-rule `pr {}` inheritance the removal PRs reuse
+- IMPL-0013 — orphan cleanup, auto-close, sticky reconcile-log; the Q9 fail-safe stance this design extends to gates and restoration
+- INV-0003 — `CreateOrUpdateFile` three-branch idempotency the deletion path mirrors
+- `examples/guardian-full.hcl` — the name-glob `ignore` workaround this design replaces
+- `internal/policy/types.go:15-25`, `internal/policy/loader.go:484-499`, `internal/policy/validate.go:79-127`, `internal/checker/engine_policy.go:221-302,582-621`, `internal/checker/drift.go:71-156,305-338` — code paths audited for this design (as of appVersion 1.9.0)

--- a/docs/design/0020-absent-check-mode-and-conditional-file-rules.md
+++ b/docs/design/0020-absent-check-mode-and-conditional-file-rules.md
@@ -1,7 +1,7 @@
 ---
 id: DESIGN-0020
 title: "Absent check mode and conditional file rules"
-status: Draft
+status: Approved
 author: Donald Gifford
 created: 2026-07-23
 ---
@@ -9,7 +9,7 @@ created: 2026-07-23
 
 # DESIGN 0020: Absent check mode and conditional file rules
 
-**Status:** Draft
+**Status:** Approved
 **Author:** Donald Gifford
 **Date:** 2026-07-23
 
@@ -37,11 +37,11 @@ created: 2026-07-23
   - [Phase 0 — Policy schema, loader, validation](#phase-0--policy-schema-loader-validation)
   - [Phase 1 — Engine evaluation: when-gate and absent mode](#phase-1--engine-evaluation-when-gate-and-absent-mode)
   - [Phase 2 — Remediation: deletion commits, PR wording, convergence](#phase-2--remediation-deletion-commits-pr-wording-convergence)
-  - [Phase 3 — Push-event fast convergence (conditional on OQ 4)](#phase-3--push-event-fast-convergence-conditional-on-oq-4)
+  - [Phase 3 — Push-event fast convergence](#phase-3--push-event-fast-convergence)
   - [Phase 4 — Documentation and examples](#phase-4--documentation-and-examples)
 - [Testing Strategy](#testing-strategy)
 - [Migration / Rollout Plan](#migration--rollout-plan)
-- [Open Questions](#open-questions)
+- [Resolved Decisions](#resolved-decisions)
 - [References](#references)
 <!--toc:end-->
 
@@ -178,7 +178,7 @@ Grammar additions:
   `Required: true` on both attributes is relaxed to optional, with
   per-check-mode requiredness enforced in `validateFileRule`.
 - `when { rule_satisfied = "<rule-name>" }` — new optional block on
-  `rule "file"` blocks (any check mode, not just `absent` — see OQ 7).
+  `rule "file"` blocks (any check mode, not just `absent` — Decision 7).
   References a sibling file rule by its HCL label. The gate is true when
   the referenced rule is **satisfied on the default branch**: at least one
   of its `paths` exists and (for `contains`) its assertions pass / (for
@@ -191,7 +191,7 @@ path list (`any_exists = [...]`) because it reuses the sibling rule's
 `paths` *and* its assertions — a repo with a `renovate.json` that doesn't
 extend the org preset is not yet "using Renovate", and a duplicated path
 list is exactly the copy-paste divergence this repo's post-mortems keep
-catching (see OQ 1).
+catching (Decision 1).
 
 ### Semantics matrix
 
@@ -250,7 +250,7 @@ Changes concentrate in `findActionableRules` and a new shared helper:
    every existing path. Actionable when the set is non-empty. The
    collected paths ride along to remediation (a repo can have both
    `dependabot.yml` and `dependabot.yaml`; deleting only the first leaves
-   the rule permanently actionable — see OQ 5).
+   the rule permanently actionable — Decision 5).
 
 ### Remediation flow (deletion commits)
 
@@ -293,7 +293,7 @@ that adds `.github/CODEOWNERS` and removes `.github/dependabot.yml`).
   **restore** it (`GetFileContent` from default →
   `CreateOrUpdateFile` on branch, `chore: restore <path> (rule "<name>"
   no longer applies)`). Same fail-safe stance: any API error ⇒ leave it,
-  Warn, retry next sweep (see OQ 6).
+  Warn, retry next sweep (Decision 6).
 
 ### Validation rules
 
@@ -323,7 +323,7 @@ blocks and those validate exactly as today.
 - New `files_forbidden_present_total{rule_name, org}` CounterVec —
   incremented when an absent rule is actionable. `files_missing_total`
   is **not** incremented for absent rules; its name would invert its
-  meaning (see OQ 3).
+  meaning (Decision 3).
 - New `rule_gate_closed_total{rule_name, org}` CounterVec — incremented
   in the primary pass only when a `when` gate skips a rule. Distinct from
   `OutOfScopeTotal`/`IgnoredTotal` because gate state is repo-content
@@ -473,7 +473,9 @@ one add-rule and one absent-rule renders both sections and both commit
 kinds; re-running an identical sweep produces zero mutating API calls
 (idempotency, asserted via mock counters).
 
-### Phase 3 — Push-event fast convergence (conditional on OQ 4)
+### Phase 3 — Push-event fast convergence
+
+Auto-watch is in (Decision 4); this phase is unconditional.
 
 Tasks:
 
@@ -484,8 +486,6 @@ Tasks:
 - [ ] Webhook handler test: push touching `renovate.json` on the default
       branch enqueues a re-check for a policy where only the *gated* rule
       watches it.
-- [ ] Confirm no watched-path change when OQ 4 lands as (b); delete this
-      phase from the plan in that case.
 
 Success criteria: `make lint` and `make test` pass; the dependabot-removal
 PR opens on the first post-merge webhook delivery in the handler test, not
@@ -554,85 +554,50 @@ Additive and opt-in: policies that never write `check = "absent"` or
    rather than silently ignoring the rule — this is the desired
    fail-loud behavior, called out in the migration doc).
 
-## Open Questions
+## Resolved Decisions
 
-1. **Gate mechanism — what does `when {}` accept?**
-   - (a) **Recommendation:** `rule_satisfied = "<name>"` only. Reuses the
-     referenced rule's paths *and* assertions (a renovate.json that fails
-     the org-preset assertion isn't "using Renovate"); no duplicated path
-     lists to drift. Cycle detection is straightforward on a named graph.
-   - (b) `any_exists = ["path", ...]` only. Simpler engine (no rule graph,
-     no cycles), but duplicates path lists and cannot see assertions —
-     re-introduces the copy-paste divergence class of bug.
-   - (c) Both, mutually exclusive per block. Maximum flexibility, larger
-     validation surface and two behaviors to document.
-   - other:
+All seven open questions were resolved on 2026-07-23 with the recommended
+option (a). The two-PR eventual-consistency consequence (gate reads the
+default branch only; dependabot-only repos converge over two PR cycles)
+was reviewed and accepted at the same time.
 
-2. **Does the gate respect the referenced rule's own scope/ignore?**
-   - (a) **Recommendation:** No — content-only evaluation. The referenced
-     rule serves purely as a named bundle of paths+assertions; the gated
-     rule's *own* scope/ignore already control where the gated rule
-     applies. Mixing in the referee's gates makes the gate's value depend
-     on org/repo-name state in ways that are hard to reason about (e.g.,
-     renovate rule ignored on one repo would silently flip the dependabot
-     gate there).
-   - (b) Yes — gate is false wherever the referenced rule is
-     scoped/ignored out. More "consistent" with the referee as a whole
-     rule, but produces the surprising cross-effects above.
-   - other:
+1. **Gate mechanism** — `rule_satisfied = "<name>"` only. Reuses the
+   referenced rule's paths *and* assertions (a renovate.json that fails
+   the org-preset assertion isn't "using Renovate"); no duplicated path
+   lists to drift; cycle detection is straightforward on a named graph.
+   The `any_exists` inline form was rejected as re-introducing the
+   copy-paste divergence class of bug.
 
-3. **Metrics shape for absent-rule actionability?**
-   - (a) **Recommendation:** New `files_forbidden_present_total{rule_name,
-     org}` counter; `files_missing_total` untouched for absent rules. The
-     existing counter's name would mean its opposite; dashboards keying on
-     it (contrib/) stay truthful.
-   - (b) Reuse `files_missing_total` (rule label disambiguates). No new
-     metric, but "missing" counting "present" is a standing operator
-     footgun.
-   - other:
+2. **Gate is content-only** — the referenced rule's own scope/ignore do
+   NOT affect the gate. The referee serves purely as a named bundle of
+   paths+assertions; the gated rule's own scope/ignore control where the
+   gated rule applies. This avoids surprising cross-effects (a renovate
+   rule ignored on one repo silently flipping the dependabot gate there).
 
-4. **Auto-watch the referenced rule's paths for push-triggered re-checks
-   (Phase 3)?**
-   - (a) **Recommendation:** Yes. Merging the renovate-add PR fires a push
-     touching `renovate.json`; auto-watching means the removal PR opens
-     minutes later instead of at the next weekly sweep. Cost is a slightly
-     larger watched-path set in the webhook handler.
-   - (b) No — sweep-cadence convergence only. Simpler; the two-PR flow
-     already spans a human merge, so hours-to-days latency arguably
-     doesn't matter.
-   - other:
+3. **New metric** — `files_forbidden_present_total{rule_name, org}`;
+   `files_missing_total` is untouched for absent rules so its name stays
+   truthful for dashboards keying on it (contrib/).
 
-5. **When multiple `paths` entries exist in a repo (e.g., both
-   `dependabot.yml` and `dependabot.yaml`), what does remediation
-   delete?**
-   - (a) **Recommendation:** Every existing matching path, in one PR. The
-     rule's contract is "no file at any of these paths"; deleting only one
-     leaves the rule actionable forever.
-   - (b) First match only (parity with `findExistingFile`), converging
-     over successive PRs. Simpler diff per PR, but N PRs for N variants
-     and a confusing intermediate state.
-   - other:
+4. **Auto-watch is in** — a rule referenced by `when.rule_satisfied`
+   contributes its paths to the webhook watched set, so merging the
+   renovate-add PR triggers the removal PR within minutes rather than at
+   the next weekly sweep. Phase 3 is unconditional.
 
-6. **Stale deletion in a bundle PR (gate closes / file removed on main
-   while another rule keeps the PR open) — restore or leave?**
-   - (a) **Recommendation:** Restore the file on the reconcile branch from
-     default-branch content (the inverse-orphan arm), fail-safe on errors.
-     Leaves the PR diff always equal to current policy intent — the same
-     invariant orphan cleanup enforces for additions.
-   - (b) Leave the stale deletion until the whole PR auto-closes. No new
-     code path, but a reviewer merging the bundle would delete a file the
-     policy no longer targets — a correctness hole, not just cosmetics.
-   - other:
+5. **Delete every matching path in one PR** — the rule's contract is "no
+   file at any of these paths"; deleting only the first match would leave
+   the rule permanently actionable when both `.yml` and `.yaml` variants
+   exist.
 
-7. **Is `when {}` allowed on non-absent rules?**
-   - (a) **Recommendation:** Yes — the gate is orthogonal to check mode
-     (e.g., "require dependabot config *unless* renovate is satisfied"
-     wants a when-gated `exists` rule as the mirror-image policy). The
-     validation matrix and engine wiring are check-mode-agnostic anyway;
-     restricting it buys nothing.
-   - (b) No — absent-only for the first release; loosen later if asked.
-     Smaller doc surface now, breaking-change-shaped loosening later.
-   - other:
+6. **Restore stale deletions (inverse orphan)** — when the gate closes or
+   the file disappears from main while a bundle PR stays open, the file
+   is restored on the reconcile branch from default-branch content,
+   fail-safe on errors. The PR diff always equals current policy intent —
+   the same invariant orphan cleanup enforces for additions.
+
+7. **`when {}` is allowed on any check mode** — the gate is orthogonal to
+   check mode (a when-gated `exists` rule expresses the mirror-image
+   "require dependabot unless renovate is satisfied" policy). Validation
+   and engine wiring are check-mode-agnostic.
 
 ## References
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -51,5 +51,5 @@ docz create design "Your Design Title"
 | DESIGN-0017 | Stale-sweep cutover and repository discovery | Approved | 2026-06-22 | Donald Gifford | [0017-stale-sweep-cutover-and-repository-discovery.md](0017-stale-sweep-cutover-and-repository-discovery.md) |
 | DESIGN-0018 | Deprecate memory backend | Approved | 2026-06-22 | Donald Gifford | [0018-deprecate-memory-backend.md](0018-deprecate-memory-backend.md) |
 | DESIGN-0019 | Configurable annotation-sourced custom properties | Implemented | 2026-07-19 | Donald Gifford | [0019-configurable-annotation-sourced-custom-properties.md](0019-configurable-annotation-sourced-custom-properties.md) |
-| DESIGN-0020 | Absent check mode and conditional file rules | Draft | 2026-07-23 | Donald Gifford | [0020-absent-check-mode-and-conditional-file-rules.md](0020-absent-check-mode-and-conditional-file-rules.md) |
+| DESIGN-0020 | Absent check mode and conditional file rules | Approved | 2026-07-23 | Donald Gifford | [0020-absent-check-mode-and-conditional-file-rules.md](0020-absent-check-mode-and-conditional-file-rules.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -51,4 +51,5 @@ docz create design "Your Design Title"
 | DESIGN-0017 | Stale-sweep cutover and repository discovery | Approved | 2026-06-22 | Donald Gifford | [0017-stale-sweep-cutover-and-repository-discovery.md](0017-stale-sweep-cutover-and-repository-discovery.md) |
 | DESIGN-0018 | Deprecate memory backend | Approved | 2026-06-22 | Donald Gifford | [0018-deprecate-memory-backend.md](0018-deprecate-memory-backend.md) |
 | DESIGN-0019 | Configurable annotation-sourced custom properties | Implemented | 2026-07-19 | Donald Gifford | [0019-configurable-annotation-sourced-custom-properties.md](0019-configurable-annotation-sourced-custom-properties.md) |
+| DESIGN-0020 | Absent check mode and conditional file rules | Draft | 2026-07-23 | Donald Gifford | [0020-absent-check-mode-and-conditional-file-rules.md](0020-absent-check-mode-and-conditional-file-rules.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/impl/0019-absent-check-mode-and-conditional-file-rules.md
+++ b/docs/impl/0019-absent-check-mode-and-conditional-file-rules.md
@@ -38,7 +38,7 @@ created: 2026-07-23
 - [File Changes](#file-changes)
 - [Testing Plan](#testing-plan)
 - [Dependencies](#dependencies)
-- [Open Questions](#open-questions)
+- [Resolved Decisions (Implementation)](#resolved-decisions-implementation)
 - [References](#references)
 <!--toc:end-->
 
@@ -89,8 +89,9 @@ referee evaluation (referee's scope/ignore never affect the gate); new
 `files_forbidden_present_total` metric; auto-watch (Phase 3 is
 unconditional); delete every matching path in one PR; restore stale
 deletions (inverse orphan); `when {}` legal on any check mode. Gate
-errors fail closed. The [Open Questions](#open-questions) below are
-implementation-level only.
+errors fail closed. The
+[Resolved Decisions (Implementation)](#resolved-decisions-implementation)
+below are implementation-level only.
 
 ## Implementation Phases
 
@@ -158,7 +159,8 @@ gated, and the metrics that make both observable. No mutation paths yet.
 
 #### Tasks
 
-- [ ] 1.1 New `internal/checker/gate.go` (placement per OQ 1):
+- [ ] 1.1 New `internal/checker/gate.go` (Decision 1 — minimal breakup,
+      gate helpers only, no wider engine_policy.go refactor):
       `ruleSatisfiedOnDefault(ctx, client, owner, repo, rule)
       (bool, error)` — `evaluateRule` semantics **minus** the
       `hasExistingPRForPolicy` short-circuit, inverted per check mode
@@ -175,12 +177,12 @@ gated, and the metrics that make both observable. No mutation paths yet.
       counter — the file-rule double-iteration contract; a comment must
       say why).
 - [ ] 1.5 Fail-closed error handling: referee evaluation error ⇒ gate
-      closed, Warn log, counter with `reason="error"` (shape per OQ 3);
+      closed, Warn log, counter with `reason="error"` (Decision 3);
       test with an erroring mock asserting the rule is skipped and no
       remediation is planned.
 - [ ] 1.6 `evaluateAbsent` arm in `evaluateRule`: actionable iff **any**
       path in `rule.Paths` exists on the default branch (existence-only;
-      no content fetch). No path plumbing to remediation (per OQ 2).
+      no content fetch). No path plumbing to remediation (Decision 2).
 - [ ] 1.7 `internal/metrics/metrics.go`: `FilesForbiddenPresentTotal
       {rule_name, org}` and `RuleGateClosedTotal{rule_name, org, reason}`
       CounterVecs (reusing `labelRuleName`/`labelOrg`/`labelReason`
@@ -277,21 +279,24 @@ the next sweep.
 
 #### Tasks
 
-- [ ] 3.1 `internal/policy/watch.go.ExtractWatchedPaths`: paths of any
-      rule referenced by a `when.rule_satisfied` join the watched set
-      (union with the existing reconciler-`watch = true` sources). Scope
-      of additional own-path watching per OQ 4.
-- [ ] 3.2 Removed-file push handling per OQ 5 (today
-      `hasWatchedFileChanges` intentionally ignores `commit.Removed` —
-      `internal/webhook/handler.go:314`; a push that *removes*
-      `renovate.json` flips a gate, so removals are now semantically
-      significant for watched paths).
-- [ ] 3.3 Webhook handler tests: push adding `renovate.json` on the
-      default branch enqueues a re-check for a policy where only the
-      *gated* rule references it; plus coverage for whatever OQ 4/OQ 5
-      resolutions add.
-- [ ] 3.4 Doc comment on `ExtractWatchedPaths` updated to name both
-      sources (reconciler watch, gate reference).
+- [ ] 3.1 `internal/policy/watch.go.ExtractWatchedPaths`: for any rule
+      carrying a `when` gate, both the referee's paths AND the gated
+      rule's own paths join the watched set (Decision 4), unioned with
+      the existing reconciler-`watch = true` sources.
+- [ ] 3.2 Extend `hasWatchedFileChanges` to scan `commit.Removed` for
+      watched paths (Decision 5; today removals are intentionally
+      ignored — `internal/webhook/handler.go:314` — which predates
+      removals having policy meaning: a removed `renovate.json` flips a
+      gate). Update the function's doc comment, which currently
+      documents the removed-files exclusion.
+- [ ] 3.3 Webhook handler tests: (i) push adding `renovate.json`
+      enqueues a re-check for a policy where only the *gated* rule
+      references it; (ii) push re-adding `dependabot.yml` (a gated
+      rule's own path) enqueues a re-check; (iii) push *removing*
+      `renovate.json` enqueues a re-check; (iv) pushes touching
+      unwatched paths still enqueue nothing.
+- [ ] 3.4 Doc comment on `ExtractWatchedPaths` updated to name all three
+      sources (reconciler watch, gate reference, gated rule's own paths).
 
 #### Success Criteria
 
@@ -331,7 +336,7 @@ the next sweep.
       invocation); flip DESIGN-0020 to Implemented and this IMPL to
       Completed (frontmatter + body `**Status:**` line, both); mkdocs
       strict-mode warning count unchanged from the 14-file baseline.
-- [ ] 4.6 PR/release mechanics per OQ 6: semver label `minor` (new HCL
+- [ ] 4.6 PR/release mechanics (Decision 6): semver label `minor` (new HCL
       surface, additive binary feature), appVersion bump alongside,
       verifying appVersion against the real tag line per the
       IMPL-0017 post-mortem (Chart.yaml appVersion must equal the tag
@@ -355,13 +360,13 @@ the next sweep.
 | `internal/policy/loader.go` | Modify | schema relax, `when` block, `decodeWhenBlock` |
 | `internal/policy/validate.go` | Modify | validation matrix, `validateWhenGates` (cycle DFS) |
 | `internal/policy/watch.go` | Modify | gate-referenced paths join the watched set |
-| `internal/checker/gate.go` | Create | `ruleSatisfiedOnDefault`, `gateEvaluator` memo (OQ 1) |
+| `internal/checker/gate.go` | Create | `ruleSatisfiedOnDefault`, `gateEvaluator` memo (Decision 1) |
 | `internal/checker/engine_policy.go` | Modify | gate wiring both passes, `evaluateAbsent`, deletion arm in `syncActionableFiles`, body sections, dry-run detail |
 | `internal/checker/drift.go` | Modify | inverse-orphan restoration, reconcile-log wording |
 | `internal/checker/pr.go` | Modify | `buildPRVars` Action population |
 | `internal/template/contexts.go` | Modify | `Rule.Action` (additive) |
 | `internal/metrics/metrics.go` | Modify | two new CounterVecs |
-| `internal/webhook/handler.go` | Modify | removed-file handling per OQ 5 |
+| `internal/webhook/handler.go` | Modify | removed-file handling (Decision 5) |
 | `internal/checker/convergence_test.go` | Modify | renovate-first lifecycle scenarios |
 | `examples/guardian-full.hcl` | Modify | `no_dependabot` worked example |
 | `docs/usage/policy-reference.md` | Modify | operator reference |
@@ -383,8 +388,8 @@ the three canonical stub files.
       restoration, multi-path, idempotent re-sweep with zero mutating
       calls); stateful-mock fidelity for `GetContentsOnBranch` after
       writes.
-- [ ] Phase 3: webhook handler watched-set tests including the OQ 4/5
-      resolutions.
+- [ ] Phase 3: webhook handler watched-set tests — gate-referee add,
+      own-path re-add, referee removal, unwatched no-op (Decisions 4/5).
 - [ ] `go test ./examples/...` covering the updated `guardian-full.hcl`.
 - [ ] Homelab smoke (operator-side, checkbox stays open until run):
       dry-run upgrade shows planned deletions only; enable on the test
@@ -401,83 +406,44 @@ the three canonical stub files.
   `GetContentsOnBranch`, `GetFileContent`, `CreateOrUpdateFile`).
 - Post-v1.9.0 main (IMPL-0017 merged) is the base.
 
-## Open Questions
+## Resolved Decisions (Implementation)
 
-1. **Where do the gate evaluator and absent evaluation live?**
-   - (a) **Recommendation:** new `internal/checker/gate.go` for
-     `ruleSatisfiedOnDefault` + `gateEvaluator` (mirrors the
-     `scope.go` precedent for gate helpers; `engine_policy.go` is
-     already 1,155 lines and gocyclo/funlen limits bite there), with
-     `evaluateAbsent` staying in `engine_policy.go` beside its three
-     sibling evaluate arms.
-   - (b) Everything inline in `engine_policy.go` — one fewer file, but
-     pushes the file toward the lint ceilings and buries the memoization
-     type mid-file.
-   - other:
+All six open questions were resolved on 2026-07-23 with the recommended
+option (a).
 
-2. **How do collected absent-rule paths reach remediation?**
-   - (a) **Recommendation:** they don't — no plumbing.
-     `syncActionableFiles` re-probes each `rule.Paths` entry on the
-     reconcile branch via `GetContentsOnBranch`, which it must call
-     anyway to obtain the blob SHA for `DeleteFile`. Evaluation-time
-     collection stays local to `evaluateAbsent`. Zero signature churn
-     (`findActionableRules` keeps returning `[]policy.FileRuleConfig`;
-     `buildPRVars`, `discoverOrphans`, `refreshPolicyPR` call sites
-     untouched).
-   - (b) Thread an `actionableRule{rule, existingPaths}` wrapper through
-     the actionable slice — saves one `GetContents` round per path at
-     remediation time but changes the return type and every consumer,
-     and the branch-side SHA fetch still has to happen.
-   - other:
+1. **Code placement — new `internal/checker/gate.go`, minimal breakup
+   only.** `ruleSatisfiedOnDefault` + `gateEvaluator` live in the new
+   file (mirrors the `scope.go` precedent; `engine_policy.go` is already
+   1,155 lines); `evaluateAbsent` stays in `engine_policy.go` beside its
+   three sibling evaluate arms. **Explicit constraint from review:** do
+   NOT expand this into a wider engine_policy.go restructuring — the
+   feature ships against the file as it stands, and broader structural
+   cleanup is deferred to a separate tech-debt investigation after the
+   feature is proven working in service.
 
-3. **`rule_gate_closed_total` shape for the fail-closed error case?**
-   - (a) **Recommendation:** one counter with a `reason` label —
-     `rule_gate_closed_total{rule_name, org, reason}`, reason ∈
-     `not_satisfied` | `error`. Bounded cardinality (2 values), and an
-     alert on `reason="error"` distinguishes "gate working as designed"
-     from "API trouble is silently suppressing rules", which are
-     operationally very different.
-   - (b) No reason label; errors visible only in Warn logs. Simpler, but
-     a sustained API failure that suppresses a rule fleet-wide would be
-     invisible to metrics.
-   - other:
+2. **No path plumbing to remediation.** `syncActionableFiles` re-probes
+   each `rule.Paths` entry on the reconcile branch via
+   `GetContentsOnBranch` — needed anyway for the `DeleteFile` blob SHA.
+   `findActionableRules` keeps returning `[]policy.FileRuleConfig`; all
+   consumer call sites untouched.
 
-4. **Watched-set symmetry: also watch the gated rule's own paths?**
-   - (a) **Recommendation:** Yes — when a rule carries a `when` gate,
-     watch the referee's paths (Decision 4) *and* the gated rule's own
-     paths. A push that re-adds `dependabot.yml` to a gated repo then
-     triggers the removal PR immediately instead of at the next weekly
-     sweep. Same mechanism, one union, symmetric convergence.
-   - (b) Referee paths only — the literal Decision 4 scope. Re-added
-     forbidden files wait for the sweep cadence.
-   - other:
+3. **`rule_gate_closed_total{rule_name, org, reason}`** with reason ∈
+   `not_satisfied` | `error`. Bounded cardinality; `reason="error"` is
+   the alertable signal for "API trouble is silently suppressing rules".
 
-5. **Push events: start honoring `commit.Removed` for watched paths?**
-   - (a) **Recommendation:** Yes, for all watched paths.
-     `hasWatchedFileChanges` deliberately ignores removals today
-     (`handler.go:314`) — that was correct when watched files only fed
-     content reconcilers, but a removal now carries policy meaning: a
-     removed `renovate.json` flips a gate (restoration/auto-close should
-     react), and under OQ 4(a) a removed `dependabot.yml` is a
-     convergence event. One extra loop over `commit.Removed`; re-check
-     is cheap and idempotent.
-   - (b) Keep ignoring removals; the sweep catches gate flips hours or
-     days later. No handler change, slower convergence on the
-     gate-closing edge only.
-   - other:
+4. **Watched-set symmetry** — a gated rule contributes both the
+   referee's paths and its own paths to the watched set. A re-added
+   `dependabot.yml` triggers the removal PR on the push path.
 
-6. **PR packaging and release shape?**
-   - (a) **Recommendation:** one feature branch, one PR for Phases 0–4,
-     commit-per-task, semver label `minor` — the IMPL-0017 flow, which
-     just shipped cleanly. The phases are tightly coupled (Phase 0's
-     schema is inert without Phase 1/2; splitting ships dead config
-     surface) and one PR means one release, one migration note, one
-     appVersion bump.
-   - (b) Two PRs: core engine (Phases 0–2, `minor`) then webhook + docs
-     (Phases 3–4, `patch` or folded into the first release). Smaller
-     reviews, but the intermediate release has sweep-only convergence
-     and the docs lag the feature.
-   - other:
+5. **Honor `commit.Removed` for watched paths** — removals now carry
+   policy meaning (a removed `renovate.json` flips a gate; a removed
+   `dependabot.yml` is a convergence event). `hasWatchedFileChanges`
+   gains one loop over `commit.Removed`; its doc comment loses the
+   removed-files exclusion.
+
+6. **Single PR, Phases 0–4, commit-per-task, `minor` label** — the
+   IMPL-0017 flow. One release, one migration note, one appVersion bump
+   (verified against the real tag line per task 4.6).
 
 ## References
 

--- a/docs/impl/0019-absent-check-mode-and-conditional-file-rules.md
+++ b/docs/impl/0019-absent-check-mode-and-conditional-file-rules.md
@@ -1,0 +1,488 @@
+---
+id: IMPL-0019
+title: "Absent check mode and conditional file rules"
+status: Draft
+author: Donald Gifford
+created: 2026-07-23
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# IMPL 0019: Absent check mode and conditional file rules
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-07-23
+
+<!--toc:start-->
+- [Objective](#objective)
+- [Scope](#scope)
+  - [In Scope](#in-scope)
+  - [Out of Scope](#out-of-scope)
+- [Design Decisions Carried In](#design-decisions-carried-in)
+- [Implementation Phases](#implementation-phases)
+  - [Phase 0: Policy schema, loader, validation](#phase-0-policy-schema-loader-validation)
+    - [Tasks](#tasks)
+    - [Success Criteria](#success-criteria)
+  - [Phase 1: Engine evaluation — when-gate and absent mode](#phase-1-engine-evaluation--when-gate-and-absent-mode)
+    - [Tasks](#tasks-1)
+    - [Success Criteria](#success-criteria-1)
+  - [Phase 2: Remediation — deletion commits, PR wording, convergence](#phase-2-remediation--deletion-commits-pr-wording-convergence)
+    - [Tasks](#tasks-2)
+    - [Success Criteria](#success-criteria-2)
+  - [Phase 3: Push-event fast convergence](#phase-3-push-event-fast-convergence)
+    - [Tasks](#tasks-3)
+    - [Success Criteria](#success-criteria-3)
+  - [Phase 4: Documentation, examples, release](#phase-4-documentation-examples-release)
+    - [Tasks](#tasks-4)
+    - [Success Criteria](#success-criteria-4)
+- [File Changes](#file-changes)
+- [Testing Plan](#testing-plan)
+- [Dependencies](#dependencies)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Objective
+
+Implement [DESIGN-0020](../design/0020-absent-check-mode-and-conditional-file-rules.md)
+(Approved 2026-07-23): a fourth file-rule check mode `check = "absent"`
+whose remediation is a file-deletion PR on the existing reconcile branch,
+plus a `when { rule_satisfied = "<rule>" }` gating block that makes any
+file rule conditional on a sibling rule being satisfied on the default
+branch. Driving use case: renovate-first policies — never add Dependabot,
+and remove `dependabot.yml` from any repo whose `renovate_config` rule
+passes.
+
+**Implements:** DESIGN-0020
+
+## Scope
+
+### In Scope
+
+- `internal/policy`: `CheckAbsent`, `WhenConfig`, HCL schema/decode,
+  the full validation matrix including gate-graph cycle detection.
+- `internal/checker`: gate evaluation (fail-closed, memoized per
+  repo-check), absent-mode evaluation, deletion remediation, inverse-orphan
+  restoration, reconcile-log wording, PR body Added/Removed split.
+- `internal/template`: additive `Rule.Action` field.
+- `internal/metrics`: `files_forbidden_present_total`,
+  `rule_gate_closed_total`.
+- `internal/policy/watch.go` + `internal/webhook`: watched-set extension
+  for gate-referenced paths (DESIGN-0020 Decision 4).
+- Operator docs, `examples/guardian-full.hcl`, migration notes.
+
+### Out of Scope
+
+- `when {}` on setting / branch-protection rules (DESIGN-0020 non-goal).
+- Same-PR atomicity between the gating rule's addition and the gated
+  rule's deletion — the two-PR eventual-consistency flow is accepted.
+- Direct-to-default-branch deletes; everything flows through the
+  reconcile-branch PR.
+- Chart changes (no new values, no new alerts; deletion PRs surface
+  through existing PR metrics).
+
+## Design Decisions Carried In
+
+All seven DESIGN-0020 decisions are settled (option a, 2026-07-23) and
+are **not** re-opened here: `rule_satisfied`-only gate; content-only
+referee evaluation (referee's scope/ignore never affect the gate); new
+`files_forbidden_present_total` metric; auto-watch (Phase 3 is
+unconditional); delete every matching path in one PR; restore stale
+deletions (inverse orphan); `when {}` legal on any check mode. Gate
+errors fail closed. The [Open Questions](#open-questions) below are
+implementation-level only.
+
+## Implementation Phases
+
+Each phase builds on the previous one. A phase is complete when all its
+tasks are checked off and its success criteria are met. Run `make fmt`
+and `make lint` after each task; commit per numbered task with
+conventional commits.
+
+---
+
+### Phase 0: Policy schema, loader, validation
+
+Everything the engine needs to *see* the new config, failing loudly on
+every malformed variant before any engine code exists.
+
+#### Tasks
+
+- [ ] 0.1 Add `CheckAbsent CheckMode = "absent"` to
+      `internal/policy/types.go` (const block + `CheckMode()` switch) and
+      the `validChecks` allowlist in `validate.go.validateFileRule`.
+- [ ] 0.2 Add `WhenConfig struct { RuleSatisfied string }` and
+      `When *WhenConfig` field on `FileRuleConfig` (`types.go`), with doc
+      comments stating default-branch-only + content-only + fail-closed
+      semantics.
+- [ ] 0.3 `loader.go`: drop `Required: true` from `target` and `template`
+      in `ruleBodySchema` (loader.go:484-491); add `{Type: "when"}` to its
+      block list; implement `decodeWhenBlock` (own `hcl.BodySchema` with
+      the single `rule_satisfied` attribute so unknown attrs fail load,
+      per the INV-0010 guardian-block precedent); wire into
+      `decodeRuleSubBlocks`.
+- [ ] 0.4 `validate.go`: move `target`/`template` requiredness out of the
+      HCL schema into `validateFileRule`, conditioned on check mode —
+      absent **forbids** `target`, `template`, `assertion` blocks, and
+      `reconcile` blocks; all other modes **require** `target` +
+      `template` exactly as today.
+- [ ] 0.5 `validate.go`: new `validateWhenGates(rules []FileRuleConfig)`
+      — referenced rule must exist among file rules (error lists known
+      rule names), must not be a setting/branch-protection name, must be
+      enabled, no self-reference, no cycles of any length (DFS over the
+      gate graph), empty `when {}` block is an error.
+- [ ] 0.6 Loader tests: the DESIGN-0020 HCL-surface example loads clean;
+      one test per validation-matrix row asserting the exact
+      location-prefixed error; cycle tests at length 2 and 3; unknown
+      attribute inside `when {}` fails load.
+- [ ] 0.7 `policy.Version` test: adding a `when` block, or flipping a
+      rule's check mode to `absent`, changes the hash (`version.go`
+      discrimination contract).
+
+#### Success Criteria
+
+- `make lint` and `make test` pass.
+- A `guardian.hcl` containing the DESIGN-0020 example parses without
+  error; every validation-matrix row has a failing-fixture test.
+- `policy.BuiltinDefaults()` is byte-identical (no absent rules ship as
+  defaults; defaults tests untouched).
+- No engine behavior change yet — an absent rule loads but is inert
+  until Phase 1 (verified by an engine test asserting zero actions).
+
+---
+
+### Phase 1: Engine evaluation — when-gate and absent mode
+
+The read-only half of the engine work: which rules fire, which are
+gated, and the metrics that make both observable. No mutation paths yet.
+
+#### Tasks
+
+- [ ] 1.1 New `internal/checker/gate.go` (placement per OQ 1):
+      `ruleSatisfiedOnDefault(ctx, client, owner, repo, rule)
+      (bool, error)` — `evaluateRule` semantics **minus** the
+      `hasExistingPRForPolicy` short-circuit, inverted per check mode
+      (exists / contains / exact / absent as specified in DESIGN-0020
+      §Evaluation flow).
+- [ ] 1.2 `gate.go`: per-repo-check memoization — a `gateEvaluator`
+      struct holding `map[string]gateResult`, constructed inside
+      `checkRepoWithPolicy` and threaded to both iteration passes (never
+      stored on `Engine`: the engine is shared across worker goroutines).
+- [ ] 1.3 Wire the gate into `findActionableRules` after the scope and
+      ignore gates: closed gate ⇒ Info log (rule, referee, referee
+      state) + `RuleGateClosedTotal` increment, rule skipped.
+- [ ] 1.4 Wire the same gate into `runReconcilers` **silently** (no
+      counter — the file-rule double-iteration contract; a comment must
+      say why).
+- [ ] 1.5 Fail-closed error handling: referee evaluation error ⇒ gate
+      closed, Warn log, counter with `reason="error"` (shape per OQ 3);
+      test with an erroring mock asserting the rule is skipped and no
+      remediation is planned.
+- [ ] 1.6 `evaluateAbsent` arm in `evaluateRule`: actionable iff **any**
+      path in `rule.Paths` exists on the default branch (existence-only;
+      no content fetch). No path plumbing to remediation (per OQ 2).
+- [ ] 1.7 `internal/metrics/metrics.go`: `FilesForbiddenPresentTotal
+      {rule_name, org}` and `RuleGateClosedTotal{rule_name, org, reason}`
+      CounterVecs (reusing `labelRuleName`/`labelOrg`/`labelReason`
+      consts). Absent-actionable increments the new counter and must NOT
+      increment `FilesMissingTotal` (asserted).
+- [ ] 1.8 Engine tests (`engine_test.go` mock pattern): all five
+      DESIGN-0020 semantics-matrix rows; gate-true-despite-open-referee-PR
+      (the short-circuit distinction); memoization (mock call counting:
+      at most one referee content evaluation per repo-check); metric
+      assertions with unique label values.
+
+#### Success Criteria
+
+- `make lint` and `make test` pass.
+- Semantics matrix fully covered by table-driven tests.
+- Gate evaluation cost: ≤1 referee evaluation per referenced rule per
+  repo-check, asserted via mock counters.
+- Dry-run only: with `dry_run = true`, an actionable absent rule logs
+  its planned deletions and mutates nothing (bridge assertion ahead of
+  Phase 2).
+
+---
+
+### Phase 2: Remediation — deletion commits, PR wording, convergence
+
+The mutation half: deletion commits on the reconcile branch, PR text
+that describes removals, restoration of stale deletions, and the
+multi-sweep convergence suite that proves the lifecycle.
+
+#### Tasks
+
+- [ ] 2.1 `syncActionableFiles` action split (`engine_policy.go:582`):
+      absent rules walk **all** `rule.Paths`, `GetContentsOnBranch` each
+      on the reconcile branch — exists ⇒ `DeleteFile(branch, path, sha,
+      "chore: remove <path> (forbidden by rule \"<name>\")")`; already
+      absent ⇒ idempotent skip (mirror of the INV-0003 three-branch
+      contract). Add/fix modes unchanged.
+- [ ] 2.2 Dry-run detail: the `checkRepoWithPolicy` dry-run arm
+      enumerates planned deletions per absent rule (path list in the log
+      record) — deletion is the engine's first destructive remediation;
+      "would create PR" alone is not reviewable.
+- [ ] 2.3 `internal/template/contexts.go`: `Rule.Action string` field
+      (`"add"` | `"remove"`), populated in `buildPRVars` from
+      `CheckMode()`. Additive — `ValidateZero` strict-mode templates keep
+      passing (asserted).
+- [ ] 2.4 `buildPRBodyFromPolicy`: split into "Added files" / "Removed
+      files" sections; CODEOWNERS-placeholder note renders only when an
+      add-mode rule is present.
+- [ ] 2.5 Inverse-orphan restoration (`drift.go`): absent arm in
+      `discoverOrphans` — for each no-longer-actionable absent rule,
+      where default branch has a path and the reconcile branch does not,
+      restore via `GetFileContent`(default) + `CreateOrUpdateFile`(branch,
+      `"chore: restore <path> (rule \"<name>\" no longer applies)"`).
+      Fail-safe: any API error ⇒ leave it, Warn,
+      `PROrphanLeftTotal{org}` increment, retry next sweep.
+- [ ] 2.6 Reconcile-log wording (`drift.go.buildReconcileLogEvents`):
+      absent-aware statuses (`present on main, pending removal` /
+      `absent from main`) and gate-closed status (`skipped (when-gate
+      closed: <referee> not satisfied)`) — requires threading gate
+      outcomes into the event builder. Note in the task commit: status
+      strings feed the content hash, so every open PR gets exactly one
+      extra comment edit after upgrade.
+- [ ] 2.7 Convergence suite (`convergence_test.go`, extending
+      `stagedConvergenceState`): renovate-first lifecycle sweep 1
+      (add-renovate PR) → merge → sweep 2 (remove-dependabot PR) → merge
+      → sweep 3 (converged, no action); hand-deleted dependabot →
+      auto-close; gate closes mid-flight in a bundle PR → restoration;
+      both `.yml` + `.yaml` present → both deleted in one PR; identical
+      re-sweep ⇒ zero mutating API calls.
+- [ ] 2.8 Mock-fidelity check per the list-then-act rule: the mock's
+      `GetContentsOnBranch` must reflect prior `DeleteFile` /
+      `CreateOrUpdateFile` calls on the same mock instance, and the
+      idempotency assertions must count mutating calls — an always-static
+      mock passes those tests vacuously.
+
+#### Success Criteria
+
+- `make ci` passes.
+- The convergence suite demonstrates the full renovate-first lifecycle
+  end-to-end against stateful mocks, including auto-close and
+  restoration edges.
+- A bundle PR mixing one add-rule and one absent-rule renders both body
+  sections and produces both commit kinds on the branch.
+- Re-running an identical sweep produces zero mutating API calls,
+  asserted via mock counters (not just "no error").
+
+---
+
+### Phase 3: Push-event fast convergence
+
+Auto-watch per DESIGN-0020 Decision 4: merging the referee's add-PR
+triggers the gated rule's re-check within the webhook path instead of
+the next sweep.
+
+#### Tasks
+
+- [ ] 3.1 `internal/policy/watch.go.ExtractWatchedPaths`: paths of any
+      rule referenced by a `when.rule_satisfied` join the watched set
+      (union with the existing reconciler-`watch = true` sources). Scope
+      of additional own-path watching per OQ 4.
+- [ ] 3.2 Removed-file push handling per OQ 5 (today
+      `hasWatchedFileChanges` intentionally ignores `commit.Removed` —
+      `internal/webhook/handler.go:314`; a push that *removes*
+      `renovate.json` flips a gate, so removals are now semantically
+      significant for watched paths).
+- [ ] 3.3 Webhook handler tests: push adding `renovate.json` on the
+      default branch enqueues a re-check for a policy where only the
+      *gated* rule references it; plus coverage for whatever OQ 4/OQ 5
+      resolutions add.
+- [ ] 3.4 Doc comment on `ExtractWatchedPaths` updated to name both
+      sources (reconciler watch, gate reference).
+
+#### Success Criteria
+
+- `make lint` and `make test` pass.
+- In the handler test, the dependabot-removal re-check enqueues on the
+  first post-merge push event, not on the next scheduled sweep.
+- No webhook behavior change for policies with no `when` blocks
+  (existing handler tests untouched and green).
+
+---
+
+### Phase 4: Documentation, examples, release
+
+#### Tasks
+
+- [ ] 4.1 `docs/usage/policy-reference.md`: `absent` check-mode section,
+      `when {}` block reference, the validation-matrix table, gate
+      fail-closed semantics, and the search-terms collision guidance
+      (an absent rule's `search_terms` must not match the add-era PR
+      titles for the same file — the example uses `"remove dependabot"`).
+- [ ] 4.2 `examples/guardian-full.hcl`: add the `no_dependabot` rule
+      (check = "absent" + when gate on `renovate_config`); replace the
+      name-glob `ignore { repos = ["myorg/renovate-*"] }` workaround on
+      the dependabot rule, keeping the old form as a commented
+      alternative; `go test ./examples/...` green.
+- [ ] 4.3 `docs/operations/absent-rules-migration.md` (per the
+      `*-migration.md` precedent): dry-run-first recipe leading the doc
+      (destructive remediation), policy-hash bump ⇒ one-time full
+      re-sweep, reconcile-log hash bump ⇒ one comment edit per open PR,
+      downgrade behavior (older binary fails loudly at load on the
+      unknown check mode), search-terms guidance.
+- [ ] 4.4 CLAUDE.md architecture notes: absent mode, when-gate
+      fail-closed + content-only semantics, inverse-orphan restoration,
+      gate counter only-in-primary-pass reminder, memoization
+      per-repo-check-never-on-Engine.
+- [ ] 4.5 `docz update impl` / `docz update design` (one type per
+      invocation); flip DESIGN-0020 to Implemented and this IMPL to
+      Completed (frontmatter + body `**Status:**` line, both); mkdocs
+      strict-mode warning count unchanged from the 14-file baseline.
+- [ ] 4.6 PR/release mechanics per OQ 6: semver label `minor` (new HCL
+      surface, additive binary feature), appVersion bump alongside,
+      verifying appVersion against the real tag line per the
+      IMPL-0017 post-mortem (Chart.yaml appVersion must equal the tag
+      the semver label will actually cut from the latest real release).
+
+#### Success Criteria
+
+- `make ci` passes.
+- Policy-reference renders the semantics matrix and validation table;
+  the example file loads in `go test ./examples/...`.
+- Migration doc exists and leads with the dry-run recipe.
+- Docs indices regenerated; statuses flipped; mkdocs baseline unchanged.
+
+---
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/policy/types.go` | Modify | `CheckAbsent`, `WhenConfig`, `When` field |
+| `internal/policy/loader.go` | Modify | schema relax, `when` block, `decodeWhenBlock` |
+| `internal/policy/validate.go` | Modify | validation matrix, `validateWhenGates` (cycle DFS) |
+| `internal/policy/watch.go` | Modify | gate-referenced paths join the watched set |
+| `internal/checker/gate.go` | Create | `ruleSatisfiedOnDefault`, `gateEvaluator` memo (OQ 1) |
+| `internal/checker/engine_policy.go` | Modify | gate wiring both passes, `evaluateAbsent`, deletion arm in `syncActionableFiles`, body sections, dry-run detail |
+| `internal/checker/drift.go` | Modify | inverse-orphan restoration, reconcile-log wording |
+| `internal/checker/pr.go` | Modify | `buildPRVars` Action population |
+| `internal/template/contexts.go` | Modify | `Rule.Action` (additive) |
+| `internal/metrics/metrics.go` | Modify | two new CounterVecs |
+| `internal/webhook/handler.go` | Modify | removed-file handling per OQ 5 |
+| `internal/checker/convergence_test.go` | Modify | renovate-first lifecycle scenarios |
+| `examples/guardian-full.hcl` | Modify | `no_dependabot` worked example |
+| `docs/usage/policy-reference.md` | Modify | operator reference |
+| `docs/operations/absent-rules-migration.md` | Create | upgrade/migration guide |
+| `CLAUDE.md` | Modify | architecture notes |
+
+No `github.Client` interface changes ⇒ no mockClient-parity sweep across
+the three canonical stub files.
+
+## Testing Plan
+
+- [ ] Phase 0: validation-matrix fixture tests (one per row, exact
+      errors); cycle detection length 2/3; `policy.Version`
+      discrimination.
+- [ ] Phase 1: semantics-matrix table-driven engine tests; gate
+      memoization via mock call counting; fail-closed error test;
+      metric assertions with unique labels (parallel-safe).
+- [ ] Phase 2: multi-sweep convergence suite (lifecycle, auto-close,
+      restoration, multi-path, idempotent re-sweep with zero mutating
+      calls); stateful-mock fidelity for `GetContentsOnBranch` after
+      writes.
+- [ ] Phase 3: webhook handler watched-set tests including the OQ 4/5
+      resolutions.
+- [ ] `go test ./examples/...` covering the updated `guardian-full.hcl`.
+- [ ] Homelab smoke (operator-side, checkbox stays open until run):
+      dry-run upgrade shows planned deletions only; enable on the test
+      org ⇒ removal PR opens against a repo with both renovate +
+      dependabot; merge renovate-add PR on a dependabot-only repo ⇒
+      removal PR arrives via push path (Phase 3); hand-delete
+      dependabot on main ⇒ open removal PR auto-closes.
+
+## Dependencies
+
+- DESIGN-0020 Approved (done, 2026-07-23; PR #165).
+- No store/queue/scheduler surface; no chart changes; builds on
+  `github.Client` methods that already exist (`DeleteFile`,
+  `GetContentsOnBranch`, `GetFileContent`, `CreateOrUpdateFile`).
+- Post-v1.9.0 main (IMPL-0017 merged) is the base.
+
+## Open Questions
+
+1. **Where do the gate evaluator and absent evaluation live?**
+   - (a) **Recommendation:** new `internal/checker/gate.go` for
+     `ruleSatisfiedOnDefault` + `gateEvaluator` (mirrors the
+     `scope.go` precedent for gate helpers; `engine_policy.go` is
+     already 1,155 lines and gocyclo/funlen limits bite there), with
+     `evaluateAbsent` staying in `engine_policy.go` beside its three
+     sibling evaluate arms.
+   - (b) Everything inline in `engine_policy.go` — one fewer file, but
+     pushes the file toward the lint ceilings and buries the memoization
+     type mid-file.
+   - other:
+
+2. **How do collected absent-rule paths reach remediation?**
+   - (a) **Recommendation:** they don't — no plumbing.
+     `syncActionableFiles` re-probes each `rule.Paths` entry on the
+     reconcile branch via `GetContentsOnBranch`, which it must call
+     anyway to obtain the blob SHA for `DeleteFile`. Evaluation-time
+     collection stays local to `evaluateAbsent`. Zero signature churn
+     (`findActionableRules` keeps returning `[]policy.FileRuleConfig`;
+     `buildPRVars`, `discoverOrphans`, `refreshPolicyPR` call sites
+     untouched).
+   - (b) Thread an `actionableRule{rule, existingPaths}` wrapper through
+     the actionable slice — saves one `GetContents` round per path at
+     remediation time but changes the return type and every consumer,
+     and the branch-side SHA fetch still has to happen.
+   - other:
+
+3. **`rule_gate_closed_total` shape for the fail-closed error case?**
+   - (a) **Recommendation:** one counter with a `reason` label —
+     `rule_gate_closed_total{rule_name, org, reason}`, reason ∈
+     `not_satisfied` | `error`. Bounded cardinality (2 values), and an
+     alert on `reason="error"` distinguishes "gate working as designed"
+     from "API trouble is silently suppressing rules", which are
+     operationally very different.
+   - (b) No reason label; errors visible only in Warn logs. Simpler, but
+     a sustained API failure that suppresses a rule fleet-wide would be
+     invisible to metrics.
+   - other:
+
+4. **Watched-set symmetry: also watch the gated rule's own paths?**
+   - (a) **Recommendation:** Yes — when a rule carries a `when` gate,
+     watch the referee's paths (Decision 4) *and* the gated rule's own
+     paths. A push that re-adds `dependabot.yml` to a gated repo then
+     triggers the removal PR immediately instead of at the next weekly
+     sweep. Same mechanism, one union, symmetric convergence.
+   - (b) Referee paths only — the literal Decision 4 scope. Re-added
+     forbidden files wait for the sweep cadence.
+   - other:
+
+5. **Push events: start honoring `commit.Removed` for watched paths?**
+   - (a) **Recommendation:** Yes, for all watched paths.
+     `hasWatchedFileChanges` deliberately ignores removals today
+     (`handler.go:314`) — that was correct when watched files only fed
+     content reconcilers, but a removal now carries policy meaning: a
+     removed `renovate.json` flips a gate (restoration/auto-close should
+     react), and under OQ 4(a) a removed `dependabot.yml` is a
+     convergence event. One extra loop over `commit.Removed`; re-check
+     is cheap and idempotent.
+   - (b) Keep ignoring removals; the sweep catches gate flips hours or
+     days later. No handler change, slower convergence on the
+     gate-closing edge only.
+   - other:
+
+6. **PR packaging and release shape?**
+   - (a) **Recommendation:** one feature branch, one PR for Phases 0–4,
+     commit-per-task, semver label `minor` — the IMPL-0017 flow, which
+     just shipped cleanly. The phases are tightly coupled (Phase 0's
+     schema is inert without Phase 1/2; splitting ships dead config
+     surface) and one PR means one release, one migration note, one
+     appVersion bump.
+   - (b) Two PRs: core engine (Phases 0–2, `minor`) then webhook + docs
+     (Phases 3–4, `patch` or folded into the first release). Smaller
+     reviews, but the intermediate release has sweep-only convergence
+     and the docs lag the feature.
+   - other:
+
+## References
+
+- [DESIGN-0020 — Absent check mode and conditional file rules](../design/0020-absent-check-mode-and-conditional-file-rules.md) (Approved; all decisions resolved 2026-07-23)
+- IMPL-0013 — orphan cleanup / auto-close / sticky reconcile-log machinery this feature extends; the Q9 fail-safe stance generalized to gates and restoration
+- INV-0003 — `CreateOrUpdateFile` three-branch idempotency mirrored by the deletion arm
+- IMPL-0017 — single-PR, commit-per-task flow precedent; appVersion-vs-real-tag release gotcha (task 4.6)
+- Audited code paths (as of v1.9.0): `internal/policy/{types,loader,validate,version,watch}.go`, `internal/checker/{engine_policy,drift,pr}.go`, `internal/webhook/handler.go:213-330`, `internal/metrics/metrics.go`

--- a/docs/impl/README.md
+++ b/docs/impl/README.md
@@ -50,4 +50,5 @@ docz create impl "Your Implementation Title"
 | IMPL-0016 | Deprecate memory backend | Completed | 2026-06-23 | Donald Gifford | [0016-deprecate-memory-backend.md](0016-deprecate-memory-backend.md) |
 | IMPL-0017 | Configurable annotation-sourced custom properties | Completed | 2026-07-20 | Donald Gifford | [0017-configurable-annotation-sourced-custom-properties.md](0017-configurable-annotation-sourced-custom-properties.md) |
 | IMPL-0018 | Fix silently ignored operator config | Completed | 2026-07-20 | Donald Gifford | [0018-fix-silently-ignored-operator-config.md](0018-fix-silently-ignored-operator-config.md) |
+| IMPL-0019 | Absent check mode and conditional file rules | Draft | 2026-07-23 | Donald Gifford | [0019-absent-check-mode-and-conditional-file-rules.md](0019-absent-check-mode-and-conditional-file-rules.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
         - 'DESIGN-0017: Stale-sweep cutover and repository discovery': design/0017-stale-sweep-cutover-and-repository-discovery.md
         - 'DESIGN-0018: Deprecate memory backend': design/0018-deprecate-memory-backend.md
         - 'DESIGN-0019: Configurable annotation-sourced custom properties': design/0019-configurable-annotation-sourced-custom-properties.md
+        - 'DESIGN-0020: Absent check mode and conditional file rules': design/0020-absent-check-mode-and-conditional-file-rules.md
     - Implementation Plans:
         - Overview: impl/README.md
         - 'IMPL-0001: Repo Guardian Implementation Plan': impl/0001-repo-guardian-implementation-plan.md
@@ -68,6 +69,7 @@ nav:
     - Operations:
         - Chart 0.5.0 migration runbook (IMPL-0011): operations/chart-0.5.0-migration.md
         - Chart 0.6.0 / appVersion 1.7.0 — PR convergence migration: operations/pr-convergence-migration.md
+        - Custom-property annotation migration (appVersion 1.9.1 → next minor): operations/annotation-properties-migration.md
         - ECR publish setup (maintainer-side): operations/ecr-publish-setup.md
         - Homelab CNPG cutover runbook: operations/cnpg-homelab-cutover.md
         - Postgres schema operations: operations/migrations.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
         - 'IMPL-0016: Deprecate memory backend': impl/0016-deprecate-memory-backend.md
         - 'IMPL-0017: Configurable annotation-sourced custom properties': impl/0017-configurable-annotation-sourced-custom-properties.md
         - 'IMPL-0018: Fix silently ignored operator config': impl/0018-fix-silently-ignored-operator-config.md
+        - 'IMPL-0019: Absent check mode and conditional file rules': impl/0019-absent-check-mode-and-conditional-file-rules.md
     - Investigations:
         - Overview: investigation/README.md
         - 'INV-0001: Tailscale Funnel for Webhook Testing': investigation/0001-tailscale-funnel-for-webhook-testing.md


### PR DESCRIPTION
## Summary
- **DESIGN-0020** (Approved): a fourth file-rule check mode (`check = "absent"`) whose remediation is a file-deletion PR on the existing reconcile branch, plus a `when { rule_satisfied = "<rule>" }` gating block for cross-file conditionality. Driving use case: renovate-first orgs — never add dependabot, remove `dependabot.yml` wherever `renovate_config` is satisfied. All seven design open questions resolved (option a); two-PR eventual consistency accepted as a deliberate non-goal.
- **IMPL-0019** (Draft): five phases with checkbox tasks and per-phase success criteria — policy schema/loader/validation (incl. gate-graph cycle detection), engine when-gate + absent evaluation (fail-closed, memoized), deletion remediation + inverse-orphan restoration + convergence suite, push-event fast convergence, docs/examples/release. Six implementation-level open questions pending review, two of them surfaced by code audit (webhook `commit.Removed` handling; watched-set symmetry).

## Test plan
- [x] `docz update design` / `docz update impl` indices regenerated
- [x] Docs-only change — no code touched; `dont-release` label applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)