### PR TITLE
docs(inv): INV-0011 — tech-debt cleanup inventory post IMPL-0019

### DIFF
--- a/docs/design/0020-absent-check-mode-and-conditional-file-rules.md
+++ b/docs/design/0020-absent-check-mode-and-conditional-file-rules.md
@@ -244,7 +244,10 @@ Changes concentrate in `findActionableRules` and a new shared helper:
    skipped this sweep, Warn log). Rationale: the gated action is
    typically destructive (deletion); a transient error must never cause a
    delete PR against a repo whose Renovate state is unknown. This mirrors
-   the IMPL-0013 Q9 fail-safe stance.
+   the IMPL-0013 Q9 fail-safe stance and the broader principle INV-0011
+   A1 makes explicit: a destructive action never proceeds from an
+   unknown or error state — unparseable/unreachable input is never
+   treated as desired state.
 5. **`evaluateAbsent`.** New evaluation arm: walk **all** of `paths`
    (unlike `findExistingFile`, which stops at the first hit) and collect
    every existing path. Actionable when the set is non-empty. The

--- a/docs/impl/0019-absent-check-mode-and-conditional-file-rules.md
+++ b/docs/impl/0019-absent-check-mode-and-conditional-file-rules.md
@@ -121,7 +121,14 @@ every malformed variant before any engine code exists.
       block list; implement `decodeWhenBlock` (own `hcl.BodySchema` with
       the single `rule_satisfied` attribute so unknown attrs fail load,
       per the INV-0010 guardian-block precedent); wire into
-      `decodeRuleSubBlocks`.
+      `decodeRuleSubBlocks`. **Null/unknown guard (INV-0011 A8):** the
+      `rule_satisfied` cty value must be checked with `IsNull()` /
+      `IsKnown()` and its type asserted to `cty.String` BEFORE calling
+      `.AsString()` — a typed-null or conditional-unknown expression
+      (`rule_satisfied = null`, or a `? :` yielding null) otherwise
+      panics at load instead of returning a diagnostic. This is the
+      exact class of bug INV-0011 found in `decodeAnnotationProperties`;
+      the new decoder must not repeat it.
 - [ ] 0.4 `validate.go`: move `target`/`template` requiredness out of the
       HCL schema into `validateFileRule`, conditioned on check mode —
       absent **forbids** `target`, `template`, `assertion` blocks, and
@@ -135,7 +142,9 @@ every malformed variant before any engine code exists.
 - [ ] 0.6 Loader tests: the DESIGN-0020 HCL-surface example loads clean;
       one test per validation-matrix row asserting the exact
       location-prefixed error; cycle tests at length 2 and 3; unknown
-      attribute inside `when {}` fails load.
+      attribute inside `when {}` fails load; `rule_satisfied = null` and
+      a conditional yielding a typed-null return a clean diagnostic
+      rather than panicking (INV-0011 A8 regression guard).
 - [ ] 0.7 `policy.Version` test: adding a `when` block, or flipping a
       rule's check mode to `absent`, changes the hash (`version.go`
       discrimination contract).
@@ -451,4 +460,5 @@ option (a).
 - IMPL-0013 — orphan cleanup / auto-close / sticky reconcile-log machinery this feature extends; the Q9 fail-safe stance generalized to gates and restoration
 - INV-0003 — `CreateOrUpdateFile` three-branch idempotency mirrored by the deletion arm
 - IMPL-0017 — single-PR, commit-per-task flow precedent; appVersion-vs-real-tag release gotcha (task 4.6)
+- [INV-0011](../investigation/0011-tech-debt-cleanup-inventory-post-impl-0019.md) — A8 (typed-null HCL panic in `decodeAnnotationProperties`) is the same decode-guard class task 0.3 must not repeat in `decodeWhenBlock`
 - Audited code paths (as of v1.9.0): `internal/policy/{types,loader,validate,version,watch}.go`, `internal/checker/{engine_policy,drift,pr}.go`, `internal/webhook/handler.go:213-330`, `internal/metrics/metrics.go`

--- a/docs/impl/0020-pre-impl-0019-high-severity-fixes-inv-0011-group-a-high.md
+++ b/docs/impl/0020-pre-impl-0019-high-severity-fixes-inv-0011-group-a-high.md
@@ -1,0 +1,322 @@
+---
+id: IMPL-0020
+title: "Pre-IMPL-0019 high-severity fixes (INV-0011 Group A High)"
+status: Draft
+author: Donald Gifford
+created: 2026-07-23
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# IMPL 0020: Pre-IMPL-0019 high-severity fixes (INV-0011 Group A High)
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-07-23
+
+<!--toc:start-->
+- [Objective](#objective)
+- [Scope](#scope)
+  - [In Scope](#in-scope)
+  - [Out of Scope](#out-of-scope)
+- [Background](#background)
+- [Implementation Phases](#implementation-phases)
+  - [Phase 1: A1 — catalog parse-failure must not clear properties](#phase-1-a1--catalog-parse-failure-must-not-clear-properties)
+    - [Tasks](#tasks)
+    - [Success Criteria](#success-criteria)
+  - [Phase 2: A2 — remove shell-injection from the generated workflow](#phase-2-a2--remove-shell-injection-from-the-generated-workflow)
+    - [Tasks](#tasks-1)
+    - [Success Criteria](#success-criteria-1)
+  - [Phase 3: Docs, migration, release](#phase-3-docs-migration-release)
+    - [Tasks](#tasks-2)
+    - [Success Criteria](#success-criteria-2)
+- [File Changes](#file-changes)
+- [Testing Plan](#testing-plan)
+- [Dependencies](#dependencies)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Objective
+
+Fix the two High-severity findings from
+[INV-0011](../investigation/0011-tech-debt-cleanup-inventory-post-impl-0019.md)
+(A1, A2) on the shipped IMPL-0017 custom-properties surface. Both are
+independent of DESIGN-0020/IMPL-0019 and should land **before** that
+feature work begins: A2 is a live command-injection vector in every
+generated workflow PR, and A1 destroys operator data on a single
+malformed commit. Neither blocks IMPL-0019 logically — this doc exists so
+the fixes ship on their own clock rather than waiting behind a
+multi-week feature.
+
+**Implements:** INV-0011 findings A1, A2
+
+## Scope
+
+### In Scope
+
+- `internal/catalog/catalog.go` — `Parse` returns an error on
+  unparseable input instead of synthesizing destructive defaults.
+- `internal/reconciler/custom_properties.go` — `Reconcile` skips (no
+  GitHub write) on catalog parse failure.
+- `internal/rules/templates/set-custom-properties.tmpl` — annotation
+  values reach the shell via `env:` indirection, YAML-safe.
+- `internal/metrics/metrics.go` — `catalog_parse_failed_total`.
+- Tests, operator docs, migration note, release.
+
+### Out of Scope
+
+- The six Medium findings and all structural debt (A3–A8, B1–B4) — those
+  are [IMPL-0021](0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md).
+- Any DESIGN-0020/IMPL-0019 feature code.
+- Property-*name* charset validation (A6) — a separate Medium; note it is
+  distinct from A2, which concerns runtime property *values*.
+
+## Background
+
+Both findings were verified on current `main` (`b3350ef`); see INV-0011
+Group A for the full write-ups. Condensed:
+
+- **A1** — `catalog.go.Parse` returns `defaults()`
+  (Owner/Component = "Unclassified", empty `Extra`) for BOTH unparseable
+  YAML and valid-but-non-Component entities. In API mode this is fed
+  straight into full-state-sync, so a temporarily malformed
+  `catalog-info.yaml` PATCHes `null` for every mapped property and
+  overwrites Owner/Component. There is exactly one caller:
+  `custom_properties.go:157` (`desired := catalog.Parse(content,
+  r.annotationProps)`).
+- **A2** — `set-custom-properties.tmpl` interpolates `.Catalog.Owner`,
+  each `.Catalog.Properties` value, and `.Catalog.Component` directly
+  inside single-quoted `gh api -f` arguments in the generated GitHub
+  Actions workflow. Those values originate in the repo's
+  `catalog-info.yaml` (attacker-controlled for a repo the app is
+  installed on): a value like `x'$(command)'` achieves command execution
+  under the workflow's `GITHUB_TOKEN` after the PR merges. API mode is
+  unaffected — it sends values through the Go client
+  (`SetCustomPropertyValues`), never a shell.
+
+## Implementation Phases
+
+Run `make fmt` + `make lint` after each task; commit per numbered task
+with conventional commits.
+
+---
+
+### Phase 1: A1 — catalog parse-failure must not clear properties
+
+Make "I could not understand the input" distinguishable from "the input
+says these properties are empty", so the reconciler never treats an
+error as destructive desired state.
+
+#### Tasks
+
+- [ ] 1.1 Change `catalog.Parse` to
+      `Parse(content string, annotationProps map[string]string)
+      (*Properties, error)`: return a wrapped error when
+      `yaml.Unmarshal` fails. Non-Component-entity handling is an
+      explicit decision — see Open Question 1.
+- [ ] 1.2 Update the sole caller `custom_properties.go.Reconcile:157`:
+      on parse error, log `slog.Warn("catalog-info parse failed; skipping
+      reconcile to avoid clearing properties", "err", err)`, increment
+      `metrics.CatalogParseFailedTotal.WithLabelValues(owner)`, and
+      return `nil` (skip — GitHub state untouched, retried next sweep).
+- [ ] 1.3 Add `CatalogParseFailedTotal{org}` CounterVec to
+      `internal/metrics/metrics.go` (reuse `labelOrg`).
+- [ ] 1.4 Update `catalog` package tests: malformed YAML returns an
+      error (not defaults); valid Component parses as today; the
+      non-Component case per Open Question 1.
+- [ ] 1.5 Reconciler test: a malformed `catalog-info.yaml` in API mode
+      issues zero `SetCustomPropertyValues` calls and increments the
+      counter (stateful mock asserts no PATCH).
+
+#### Success Criteria
+
+- `make lint` and `make test` pass.
+- A malformed `catalog-info.yaml` provably results in no custom-property
+  write in API mode (was: clears every mapped property + sets
+  Unclassified).
+- Valid catalog-info parsing is behaviorally unchanged (existing
+  reconciler tests pass without modification, save the signature update).
+
+---
+
+### Phase 2: A2 — remove shell-injection from the generated workflow
+
+Repo-controlled values must never be shell-parsed. Render them into the
+workflow's `env:` block (YAML-safe) and reference them as quoted shell
+variables, which are passed literally and never re-evaluated.
+
+#### Tasks
+
+- [ ] 2.1 Rewrite `set-custom-properties.tmpl` so `Owner`, `Component`,
+      and each `Properties` entry are emitted as workflow `env:` entries
+      (e.g. `RG_PROP_Owner`, `RG_PROP_<name>`), then referenced in the
+      `run:` script as `"$RG_PROP_Owner"` inside the `-f` arguments. The
+      `${{ }}`-escape backtick convention still applies to the GHA
+      expressions already in the file.
+- [ ] 2.2 YAML-safe value emission: values render into `env:` such that a
+      value containing a quote, `$`, newline, or `:` cannot break the
+      workflow YAML or the shell (block scalar or a template helper that
+      quotes/escapes — mechanism per Open Question 2). A value that is
+      empty still signals "clear" via the existing `-F
+      'properties[][value]=null'` branch — the empty/clear distinction
+      moves to checking the env var, not inline rendering.
+- [ ] 2.3 Template parse + render tests
+      (`internal/rules`/`internal/template`): a hostile value
+      (`x'$(id)'`, embedded newline, `a: b`) renders to a workflow whose
+      generated shell passes the literal string and whose YAML still
+      parses. Assert the rendered output contains no unescaped
+      interpolation of the value inside the `run:` block.
+- [ ] 2.4 Confirm strict-template validation (`ValidateZero`) still
+      passes for the rewritten template context (no new required
+      `CatalogInfo` fields introduced).
+
+#### Success Criteria
+
+- `make lint` and `make test` pass.
+- A crafted annotation value that previously produced command
+  substitution now round-trips as an inert literal (regression test
+  proves the injection is closed).
+- The generated workflow YAML remains valid for values containing
+  quotes, `$`, `:`, and newlines.
+
+---
+
+### Phase 3: Docs, migration, release
+
+#### Tasks
+
+- [ ] 3.1 `docs/usage/policy-reference.md` § `custom_properties`: note
+      that a malformed `catalog-info.yaml` is skipped (not cleared), and
+      that generated-workflow values are passed literally.
+- [ ] 3.2 Short migration/security note (release notes or a
+      `docs/operations/*-migration.md` entry): describes the A2 fix as a
+      security fix, recommends operators using GHA mode regenerate any
+      open properties PRs (old branches carry the vulnerable workflow —
+      see Open Question 3).
+- [ ] 3.3 CLAUDE.md: architecture note on the catalog parse-failure
+      skip contract and the env-indirection template convention (so
+      future template edits don't reintroduce inline interpolation).
+- [ ] 3.4 `docz update impl`; flip this doc to Completed; mkdocs
+      strict-mode warning count unchanged from the 14-file baseline.
+- [ ] 3.5 Release: single `fix/` PR, `patch` semver label, appVersion
+      bump verified against the real tag line (per the IMPL-0017
+      post-mortem — Chart.yaml appVersion must equal the tag the label
+      will cut from the latest real release).
+
+#### Success Criteria
+
+- `make ci` passes.
+- Operator-facing docs describe both new behaviors; security note
+  published.
+- One `patch`-labeled PR merged; real release cut with matching
+  appVersion.
+
+---
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/catalog/catalog.go` | Modify | `Parse` returns `(*Properties, error)` |
+| `internal/reconciler/custom_properties.go` | Modify | skip on parse error + counter |
+| `internal/metrics/metrics.go` | Modify | `CatalogParseFailedTotal{org}` |
+| `internal/rules/templates/set-custom-properties.tmpl` | Modify | env-indirection, YAML-safe values |
+| `internal/catalog/catalog_test.go` | Modify | error-on-malformed tests |
+| `internal/reconciler/custom_properties_test.go` | Modify | no-write-on-parse-fail test |
+| `internal/rules/*_test.go` / `internal/template/*_test.go` | Modify | injection regression test |
+| `docs/usage/policy-reference.md` | Modify | behavior notes |
+| `docs/operations/*-migration.md` or release notes | Create | security note |
+| `CLAUDE.md` | Modify | contracts |
+
+No `github.Client` interface change ⇒ no mockClient-parity sweep.
+
+## Testing Plan
+
+- [ ] Phase 1: catalog parse-error returns error; reconciler issues zero
+      writes on malformed input; valid-catalog behavior unchanged.
+- [ ] Phase 2: injection regression (hostile value → inert literal);
+      YAML validity for quote/`$`/`:`/newline values; strict-template
+      validation still passes.
+- [ ] `go test ./examples/...` still green (guardian-full.hcl uses the
+      Jira map through this reconciler).
+- [ ] Homelab smoke (operator-side, stays open until run): push a
+      deliberately malformed catalog-info.yaml ⇒ no property change +
+      counter increments; GHA-mode repo with a quote-bearing annotation
+      value ⇒ generated workflow runs correctly and sets the literal.
+
+## Dependencies
+
+- None blocking. Builds on current `main` (post-IMPL-0017).
+- Should merge before IMPL-0019 implementation begins (sequencing, not a
+  code dependency).
+- A1's parse-abort is a prerequisite for IMPL-0021's A3 fix
+  (clear-on-file-removal is only safe to enable once malformed input can
+  no longer masquerade as "clear everything").
+
+## Open Questions
+
+1. **`catalog.Parse` behavior for valid YAML that is NOT a Backstage
+   Component entity (e.g. `kind: Resource`)?**
+   - (a) **Recommendation:** treat it like a parse failure for
+     sync purposes — return a sentinel (e.g. `(nil, ErrNotComponent)` or
+     a `Parsed bool`) that the reconciler maps to "skip, do not clear."
+     Only a valid Component entity is a positive statement of desired
+     property state; a non-Component file is "not something we manage
+     here," and clearing on it is the same data-loss class as A1.
+   - (b) Keep the current "non-Component ⇒ defaults ⇒ clear" behavior,
+     fixing only the unparseable case. Simpler diff, but a repo that
+     switches its catalog-info to a non-Component kind silently loses its
+     properties.
+   - (c) Error on both unparseable AND non-Component (single error path).
+     Cleanest code, but conflates "garbage" with "valid, just not a
+     component," which may be legitimate for some repos.
+   - other:
+
+2. **A2 value-safe rendering mechanism?**
+   - (a) **Recommendation:** emit values into the `env:` block using a
+     YAML-safe form (single-quoted scalar with `'`-doubling, or a
+     `|`-block scalar) via a small template helper, and reference them as
+     `"$RG_PROP_x"` in `run:`. Env indirection alone closes the shell
+     vector; YAML-safe emission closes the "value breaks the workflow
+     file" vector. Both are needed because the value is baked into a
+     generated file, not passed at runtime.
+   - (b) Env indirection with naive rendering — closes shell execution
+     but a value containing a newline or quote still corrupts the
+     workflow YAML (a lesser bug, but still broken output).
+   - (c) Escape values inline in the `run:` block (no env) — fragile
+     quote-within-quote escaping that the next template edit can silently
+     break; rejected for the same reason the release-pipeline post-mortem
+     moved bake metadata to `env:`.
+   - other:
+
+3. **Do we actively remediate already-open properties PRs carrying the
+   vulnerable workflow?**
+   - (a) **Recommendation:** no automated remediation; document it. The
+     GHA-mode PR-refresh gap is A4 (a separate Medium in IMPL-0021);
+     building refresh here would pull that scope forward. The migration
+     note tells operators to close/regenerate open properties PRs. Most
+     deployments (incl. homelab) run API mode, where the vector never
+     existed.
+   - (b) Add minimal branch-refresh here so the next reconcile rewrites
+     the workflow on existing PRs — safer for GHA-mode users, but
+     overlaps A4 and enlarges a security patch that should stay small.
+   - other:
+
+4. **Packaging — one PR or two?**
+   - (a) **Recommendation:** one `fix/` PR for both A1 and A2, `patch`
+     label. They're both High, both small, both on the same
+     custom-properties surface; one PR = one release = one security note.
+     (INV-0003 precedent: investigation → single tight fix PR.)
+   - (b) Two PRs (A1, then A2) — maximal isolation, but doubles review
+     and release overhead for two changes that are each < ~100 lines and
+     ship together anyway.
+   - other:
+
+## References
+
+- [INV-0011](../investigation/0011-tech-debt-cleanup-inventory-post-impl-0019.md) — source findings A1, A2 (verified on `b3350ef`)
+- [IMPL-0021](0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md) — the Medium + structural remainder (after IMPL-0019)
+- [IMPL-0019](0019-absent-check-mode-and-conditional-file-rules.md) — the feature this doc sequences before; its A3 fix depends on Phase 1 here
+- INV-0003 — precedent for investigation → small standalone fix PR
+- IMPL-0017 — the custom-properties surface being fixed; appVersion-vs-real-tag release gotcha (task 3.5)
+- Audited code (as of `b3350ef`): `internal/catalog/catalog.go:57`, `internal/reconciler/custom_properties.go:157`, `internal/rules/templates/set-custom-properties.tmpl:31`

--- a/docs/impl/0020-pre-impl-0019-high-severity-fixes-inv-0011-group-a-high.md
+++ b/docs/impl/0020-pre-impl-0019-high-severity-fixes-inv-0011-group-a-high.md
@@ -32,7 +32,7 @@ created: 2026-07-23
 - [File Changes](#file-changes)
 - [Testing Plan](#testing-plan)
 - [Dependencies](#dependencies)
-- [Open Questions](#open-questions)
+- [Resolved Decisions](#resolved-decisions)
 - [References](#references)
 <!--toc:end-->
 
@@ -113,7 +113,7 @@ error as destructive desired state.
       `Parse(content string, annotationProps map[string]string)
       (*Properties, error)`: return a wrapped error when
       `yaml.Unmarshal` fails. Non-Component-entity handling is an
-      explicit decision — see Open Question 1.
+      explicit decision — see Decision 1.
 - [ ] 1.2 Update the sole caller `custom_properties.go.Reconcile:157`:
       on parse error, log `slog.Warn("catalog-info parse failed; skipping
       reconcile to avoid clearing properties", "err", err)`, increment
@@ -123,7 +123,7 @@ error as destructive desired state.
       `internal/metrics/metrics.go` (reuse `labelOrg`).
 - [ ] 1.4 Update `catalog` package tests: malformed YAML returns an
       error (not defaults); valid Component parses as today; the
-      non-Component case per Open Question 1.
+      non-Component case per Decision 1.
 - [ ] 1.5 Reconciler test: a malformed `catalog-info.yaml` in API mode
       issues zero `SetCustomPropertyValues` calls and increments the
       counter (stateful mock asserts no PATCH).
@@ -156,7 +156,7 @@ variables, which are passed literally and never re-evaluated.
 - [ ] 2.2 YAML-safe value emission: values render into `env:` such that a
       value containing a quote, `$`, newline, or `:` cannot break the
       workflow YAML or the shell (block scalar or a template helper that
-      quotes/escapes — mechanism per Open Question 2). A value that is
+      quotes/escapes — mechanism per Decision 2). A value that is
       empty still signals "clear" via the existing `-F
       'properties[][value]=null'` branch — the empty/clear distinction
       moves to checking the env var, not inline rendering.
@@ -192,7 +192,7 @@ variables, which are passed literally and never re-evaluated.
       `docs/operations/*-migration.md` entry): describes the A2 fix as a
       security fix, recommends operators using GHA mode regenerate any
       open properties PRs (old branches carry the vulnerable workflow —
-      see Open Question 3).
+      see Decision 3).
 - [ ] 3.3 CLAUDE.md: architecture note on the catalog parse-failure
       skip contract and the env-indirection template convention (so
       future template edits don't reintroduce inline interpolation).
@@ -253,64 +253,39 @@ No `github.Client` interface change ⇒ no mockClient-parity sweep.
   (clear-on-file-removal is only safe to enable once malformed input can
   no longer masquerade as "clear everything").
 
-## Open Questions
+## Resolved Decisions
 
-1. **`catalog.Parse` behavior for valid YAML that is NOT a Backstage
-   Component entity (e.g. `kind: Resource`)?**
-   - (a) **Recommendation:** treat it like a parse failure for
-     sync purposes — return a sentinel (e.g. `(nil, ErrNotComponent)` or
-     a `Parsed bool`) that the reconciler maps to "skip, do not clear."
-     Only a valid Component entity is a positive statement of desired
-     property state; a non-Component file is "not something we manage
-     here," and clearing on it is the same data-loss class as A1.
-   - (b) Keep the current "non-Component ⇒ defaults ⇒ clear" behavior,
-     fixing only the unparseable case. Simpler diff, but a repo that
-     switches its catalog-info to a non-Component kind silently loses its
-     properties.
-   - (c) Error on both unparseable AND non-Component (single error path).
-     Cleanest code, but conflates "garbage" with "valid, just not a
-     component," which may be legitimate for some repos.
-   - other:
+All four open questions resolved 2026-07-23 with the recommended option (a).
 
-2. **A2 value-safe rendering mechanism?**
-   - (a) **Recommendation:** emit values into the `env:` block using a
-     YAML-safe form (single-quoted scalar with `'`-doubling, or a
-     `|`-block scalar) via a small template helper, and reference them as
-     `"$RG_PROP_x"` in `run:`. Env indirection alone closes the shell
-     vector; YAML-safe emission closes the "value breaks the workflow
-     file" vector. Both are needed because the value is baked into a
-     generated file, not passed at runtime.
-   - (b) Env indirection with naive rendering — closes shell execution
-     but a value containing a newline or quote still corrupts the
-     workflow YAML (a lesser bug, but still broken output).
-   - (c) Escape values inline in the `run:` block (no env) — fragile
-     quote-within-quote escaping that the next template edit can silently
-     break; rejected for the same reason the release-pipeline post-mortem
-     moved bake metadata to `env:`.
-   - other:
+1. **Non-Component valid YAML is skipped, not cleared.** `catalog.Parse`
+   returns a sentinel (e.g. `(nil, ErrNotComponent)` or a `Parsed bool`)
+   that the reconciler maps to "skip, do not clear." Only a valid
+   Component entity is a positive statement of desired property state; a
+   non-Component file is "not something we manage here," and clearing on
+   it is the same data-loss class as the A1 parse-failure case. Practical
+   effect: `Parse` distinguishes three outcomes — valid Component (sync),
+   unparseable (error → skip), valid non-Component (skip, no clear).
 
-3. **Do we actively remediate already-open properties PRs carrying the
-   vulnerable workflow?**
-   - (a) **Recommendation:** no automated remediation; document it. The
-     GHA-mode PR-refresh gap is A4 (a separate Medium in IMPL-0021);
-     building refresh here would pull that scope forward. The migration
-     note tells operators to close/regenerate open properties PRs. Most
-     deployments (incl. homelab) run API mode, where the vector never
-     existed.
-   - (b) Add minimal branch-refresh here so the next reconcile rewrites
-     the workflow on existing PRs — safer for GHA-mode users, but
-     overlaps A4 and enlarges a security patch that should stay small.
-   - other:
+2. **A2 fix = env-indirection + YAML-safe emission.** Values render into
+   the workflow `env:` block in a YAML-safe form (single-quoted scalar
+   with `'`-doubling, or a `|`-block scalar, via a small template helper)
+   and are referenced as `"$RG_PROP_x"` in `run:`. Env indirection closes
+   the shell-execution vector; YAML-safe emission closes the
+   "value breaks the generated workflow file" vector. Both are required
+   because the value is baked into a generated file, not passed at
+   runtime.
 
-4. **Packaging — one PR or two?**
-   - (a) **Recommendation:** one `fix/` PR for both A1 and A2, `patch`
-     label. They're both High, both small, both on the same
-     custom-properties surface; one PR = one release = one security note.
-     (INV-0003 precedent: investigation → single tight fix PR.)
-   - (b) Two PRs (A1, then A2) — maximal isolation, but doubles review
-     and release overhead for two changes that are each < ~100 lines and
-     ship together anyway.
-   - other:
+3. **No automated remediation of already-open properties PRs.** Documented
+   only. The GHA-mode PR-refresh gap is A4 (a separate Medium in
+   IMPL-0021); building refresh here would pull that scope into a
+   security patch that should stay small. The migration note tells
+   operators to close/regenerate open properties PRs. Most deployments
+   (incl. homelab) run API mode, where the vector never existed.
+
+4. **One `fix/` PR for both A1 and A2, `patch` label.** Both High, both
+   small, both on the same custom-properties surface — one PR, one
+   release, one security note (INV-0003 precedent: investigation → single
+   tight fix PR).
 
 ## References
 

--- a/docs/impl/0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md
+++ b/docs/impl/0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md
@@ -44,7 +44,7 @@ created: 2026-07-23
 - [File Changes](#file-changes)
 - [Testing Plan](#testing-plan)
 - [Dependencies](#dependencies)
-- [Open Questions](#open-questions)
+- [Resolved Decisions](#resolved-decisions)
 - [References](#references)
 <!--toc:end-->
 
@@ -92,13 +92,13 @@ items B1, B2, B3, B4
   reordered or parallelized; the ordering below is by blast-radius, not
   dependency.
 - Phases 5–7 (Group B) come last and each merges as its own `chore/` PR
-  — see Open Question 5 on whether Group B should split into its own
+  — see Decision 5 on whether Group B should split into its own
   IMPL entirely.
 
 ## Implementation Phases
 
 Run `make fmt` + `make lint` after each task; commit per numbered task
-with conventional commits. Packaging into PRs is Open Question 4.
+with conventional commits. Packaging into PRs is Decision 4.
 
 ---
 
@@ -124,7 +124,7 @@ Two independent logic bugs in `internal/reconciler/custom_properties.go`.
       already exists, so annotation changes never refresh the
       branch/workflow/PR body. Refresh the existing PR's workflow file
       and body when desired state has changed since it was opened
-      (reuse the IMPL-0013 refresh pattern; scope per Open Question 2).
+      (reuse the IMPL-0013 refresh pattern; scope per Decision 2).
 - [ ] 1.4 A4 test: open a properties PR, change an annotation, reconcile
       again ⇒ the branch workflow + PR body reflect the new value
       (stateful mock).
@@ -152,7 +152,7 @@ IMPL-0020's parse-abort so a malformed file can never trigger a clear.
       managed set. Today `runReconcilers`
       (`engine_policy.go:147-149`) skips when `existingPath == ""`.
       Scope carefully against the file-rule double-iteration counter
-      contract (CLAUDE.md) and per Open Question 3 (all reconcilers, or
+      contract (CLAUDE.md) and per Decision 3 (all reconcilers, or
       only clear-capable ones?).
 - [ ] 2.2 Confirm the reconciler's `!catalogFound` API-mode branch
       (`custom_properties.go:350`) clears correctly when reached from the
@@ -165,7 +165,7 @@ IMPL-0020's parse-abort so a malformed file can never trigger a clear.
 - [ ] 2.4 Reconcile docs already promise this
       (`policy-reference.md:333-336`,
       `annotation-properties-migration.md:61-68`) — verify wording now
-      matches behavior; adjust if the Open Question 3 resolution narrows
+      matches behavior; adjust if the Decision 3 resolution narrows
       it.
 
 #### Success Criteria
@@ -224,7 +224,7 @@ almost never fires.
       before it can fire (an isolated mismatch stays positive ≤ ~15 min).
       Rework to a window that outlives the `for` (e.g.
       `increase(...[1h]) > 0` with a shorter `for`, or align windows) —
-      mechanism per Open Question 1.
+      mechanism per Decision 1.
 - [ ] 4.2 Fix the same flaw in the LogQL example
       (`docs/operations/scaling.md:229-238`).
 - [ ] 4.3 helm-unittest: the alert renders with the corrected
@@ -243,7 +243,7 @@ almost never fires.
 ### Phase 5: Dead-code removal (B3)
 
 Zero-risk deletion of unreferenced legacy code. Held until IMPL-0019
-proves out per the standing constraint (Open Question 6 revisits whether
+proves out per the standing constraint (Decision 6 revisits whether
 it may ride earlier).
 
 #### Tasks
@@ -270,7 +270,7 @@ it may ride earlier).
 ### Phase 6: Structural refactors (B1, B4)
 
 Mechanical, behavior-preserving. Each is its own commit; PR grouping per
-Open Question 4.
+Decision 5 (Group B spins into its own IMPL doc).
 
 #### Tasks
 
@@ -282,7 +282,7 @@ Open Question 4.
 - [ ] 6.2 **B4 — reconcile-branch base-drift** (`engine_policy.go:529`,
       PR #71 WARN): decide and implement a mitigation
       (rebase-before-reconcile, or close/reopen aged PRs, or documented
-      "don't auto-merge repo-guardian branches") — Open Question 7.
+      "don't auto-merge repo-guardian branches") — Decision 7.
 - [ ] 6.3 **B4 — `refreshPolicyPR` body compare**
       (`engine_policy.go:655-662`): the PR body isn't exposed on the PR
       struct, so title-stable sweeps PATCH unconditionally. Expose/cache
@@ -372,90 +372,50 @@ short design pass first because several mocks are stateful.
 - B4 task 6.4 coordinates with IMPL-0019's removal-PR search-terms
   convention.
 
-## Open Questions
+## Resolved Decisions
 
-1. **A7 alert-window fix shape?**
-   - (a) **Recommendation:** `increase(repo_guardian_custom_property_missing_schema_total[1h]) > 0`
-     with `for: 5m` — a window comfortably longer than `for`, so a single
-     isolated mismatch still fires; `increase` over `rate` reads more
-     naturally for a "did this happen at all recently" alert. Apply the
-     same shape to the LogQL example.
-   - (b) Keep `rate` but widen to `[1h]` and drop `for` to `0m` — fires
-     faster but loses the debounce, noisier on flapping.
-   - (c) Leave the alert; document it as "only meaningful on large
-     fleets with sustained mismatches." Cheapest, but ships a starter
-     alert that misleads small operators into thinking it works.
-   - other:
+All seven open questions resolved 2026-07-23 with the recommended option (a).
 
-2. **A4 GHA-mode refresh scope?**
-   - (a) **Recommendation:** refresh the workflow file + PR body on the
-     existing branch when desired state changed (mirror the IMPL-0013
-     file-rule refresh); do NOT add auto-close for GHA-mode properties
-     PRs in this pass. Closes the staleness bug without importing the
-     full convergence machinery.
-   - (b) Full parity with file-rule PRs including auto-close when the
-     desired set becomes empty — larger, and GHA-mode PRs are
-     merge-once-and-delete by design, so auto-close is lower value.
-   - other:
+1. **A7 alert window:**
+   `increase(repo_guardian_custom_property_missing_schema_total[1h]) > 0`
+   with `for: 5m` — a window comfortably longer than `for`, so a single
+   isolated mismatch still fires; `increase` over `rate` reads more
+   naturally for a "did this happen at all recently" alert. Same shape
+   applied to the LogQL example.
 
-3. **A3 — run all reconcilers on file-absence, or only clear-capable
-   ones?**
-   - (a) **Recommendation:** only invoke reconcilers whose contract
-     includes a clear/absence behavior (today: `custom_properties`).
-     `label_sync`/`branch_protection`/`workflow_sync` have no meaningful
-     "file removed" semantics and running them on absence risks
-     surprising side effects. A small reconciler capability flag
-     (`RunsOnAbsence() bool`) gates it.
-   - (b) Invoke all reconcilers on absence and let each no-op — simpler
-     wiring, but couples every reconciler to a new invocation context
-     they weren't designed for and muddies the double-iteration counter
-     contract.
-   - other:
+2. **A4 refresh scope:** refresh the workflow file + PR body on the
+   existing branch when desired state changed (mirror the IMPL-0013
+   file-rule refresh); do NOT add auto-close for GHA-mode properties PRs
+   in this pass. Closes the staleness bug without importing the full
+   convergence machinery.
 
-4. **PR packaging for the Group A Mediums (Phases 1–4)?**
-   - (a) **Recommendation:** one `fix/impl-0017-hardening` PR for the
-     code Mediums (A3, A4, A5, A6, A8) with `patch` + an A6 migration
-     note; a separate chart-only PR for A7 (`dont-release`, independent
-     cadence). Two PRs, coherent scope ("everything the review found,
-     minus the High fixes already shipped").
-   - (b) One PR per finding — maximal isolation, 5+ PRs of overhead for
-     sub-100-line changes.
-   - other:
+3. **A3 gating:** only invoke reconcilers whose contract includes a
+   clear/absence behavior (today: `custom_properties`), gated by a small
+   capability flag (`RunsOnAbsence() bool`).
+   `label_sync`/`branch_protection`/`workflow_sync` have no meaningful
+   "file removed" semantics and running them on absence risks surprising
+   side effects.
 
-5. **Should Group B (Phases 5–7) split into its own IMPL doc?**
-   - (a) **Recommendation:** yes — spin Group B into `IMPL-00XX
-     (structural cleanup)` when Phases 1–4 are done and IMPL-0019 is
-     proven, keeping this doc as the Group-A-Medium hardening record.
-     Group B is refactor/migration work with different review shape and
-     its own sequencing; bundling it here makes this doc span two very
-     different kinds of change and risks it staying open for months.
-   - (b) Keep everything in this one doc — single tracking artifact for
-     "all non-High INV-0011 work," at the cost of a long-lived doc mixing
-     fixes and refactors.
-   - other:
+4. **Group A Medium packaging:** one `fix/impl-0017-hardening` PR for the
+   code Mediums (A3, A4, A5, A6, A8) with `patch` + an A6 migration note;
+   a separate chart-only PR for A7 (`dont-release`, independent cadence).
 
-6. **May the dead-code deletion (Phase 5 / B3) ride earlier than the
-   rest of Group B?**
-   - (a) **Recommendation:** no — hold all of Group B until IMPL-0019 is
-     proven, per the standing constraint. "No structural churn during
-     feature work" is a simpler bright line to hold than to litigate
-     per-file, and B3 is zero-urgency.
-   - (b) Allow B3 in the Phase 1–4 hardening window — it's risk-free
-     deletion of unreferenced code and shrinks review noise; the bright
-     line costs us carrying dead code a few more weeks.
-   - other:
+5. **Group B splits into its own IMPL doc** once Phases 1–4 are done and
+   IMPL-0019 is proven, keeping this doc as the Group-A-Medium hardening
+   record. Group B is refactor/migration work with a different review
+   shape and its own sequencing; bundling risks this doc staying open for
+   months. (Phases 5–7 remain here as the plan of record until that
+   split happens.)
 
-7. **B4 reconcile-branch base-drift (task 6.2) — which mitigation?**
-   - (a) **Recommendation:** rebase the reconcile branch onto current
-     default-branch HEAD before syncing files each reconcile. Directly
-     eliminates both the base-drift and content-drift risks the PR #71
-     WARN describes, and keeps PRs mergeable without manual intervention.
-   - (b) Close+reopen repo-guardian PRs older than N days — simpler, but
-     churns PR numbers and notification noise.
-   - (c) Document "don't enable auto-merge on repo-guardian/* branches"
-     and leave the code — zero code, but relies on operator discipline
-     and doesn't fix content-drift.
-   - other:
+6. **Dead-code deletion (B3) waits with the rest of Group B** — hold all
+   of Group B until IMPL-0019 is proven. "No structural churn during
+   feature work" is a simpler bright line to hold than to litigate
+   per-file, and B3 is zero-urgency.
+
+7. **B4 base-drift mitigation:** rebase the reconcile branch onto current
+   default-branch HEAD before syncing files each reconcile. Directly
+   eliminates both the base-drift and content-drift risks the PR #71 WARN
+   describes, and keeps PRs mergeable without manual intervention.
 
 ## References
 

--- a/docs/impl/0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md
+++ b/docs/impl/0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md
@@ -1,0 +1,468 @@
+---
+id: IMPL-0021
+title: "Post-IMPL-0019 hardening and structural cleanup (INV-0011 Group A Medium + Group B)"
+status: Draft
+author: Donald Gifford
+created: 2026-07-23
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# IMPL 0021: Post-IMPL-0019 hardening and structural cleanup (INV-0011 Group A Medium + Group B)
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-07-23
+
+<!--toc:start-->
+- [Objective](#objective)
+- [Scope](#scope)
+  - [In Scope](#in-scope)
+  - [Out of Scope](#out-of-scope)
+- [Sequencing](#sequencing)
+- [Implementation Phases](#implementation-phases)
+  - [Phase 1: Custom-properties reconciler correctness (A4, A5)](#phase-1-custom-properties-reconciler-correctness-a4-a5)
+    - [Tasks](#tasks)
+    - [Success Criteria](#success-criteria)
+  - [Phase 2: Clear-on-file-removal (A3)](#phase-2-clear-on-file-removal-a3)
+    - [Tasks](#tasks-1)
+    - [Success Criteria](#success-criteria-1)
+  - [Phase 3: Policy validation and loader hardening (A6, A8)](#phase-3-policy-validation-and-loader-hardening-a6-a8)
+    - [Tasks](#tasks-2)
+    - [Success Criteria](#success-criteria-2)
+  - [Phase 4: Alert observability (A7)](#phase-4-alert-observability-a7)
+    - [Tasks](#tasks-3)
+    - [Success Criteria](#success-criteria-3)
+  - [Phase 5: Dead-code removal (B3)](#phase-5-dead-code-removal-b3)
+    - [Tasks](#tasks-4)
+    - [Success Criteria](#success-criteria-4)
+  - [Phase 6: Structural refactors (B1, B4)](#phase-6-structural-refactors-b1-b4)
+    - [Tasks](#tasks-5)
+    - [Success Criteria](#success-criteria-5)
+  - [Phase 7: Mock migration (B2)](#phase-7-mock-migration-b2)
+    - [Tasks](#tasks-6)
+    - [Success Criteria](#success-criteria-6)
+- [File Changes](#file-changes)
+- [Testing Plan](#testing-plan)
+- [Dependencies](#dependencies)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Objective
+
+Land the six Medium findings (A3–A8) and the four structural-debt items
+(B1–B4) from
+[INV-0011](../investigation/0011-tech-debt-cleanup-inventory-post-impl-0019.md),
+**after** DESIGN-0020/IMPL-0019 has shipped and is proven working in
+service. The Group A Mediums are concrete correctness/observability
+fixes; Group B is structural cleanup that the standing constraint
+("prove the feature before optimizing") deliberately defers to here.
+
+**Implements:** INV-0011 findings A3, A4, A5, A6, A7, A8 and structural
+items B1, B2, B3, B4
+
+## Scope
+
+### In Scope
+
+- Group A Mediums: A3 (clear-on-file-removal unreachable), A4 (GHA-mode
+  PR staleness), A5 (schema-missing no-op PATCH loop), A6 (property-name
+  charset), A7 (unfireable alert window), A8 (typed-null HCL panic in
+  `decodeAnnotationProperties`).
+- Group B structural: B1 (`engine_policy.go` split), B2 (hand-written
+  mocks → mockery), B3 (dead `scheduler/sweep.go`), B4 (standing
+  WARNs/fragility).
+
+### Out of Scope
+
+- A1 and A2 (High) — shipped earlier in
+  [IMPL-0020](0020-pre-impl-0019-high-severity-fixes-inv-0011-group-a-high.md).
+- Any new operator-facing feature.
+- A8's *new-code* guard for `decodeWhenBlock` — already folded into
+  IMPL-0019 Phase 0. This doc's A8 task is the **existing**
+  `decodeAnnotationProperties` instance only.
+
+## Sequencing
+
+- **Hard prerequisite:** IMPL-0019 merged and validated in service
+  (Group B especially — the whole reason it was deferred).
+- **A3 depends on IMPL-0020's A1 fix** (clear-on-removal is only safe
+  once malformed input can no longer masquerade as "clear everything").
+- Phases 1–4 (Group A Mediums) are independent of each other and may be
+  reordered or parallelized; the ordering below is by blast-radius, not
+  dependency.
+- Phases 5–7 (Group B) come last and each merges as its own `chore/` PR
+  — see Open Question 5 on whether Group B should split into its own
+  IMPL entirely.
+
+## Implementation Phases
+
+Run `make fmt` + `make lint` after each task; commit per numbered task
+with conventional commits. Packaging into PRs is Open Question 4.
+
+---
+
+### Phase 1: Custom-properties reconciler correctness (A4, A5)
+
+Two independent logic bugs in `internal/reconciler/custom_properties.go`.
+
+#### Tasks
+
+- [ ] 1.1 **A5 (no-op PATCH loop):** filter schema-missing properties
+      *before* the drift computation, not only before the PATCH.
+      Currently `diffProperties` (`custom_properties.go:164`) compares
+      the full managed set while `filterBySchema`
+      (`custom_properties.go:313`) trims only the payload — so a
+      schema-missing mapped property reports drift forever and re-PATCHes
+      the already-correct defined ones each sweep. Move/apply the schema
+      filter (or exempt schema-missing names) ahead of `diffProperties`.
+- [ ] 1.2 A5 test: with Owner/Component already correct and one mapped
+      property absent from the org schema, a second reconcile issues zero
+      PATCH calls (stateful mock counts calls across two sweeps).
+- [ ] 1.3 **A4 (GHA-mode staleness):** `handleGHAMode`
+      (`custom_properties.go:223-226`) returns early when a properties PR
+      already exists, so annotation changes never refresh the
+      branch/workflow/PR body. Refresh the existing PR's workflow file
+      and body when desired state has changed since it was opened
+      (reuse the IMPL-0013 refresh pattern; scope per Open Question 2).
+- [ ] 1.4 A4 test: open a properties PR, change an annotation, reconcile
+      again ⇒ the branch workflow + PR body reflect the new value
+      (stateful mock).
+
+#### Success Criteria
+
+- `make lint` and `make test` pass.
+- Schema-missing mapped property no longer causes per-sweep PATCH churn
+  (A5) — asserted by a zero-call second sweep.
+- A GHA-mode properties PR reflects the latest desired state after an
+  annotation change (A4).
+
+---
+
+### Phase 2: Clear-on-file-removal (A3)
+
+Make the documented clear-on-removal behavior real. Depends on
+IMPL-0020's parse-abort so a malformed file can never trigger a clear.
+
+#### Tasks
+
+- [ ] 2.1 Engine: invoke the `custom_properties` reconciler when the
+      rule's configured file is absent, so the reconciler's existing
+      (currently production-dead) no-catalog arm runs and clears the
+      managed set. Today `runReconcilers`
+      (`engine_policy.go:147-149`) skips when `existingPath == ""`.
+      Scope carefully against the file-rule double-iteration counter
+      contract (CLAUDE.md) and per Open Question 3 (all reconcilers, or
+      only clear-capable ones?).
+- [ ] 2.2 Confirm the reconciler's `!catalogFound` API-mode branch
+      (`custom_properties.go:350`) clears correctly when reached from the
+      engine (it is already unit-tested in isolation; this wires the
+      engine path that reaches it).
+- [ ] 2.3 Multi-sweep test: repo with a synced catalog-info → file
+      removed → next reconcile clears the mapped properties (not left
+      stale), and a *malformed* file still skips (IMPL-0020 A1 boundary
+      re-asserted here).
+- [ ] 2.4 Reconcile docs already promise this
+      (`policy-reference.md:333-336`,
+      `annotation-properties-migration.md:61-68`) — verify wording now
+      matches behavior; adjust if the Open Question 3 resolution narrows
+      it.
+
+#### Success Criteria
+
+- `make lint` and `make test` pass.
+- Removing `catalog-info.yaml` clears the managed properties on the next
+  reconcile; the reconciler's no-catalog arm is no longer dead code.
+- A malformed file still skips (no clear) — the A1/A3 boundary holds.
+
+---
+
+### Phase 3: Policy validation and loader hardening (A6, A8)
+
+Both in `internal/policy`; independent of each other.
+
+#### Tasks
+
+- [ ] 3.1 **A6 (charset):** correct `githubPropertyNamePattern`
+      (`validate.go:144`) to GitHub's actual set —
+      `^[a-zA-Z0-9_$#-]{1,75}$` (allow `$` `#`, disallow `.`). Verified
+      against GitHub docs in INV-0011. Update the mirrored regex text in
+      `policy-reference.md:360-362`.
+- [ ] 3.2 A6 tests: `$`/`#` names accepted; a `.` name rejected at load
+      with the location-prefixed error.
+- [ ] 3.3 A6 migration note: this is load-breaking for any policy already
+      using a dotted property name — startup now fails loudly at load
+      rather than 422-ing at sync time. Document the upgrade edge.
+- [ ] 3.4 **A8 (typed-null panic):** guard
+      `decodeAnnotationProperties` (`loader.go:664-695`) with
+      `val.IsNull()` / `!val.IsKnown()` before `AsValueMap()`, and the
+      per-value `AsString()` likewise, returning a diagnostic instead of
+      panicking. (The *new* `decodeWhenBlock` already got this guard in
+      IMPL-0019 Phase 0; this fixes the pre-existing instance.)
+- [ ] 3.5 A8 test: `annotation_properties = null` and a conditional
+      yielding a typed-null map return a clean diagnostic, not a panic.
+
+#### Success Criteria
+
+- `make lint` and `make test` pass.
+- Property names with `$`/`#` load; `.` names fail loudly at load.
+- A typed-null `annotation_properties` produces a diagnostic; no panic
+  path remains in either HCL map decoder.
+
+---
+
+### Phase 4: Alert observability (A7)
+
+Chart-only; the `RepoGuardianPropertySchemaMissing` alert currently
+almost never fires.
+
+#### Tasks
+
+- [ ] 4.1 Fix the alert window in
+      `charts/repo-guardian/templates/prometheusrule.yaml:128-129`: the
+      `rate(...[15m]) > 0` + `for: 30m` pairing resets the pending alert
+      before it can fire (an isolated mismatch stays positive ≤ ~15 min).
+      Rework to a window that outlives the `for` (e.g.
+      `increase(...[1h]) > 0` with a shorter `for`, or align windows) —
+      mechanism per Open Question 1.
+- [ ] 4.2 Fix the same flaw in the LogQL example
+      (`docs/operations/scaling.md:229-238`).
+- [ ] 4.3 helm-unittest: the alert renders with the corrected
+      expression; existing enable/disable/override cases still pass.
+- [ ] 4.4 Chart version bump (`dont-release`, chart-only cadence).
+
+#### Success Criteria
+
+- `make helm-unittest` passes with the corrected expression.
+- A single isolated schema-missing event would drive the alert to firing
+  under the default freshness (validated by reasoning/promtool, noted in
+  the PR).
+
+---
+
+### Phase 5: Dead-code removal (B3)
+
+Zero-risk deletion of unreferenced legacy code. Held until IMPL-0019
+proves out per the standing constraint (Open Question 6 revisits whether
+it may ride earlier).
+
+#### Tasks
+
+- [ ] 5.1 Delete `internal/scheduler/sweep.go` (`Sweeper`, `NewSweeper`,
+      `ReconcileAll`, deprecated `Start`) and its tests — confirmed
+      referenced only within its own file/tests; the IMPL-0015 Phase 1
+      "repurpose as Discoverer" never consumed it (`Discoverer` shipped
+      as its own type).
+- [ ] 5.2 Sweep for other post-IMPL-0015/0016/0017 leftovers (unused
+      config plumbing for the removed `sweep` schedule, orphaned
+      helpers) via `deadcode`/`staticcheck U1000` and a reference scan.
+- [ ] 5.3 Confirm `make ci` green after deletion (no dangling
+      references, no coverage-threshold regression from removed tests).
+
+#### Success Criteria
+
+- `make ci` passes with the dead code removed.
+- `deadcode ./...` reports no new unreachable exported symbols in the
+  scheduler package.
+
+---
+
+### Phase 6: Structural refactors (B1, B4)
+
+Mechanical, behavior-preserving. Each is its own commit; PR grouping per
+Open Question 4.
+
+#### Tasks
+
+- [ ] 6.1 **B1 (`engine_policy.go` split):** extract into
+      `engine_settings.go`, `engine_branch_protection.go`, and
+      `engine_pr.go` (the three concerns cohabiting the 1,155-line file
+      alongside file-rule evaluation). Pure moves — no behavior change,
+      no signature change; verified by an unchanged test suite.
+- [ ] 6.2 **B4 — reconcile-branch base-drift** (`engine_policy.go:529`,
+      PR #71 WARN): decide and implement a mitigation
+      (rebase-before-reconcile, or close/reopen aged PRs, or documented
+      "don't auto-merge repo-guardian branches") — Open Question 7.
+- [ ] 6.3 **B4 — `refreshPolicyPR` body compare**
+      (`engine_policy.go:655-662`): the PR body isn't exposed on the PR
+      struct, so title-stable sweeps PATCH unconditionally. Expose/cache
+      the body (or hash it) to skip no-op PATCHes.
+- [ ] 6.4 **B4 — `hasExistingPRForPolicy` search-terms fragility**
+      (`engine_policy.go:438-456`): substring matching collides across
+      rules and across add-vs-remove eras (sharper-edged now that
+      IMPL-0019 ships removal PRs). Tighten matching (scoped/anchored
+      terms, or a structured marker) — coordinate with whatever
+      convention IMPL-0019 landed for removal-PR search terms.
+
+#### Success Criteria
+
+- `make ci` passes; the B1 split changes no behavior (test suite
+  unchanged and green).
+- Each B4 item either fixed or explicitly downgraded to a documented
+  WARN with a rationale.
+
+---
+
+### Phase 7: Mock migration (B2)
+
+Migrate the hand-written `github.Client` mocks to mockery. Gated on a
+short design pass first because several mocks are stateful.
+
+#### Tasks
+
+- [ ] 7.1 Design pass: catalog the stateful mock behaviors
+      (recording, list-then-act fidelity in
+      `custom_properties_test.go`, `convergence_test.go`) and decide how
+      they map onto mockery (expectation plumbing vs hand-kept wrapper
+      types) — this is the "not a pure win" risk flagged in INV-0011 B2.
+- [ ] 7.2 Migrate the three canonical stub sites
+      (`engine_test.go`, `sweep_test.go` — or its replacement after
+      Phase 5, `custom_properties_test.go`) to generated mocks, keeping
+      stateful behavior intact.
+- [ ] 7.3 `make mocks` wired and documented; CLAUDE.md updated to drop
+      the "add stubs to three files in lockstep" convention once the
+      generated mocks are authoritative.
+
+#### Success Criteria
+
+- `make ci` passes with generated mocks.
+- Adding a `github.Client` method no longer requires a manual three-file
+  stub sweep (verified by regenerating).
+- Stateful test behaviors (idempotency, list-then-act) still hold.
+
+---
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/reconciler/custom_properties.go` | Modify | A5 filter-before-diff, A4 PR refresh |
+| `internal/checker/engine_policy.go` | Modify | A3 reconciler-on-absence; B1 split source; B4 items |
+| `internal/checker/engine_settings.go` | Create | B1 extraction |
+| `internal/checker/engine_branch_protection.go` | Create | B1 extraction |
+| `internal/checker/engine_pr.go` | Create | B1 extraction |
+| `internal/policy/validate.go` | Modify | A6 charset |
+| `internal/policy/loader.go` | Modify | A8 null/unknown guard |
+| `charts/repo-guardian/templates/prometheusrule.yaml` | Modify | A7 alert window |
+| `charts/repo-guardian/tests/prometheusrule_test.yaml` | Modify | A7 assertion |
+| `internal/scheduler/sweep.go` | Delete | B3 dead code |
+| `internal/{checker,scheduler,reconciler}/*_test.go` | Modify | B2 mockery migration |
+| `docs/usage/policy-reference.md` | Modify | A6 charset text |
+| `docs/operations/scaling.md` | Modify | A7 LogQL example |
+| `CLAUDE.md` | Modify | A6 migration, B2 convention drop |
+
+## Testing Plan
+
+- [ ] Phase 1: A5 zero-call second sweep; A4 PR-refresh after annotation
+      change.
+- [ ] Phase 2: clear-on-removal multi-sweep; malformed-file-still-skips
+      boundary.
+- [ ] Phase 3: A6 `$`/`#` accept + `.` reject; A8 typed-null diagnostic
+      (no panic).
+- [ ] Phase 4: helm-unittest alert render; firing-window reasoning noted.
+- [ ] Phase 5: `make ci` + `deadcode` clean after removal.
+- [ ] Phase 6: unchanged test suite green after B1 split; B4 items
+      covered or documented.
+- [ ] Phase 7: generated mocks pass full suite incl. stateful behaviors.
+
+## Dependencies
+
+- IMPL-0019 merged and proven in service (hard prerequisite for Group B).
+- IMPL-0020 merged (A1 parse-abort) — prerequisite for Phase 2 (A3).
+- B4 task 6.4 coordinates with IMPL-0019's removal-PR search-terms
+  convention.
+
+## Open Questions
+
+1. **A7 alert-window fix shape?**
+   - (a) **Recommendation:** `increase(repo_guardian_custom_property_missing_schema_total[1h]) > 0`
+     with `for: 5m` — a window comfortably longer than `for`, so a single
+     isolated mismatch still fires; `increase` over `rate` reads more
+     naturally for a "did this happen at all recently" alert. Apply the
+     same shape to the LogQL example.
+   - (b) Keep `rate` but widen to `[1h]` and drop `for` to `0m` — fires
+     faster but loses the debounce, noisier on flapping.
+   - (c) Leave the alert; document it as "only meaningful on large
+     fleets with sustained mismatches." Cheapest, but ships a starter
+     alert that misleads small operators into thinking it works.
+   - other:
+
+2. **A4 GHA-mode refresh scope?**
+   - (a) **Recommendation:** refresh the workflow file + PR body on the
+     existing branch when desired state changed (mirror the IMPL-0013
+     file-rule refresh); do NOT add auto-close for GHA-mode properties
+     PRs in this pass. Closes the staleness bug without importing the
+     full convergence machinery.
+   - (b) Full parity with file-rule PRs including auto-close when the
+     desired set becomes empty — larger, and GHA-mode PRs are
+     merge-once-and-delete by design, so auto-close is lower value.
+   - other:
+
+3. **A3 — run all reconcilers on file-absence, or only clear-capable
+   ones?**
+   - (a) **Recommendation:** only invoke reconcilers whose contract
+     includes a clear/absence behavior (today: `custom_properties`).
+     `label_sync`/`branch_protection`/`workflow_sync` have no meaningful
+     "file removed" semantics and running them on absence risks
+     surprising side effects. A small reconciler capability flag
+     (`RunsOnAbsence() bool`) gates it.
+   - (b) Invoke all reconcilers on absence and let each no-op — simpler
+     wiring, but couples every reconciler to a new invocation context
+     they weren't designed for and muddies the double-iteration counter
+     contract.
+   - other:
+
+4. **PR packaging for the Group A Mediums (Phases 1–4)?**
+   - (a) **Recommendation:** one `fix/impl-0017-hardening` PR for the
+     code Mediums (A3, A4, A5, A6, A8) with `patch` + an A6 migration
+     note; a separate chart-only PR for A7 (`dont-release`, independent
+     cadence). Two PRs, coherent scope ("everything the review found,
+     minus the High fixes already shipped").
+   - (b) One PR per finding — maximal isolation, 5+ PRs of overhead for
+     sub-100-line changes.
+   - other:
+
+5. **Should Group B (Phases 5–7) split into its own IMPL doc?**
+   - (a) **Recommendation:** yes — spin Group B into `IMPL-00XX
+     (structural cleanup)` when Phases 1–4 are done and IMPL-0019 is
+     proven, keeping this doc as the Group-A-Medium hardening record.
+     Group B is refactor/migration work with different review shape and
+     its own sequencing; bundling it here makes this doc span two very
+     different kinds of change and risks it staying open for months.
+   - (b) Keep everything in this one doc — single tracking artifact for
+     "all non-High INV-0011 work," at the cost of a long-lived doc mixing
+     fixes and refactors.
+   - other:
+
+6. **May the dead-code deletion (Phase 5 / B3) ride earlier than the
+   rest of Group B?**
+   - (a) **Recommendation:** no — hold all of Group B until IMPL-0019 is
+     proven, per the standing constraint. "No structural churn during
+     feature work" is a simpler bright line to hold than to litigate
+     per-file, and B3 is zero-urgency.
+   - (b) Allow B3 in the Phase 1–4 hardening window — it's risk-free
+     deletion of unreferenced code and shrinks review noise; the bright
+     line costs us carrying dead code a few more weeks.
+   - other:
+
+7. **B4 reconcile-branch base-drift (task 6.2) — which mitigation?**
+   - (a) **Recommendation:** rebase the reconcile branch onto current
+     default-branch HEAD before syncing files each reconcile. Directly
+     eliminates both the base-drift and content-drift risks the PR #71
+     WARN describes, and keeps PRs mergeable without manual intervention.
+   - (b) Close+reopen repo-guardian PRs older than N days — simpler, but
+     churns PR numbers and notification noise.
+   - (c) Document "don't enable auto-merge on repo-guardian/* branches"
+     and leave the code — zero code, but relies on operator discipline
+     and doesn't fix content-drift.
+   - other:
+
+## References
+
+- [INV-0011](../investigation/0011-tech-debt-cleanup-inventory-post-impl-0019.md) — source findings A3–A8 (Group A) and B1–B4 (Group B), verified on `b3350ef`
+- [IMPL-0020](0020-pre-impl-0019-high-severity-fixes-inv-0011-group-a-high.md) — the High fixes shipped before IMPL-0019; A1 is a prerequisite for Phase 2 (A3)
+- [IMPL-0019](0019-absent-check-mode-and-conditional-file-rules.md) — hard prerequisite (proven in service) for Group B; its removal-PR search-terms convention coordinates with B4 task 6.4
+- IMPL-0013 — the PR-refresh + convergence machinery reused by A4 and referenced by B4
+- DESIGN-0012 — sanctioned the mockery migration (B2) as a follow-up
+- GitHub docs — [Managing custom properties](https://docs.github.com/en/organizations/managing-organization-settings/managing-custom-properties-for-repositories-in-your-organization) (A6 charset)
+- Audited code (as of `b3350ef`): `internal/reconciler/custom_properties.go:{164,223,313,350}`, `internal/checker/engine_policy.go:{147,438,529,655}`, `internal/policy/{validate.go:144,loader.go:664}`, `internal/scheduler/sweep.go`, `charts/repo-guardian/templates/prometheusrule.yaml:128`

--- a/docs/impl/README.md
+++ b/docs/impl/README.md
@@ -51,4 +51,6 @@ docz create impl "Your Implementation Title"
 | IMPL-0017 | Configurable annotation-sourced custom properties | Completed | 2026-07-20 | Donald Gifford | [0017-configurable-annotation-sourced-custom-properties.md](0017-configurable-annotation-sourced-custom-properties.md) |
 | IMPL-0018 | Fix silently ignored operator config | Completed | 2026-07-20 | Donald Gifford | [0018-fix-silently-ignored-operator-config.md](0018-fix-silently-ignored-operator-config.md) |
 | IMPL-0019 | Absent check mode and conditional file rules | Draft | 2026-07-23 | Donald Gifford | [0019-absent-check-mode-and-conditional-file-rules.md](0019-absent-check-mode-and-conditional-file-rules.md) |
+| IMPL-0020 | Pre-IMPL-0019 high-severity fixes (INV-0011 Group A High) | Draft | 2026-07-23 | Donald Gifford | [0020-pre-impl-0019-high-severity-fixes-inv-0011-group-a-high.md](0020-pre-impl-0019-high-severity-fixes-inv-0011-group-a-high.md) |
+| IMPL-0021 | Post-IMPL-0019 hardening and structural cleanup (INV-0011 Group A Medium + Group B) | Draft | 2026-07-23 | Donald Gifford | [0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md](0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/investigation/0011-tech-debt-cleanup-inventory-post-impl-0019.md
+++ b/docs/investigation/0011-tech-debt-cleanup-inventory-post-impl-0019.md
@@ -1,0 +1,90 @@
+---
+id: INV-0011
+title: "Tech debt cleanup inventory post IMPL-0019"
+status: Open
+author: Donald Gifford
+created: 2026-07-23
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# INV 0011: Tech debt cleanup inventory post IMPL-0019
+
+**Status:** Open
+**Author:** Donald Gifford
+**Date:** 2026-07-23
+
+<!--toc:start-->
+- [Question](#question)
+- [Hypothesis](#hypothesis)
+- [Context](#context)
+- [Approach](#approach)
+- [Environment](#environment)
+- [Findings](#findings)
+  - [Observation 1](#observation-1)
+  - [Observation 2](#observation-2)
+- [Conclusion](#conclusion)
+- [Recommendation](#recommendation)
+- [References](#references)
+<!--toc:end-->
+
+## Question
+
+<!-- What specific question are we trying to answer? Be precise — a good
+     investigation question has a clear yes/no or concrete answer.
+     Example: "Can we use X library to achieve Y without Z limitation?" -->
+
+## Hypothesis
+
+<!-- What do you expect to find, and why? This forces upfront thinking and
+     makes the conclusion more meaningful. -->
+
+## Context
+
+<!-- Why is this investigation needed right now? What design, plan, or
+     error triggered it? Link to the parent document(s). -->
+
+**Triggered by:** <!-- RFC-XXXX / DESIGN-XXXX / PLAN-XXXX / issue #XXX -->
+
+## Approach
+
+<!-- How will you test the hypothesis? List the specific steps, experiments,
+     or code paths you will exercise. Keep it concrete enough that someone
+     else could replicate the investigation. -->
+
+1.
+2.
+3.
+
+## Environment
+
+<!-- Versions, configuration, or setup details relevant to reproducibility.
+     Delete this section if not applicable. -->
+
+| Component | Version / Value |
+|-----------|----------------|
+|           |                |
+
+## Findings
+
+<!-- What did you actually observe? Include command output, logs, benchmark
+     numbers, or code snippets as evidence. Fill this in as you go. -->
+
+### Observation 1
+
+### Observation 2
+
+## Conclusion
+
+<!-- Answer the original question directly. State clearly what was found:
+     confirmed / refuted / inconclusive, and why. -->
+
+**Answer:** <!-- Yes / No / Inconclusive -->
+
+## Recommendation
+
+<!-- What should happen next based on this conclusion? Update the parent
+     doc, unblock the design decision, open a follow-up investigation, etc. -->
+
+## References
+
+<!-- Links to parent docs, related investigations, issues, external sources -->

--- a/docs/investigation/0011-tech-debt-cleanup-inventory-post-impl-0019.md
+++ b/docs/investigation/0011-tech-debt-cleanup-inventory-post-impl-0019.md
@@ -20,71 +20,329 @@ created: 2026-07-23
 - [Approach](#approach)
 - [Environment](#environment)
 - [Findings](#findings)
-  - [Observation 1](#observation-1)
-  - [Observation 2](#observation-2)
+  - [Group A — Verified defects in the shipped IMPL-0017 surface](#group-a--verified-defects-in-the-shipped-impl-0017-surface)
+  - [Group B — Structural debt (deferred by explicit constraint)](#group-b--structural-debt-deferred-by-explicit-constraint)
+  - [Review-verification notes](#review-verification-notes)
 - [Conclusion](#conclusion)
 - [Recommendation](#recommendation)
+- [Open Questions](#open-questions)
 - [References](#references)
 <!--toc:end-->
 
 ## Question
 
-<!-- What specific question are we trying to answer? Be precise — a good
-     investigation question has a clear yes/no or concrete answer.
-     Example: "Can we use X library to achieve Y without Z limitation?" -->
+What defects and structural debt exist in the current codebase
+(post-IMPL-0017, appVersion 1.9.0), and how should fixes be sequenced
+given the standing constraint that the DESIGN-0020 / IMPL-0019 feature
+must be built and proven working before structural optimization begins?
 
 ## Hypothesis
 
-<!-- What do you expect to find, and why? This forces upfront thinking and
-     makes the conclusion more meaningful. -->
+The operator-provided review findings (8 items, reviewed at PR-#164 head
+`79fd16a`) are real and reproducible on current `main`; the four
+structural areas scoped via review discussion (engine_policy.go size,
+hand-written mocks, dead/legacy code, known WARNs) are documentable now
+and safely deferrable; the High-severity items are not deferrable.
 
 ## Context
 
-<!-- Why is this investigation needed right now? What design, plan, or
-     error triggered it? Link to the parent document(s). -->
+IMPL-0019 Decision 1 explicitly deferred any `engine_policy.go`
+restructuring to "a separate tech-debt investigation after the feature
+is proven working in service" — this is that investigation. Separately,
+an operator code review of the IMPL-0017 surface produced 8 findings
+(2 High, 6 Medium) that needed verification against current `main` and
+a triage decision: which are bugs to fix now vs debt to schedule.
 
-**Triggered by:** <!-- RFC-XXXX / DESIGN-XXXX / PLAN-XXXX / issue #XXX -->
+**Triggered by:** IMPL-0019 (Resolved Decision 1), DESIGN-0019/IMPL-0017
+post-ship review
 
 ## Approach
 
-<!-- How will you test the hypothesis? List the specific steps, experiments,
-     or code paths you will exercise. Keep it concrete enough that someone
-     else could replicate the investigation. -->
-
-1.
-2.
-3.
+1. Re-verify each of the 8 operator review findings against current
+   `main` (`04683f8`, post-#164) at the cited file:line locations.
+2. Cross-check finding 6's charset claim against GitHub's documentation
+   for custom-property naming constraints.
+3. Audit the four structural areas: line counts and lint-ceiling
+   pressure for `engine_policy.go`; the mockClient parity-sweep cost;
+   reference-scan for dead legacy code; inventory of standing WARN
+   comments.
+4. Triage into: immediate fixes (High), scheduled hardening (Medium),
+   deferred structural work (post-IMPL-0019 per constraint).
 
 ## Environment
 
-<!-- Versions, configuration, or setup details relevant to reproducibility.
-     Delete this section if not applicable. -->
-
 | Component | Version / Value |
 |-----------|----------------|
-|           |                |
+| main | `04683f8` (feat!: IMPL-0017, PR #164) |
+| appVersion / chart | 1.9.0 / 1.0.0-rc.6 |
+| Review baseline | PR #164 head `79fd16a` (operator review) |
 
 ## Findings
 
-<!-- What did you actually observe? Include command output, logs, benchmark
-     numbers, or code snippets as evidence. Fill this in as you go. -->
+### Group A — Verified defects in the shipped IMPL-0017 surface
 
-### Observation 1
+All 8 operator findings **confirmed on current main**. Numbering
+preserved from the review.
 
-### Observation 2
+**A1 (High): Invalid catalog YAML destructively clears mapped
+properties.** `internal/catalog/catalog.go:57` — `Parse` returns
+`defaults()` (Owner/Component = "Unclassified", no Extra map) for BOTH
+unparseable YAML and non-Component entities, indistinguishable from a
+valid file with no annotations. Under API-mode full state sync
+(`custom_properties.go.desiredToPropertyValues`), a temporarily
+malformed `catalog-info.yaml` immediately PATCHes `null` for every
+mapped property and overwrites Owner/Component with "Unclassified".
+Parse failure should abort reconciliation (skip + Warn + metric), never
+be presented as desired state.
+
+**A2 (High, security): Generated workflow interpolates annotation
+values into shell without escaping.**
+`internal/rules/templates/set-custom-properties.tmpl:31` — `.Catalog.Owner`,
+each `annotation_properties` value, and `.Catalog.Component` render
+inside single-quoted `gh api -f` arguments in the generated GitHub
+Actions workflow. These values come from repo-controlled
+`catalog-info.yaml`: an apostrophe breaks the workflow; a value like
+`x'$(command)'` achieves command execution with the workflow's
+`GITHUB_TOKEN` once the PR merges. Same remediation class as the
+release-pipeline post-mortem's bake-metadata fix: pass values through
+`env:` (never shell-parsed) rather than inline interpolation, and/or
+reject hostile characters at parse time.
+
+**A3 (Medium): Documented clear-on-file-removal is unreachable code.**
+`internal/checker/engine_policy.go:147-149` skips all reconcilers when
+no configured path exists (`existingPath == ""`), and
+`getFileContentForReconciler` returning `""` also skips. Verification
+found this is *stronger* than the review stated: the reconciler already
+ships the no-catalog arm (`resolveCatalogContent` re-reads the repo when
+`params.Content` is empty; `handleAPIMode`'s `!catalogFound` branch
+exists and is tested) — but the engine never invokes reconcilers without
+file content, so the arm is production-dead. Contradicts
+`docs/usage/policy-reference.md:333-336` and
+`docs/operations/annotation-properties-migration.md:61-68`, which
+promise clears when the whole file is removed.
+
+**A4 (Medium): GHA-mode PRs freeze stale property values.**
+`internal/reconciler/custom_properties.go:223-226` — `handleGHAMode`
+returns as soon as `findPropertiesPR` finds an existing PR. Annotation
+changes after PR creation never refresh the branch/workflow/PR body;
+merging applies the obsolete values. (Contrast: the file-rule PR path
+gained exactly this refresh machinery in IMPL-0013.)
+
+**A5 (Medium): Schema-missing properties cause a permanent no-op PATCH
+loop.** Drift is computed at `custom_properties.go:164`
+(`diffProperties`, full managed set, *before* mode dispatch) but the
+schema filter runs only on the PATCH payload
+(`custom_properties.go:313-314`). A mapped property absent from the org
+schema never appears in GitHub's current values → `diffProperties`
+reports drift forever → every reconcile PATCHes the already-correct
+defined properties. Filter (or exempt schema-missing names) before the
+diff, not just before the PATCH.
+
+**A6 (Medium): Property-name validation uses the wrong GitHub charset.**
+`internal/policy/validate.go:141-144` uses `^[a-zA-Z0-9_.-]{1,75}$`.
+Verified against GitHub's docs (managing custom properties): the allowed
+set is `a-z A-Z 0-9 _ - $ #`, max 75 — periods are NOT permitted, `$`
+and `#` ARE. We accept invalid names (`.`— fails later at PATCH time)
+and reject valid ones (`$`, `#`). The same wrong expression is
+documented at `docs/usage/policy-reference.md:360-362`. Note the fix is
+load-behavior-breaking for any existing policy using dotted names
+(fail-loud at load replaces a 422 at sync time — an improvement, but it
+needs a migration note).
+
+**A7 (Medium): `RepoGuardianPropertySchemaMissing` usually cannot
+fire.** `charts/repo-guardian/templates/prometheusrule.yaml:128-129`
+pairs `rate(counter[15m]) > 0` with `for: 30m`. An isolated mismatch
+keeps the rate positive ≤ ~15 minutes, so the pending alert resets
+before firing; with default 24h freshness and jittered sweeps, only
+large fleets with continuous re-hits would ever alert. The LogQL example
+at `docs/operations/scaling.md:229-238` shares the flaw. Fix shape:
+widen the rate window past the `for` duration (e.g.
+`increase(...[1h]) > 0` with a shorter `for`, or align windows).
+
+**A8 (Medium): Typed-null HCL maps can panic at startup.**
+`internal/policy/loader.go:664-695` — `decodeAnnotationProperties`
+checks `IsObjectType()/IsMapType()` but not `val.IsNull()` /
+`!val.IsKnown()` before `AsValueMap()`; per-value `AsString()` has the
+same gap. A conditional HCL expression yielding a typed-null object
+passes the type check and panics instead of producing a diagnostic.
+(The type-check itself was hardened for List/Tuple during IMPL-0017
+review — this is the remaining null/unknown edge of the same guard.)
+
+### Group B — Structural debt (deferred by explicit constraint)
+
+Per IMPL-0019 Decision 1 and review direction, none of this starts until
+the DESIGN-0020/IMPL-0019 feature is proven working in service.
+
+**B1: `engine_policy.go` structure.** 1,155 lines pre-IMPL-0019; the
+new feature adds evaluation/remediation arms to it. Contains four
+separable concerns: file-rule evaluation, PR create/update machinery,
+setting-rule evaluation, branch-protection evaluation. gocyclo/funlen
+pressure is recurring (two extraction refactors already forced by lint:
+`syncActionableFiles`, `createNewPolicyPR`). Candidate split:
+`engine_settings.go`, `engine_branch_protection.go`, `engine_pr.go` —
+mechanical moves, no behavior change.
+
+**B2: Hand-written `github.Client` mocks → mockery.** Every interface
+addition costs a three-file parity sweep
+(`internal/checker/engine_test.go`, `internal/scheduler/sweep_test.go`,
+`internal/reconciler/custom_properties_test.go` + embedders), documented
+as a standing convention in CLAUDE.md and paid again in IMPL-0017
+(`GetOrgPropertySchema` stubs). DESIGN-0012 already sanctioned the
+migration as a follow-up. Complication to scope honestly: several mocks
+are *stateful* (recording, list-then-act fidelity) — mockery replaces
+the boilerplate but the stateful behaviors need hand-kept wrappers or
+expectation plumbing; this is not a pure win and needs a small design
+pass first.
+
+**B3: Dead/legacy code.** Confirmed by reference scan:
+`internal/scheduler/sweep.go` (`Sweeper`, `NewSweeper`, `ReconcileAll`,
+deprecated `Start`) is referenced only within its own file and tests —
+the IMPL-0015 Phase 1 plan kept it "to repurpose as Discoverer.Discover",
+but `Discoverer` shipped as its own type; the repurpose never consumed
+it. Delete file + tests. Sweep should also catch any other
+post-IMPL-0015/0016/0017 leftovers (e.g. unused config plumbing for the
+removed schedule).
+
+**B4: Standing WARNs / known fragility.**
+- Reconcile-branch base-drift WARN (`engine_policy.go:529-541`, PR #71):
+  stale branch + auto-merge can overwrite manual default-branch edits.
+  Mitigations sketched in the comment (rebase-before-reconcile,
+  close/reopen aged PRs) — needs a decision, not just a comment.
+- `refreshPolicyPR` body-compare limitation (`engine_policy.go:655-662`):
+  body not exposed on the PR struct, so title-stable sweeps PATCH
+  unconditionally — one wasted PATCH per touched repo per sweep.
+- `hasExistingPRForPolicy` substring matching on `search_terms`
+  (`engine_policy.go:438-456`): fragile against title collisions;
+  becomes sharper-edged with IMPL-0019's removal PRs (an absent rule's
+  terms must not match add-era titles — currently guidance-only).
+
+### Review-verification notes
+
+- Review baseline was PR #164 head `79fd16a`; all findings re-verified
+  on merged `main` (`04683f8`) — line numbers cited above are current.
+- The review's CI note (Security Scan failing on GO-2026-5970,
+  `golang.org/x/text v0.37.0`) was already resolved before merge:
+  `6ae1e1f` bumped x/text to v0.39.0; the advisory-vs-scan-timing
+  behavior is documented in the 2026-07-22 session notes.
+- Targeted race tests for catalog/policy/github/reconciler packages
+  passed at review time; nothing in Group A is a race — all are logic
+  and contract defects.
 
 ## Conclusion
 
-<!-- Answer the original question directly. State clearly what was found:
-     confirmed / refuted / inconclusive, and why. -->
-
-**Answer:** <!-- Yes / No / Inconclusive -->
+**Answer: Confirmed.** All 8 review findings reproduce on current main
+(one — A3 — is worse than reported: the promised behavior exists but is
+unreachable). The four structural areas are real, documented, and safely
+deferrable. Two findings (A1, A2) are High severity — A2 is a
+repo-controlled command-injection vector into a `GITHUB_TOKEN`-bearing
+workflow — and should not wait for the post-IMPL-0019 cleanup window.
 
 ## Recommendation
 
-<!-- What should happen next based on this conclusion? Update the parent
-     doc, unblock the design decision, open a follow-up investigation, etc. -->
+Three tracks, sequenced around the IMPL-0019 constraint:
+
+1. **Immediate fix PR (before IMPL-0019 implementation starts):** A1 +
+   A2 as a single `fix/` PR with the `patch` label. Small blast radius
+   (catalog.go signature + one template + reconciler skip-path), highest
+   severity, and both are regressions of operator trust in a feature
+   that just shipped.
+2. **Hardening fix PR (can land during IMPL-0019 work):** A3, A4, A5,
+   A6, A8 (`patch`), plus a chart-only PR for A7 (`dont-release`).
+   Packaging per Open Question 4.
+3. **Structural cleanup (post-IMPL-0019, feature proven):** B1–B4, each
+   as its own `chore/` PR, scoped by a short plan per area (B2 needs the
+   stateful-mock design pass first). This INV stays Open until those
+   land; flip to Resolved when the last track-3 item merges or is
+   explicitly descoped.
+
+## Open Questions
+
+1. **Sequencing of the High fixes (A1+A2) relative to IMPL-0019?**
+   - (a) **Recommendation:** dedicated `fix/` PR first, before IMPL-0019
+     implementation begins — A2 is a live injection vector in every
+     generated workflow PR and A1 destroys operator data on a malformed
+     commit; both are small, self-contained fixes (INV-0003 precedent:
+     investigation → tiny fix PR without a full IMPL doc).
+   - (b) Fold into IMPL-0019 Phase 0 — one less PR, but couples security
+     fixes to an unrelated feature timeline and delays them by however
+     long Phase 0 review takes.
+   - (c) Defer to the hardening PR — leaves the injection vector open
+     longest; rejected unless the GHA mode is confirmed unused in every
+     live deployment.
+   - other:
+
+2. **A1 fix semantics — what does a parse failure mean?**
+   - (a) **Recommendation:** abort the reconcile for that repo: skip
+     with `slog.Warn` + new counter
+     (`catalog_parse_failed_total{org}`), leaving GitHub state
+     untouched. Malformed input is unknowable intent — never synthesize
+     a destructive default from it. `Parse` returns an error instead of
+     silently defaulting (signature change; the non-Component-entity
+     case stays a clean "no properties" result since that IS knowable
+     intent).
+   - (b) Fall back to last-known-good desired state — requires
+     persisting prior desired state per repo (new Store surface); more
+     machinery than the problem warrants.
+   - (c) Keep defaults but log loudly — still destroys data, just
+     audibly.
+   - other:
+
+3. **A2 fix mechanism for the generated workflow?**
+   - (a) **Recommendation:** both layers — render values into the
+     workflow's `env:` block and reference them as `"$VAR"` inside the
+     `run:` script (env values are never shell-parsed; the exact
+     pattern the release-pipeline post-mortem established for bake
+     metadata), AND tighten annotation-value validation at policy load
+     to reject control characters. Defense in depth; the env fix alone
+     is complete, the validation catches garbage earlier.
+   - (b) env-indirection only — sufficient, minimal.
+   - (c) Shell-escape values at template render — fragile (quoting
+     escaping quoting) and every future template edit can reintroduce
+     the bug.
+   - other:
+
+4. **Packaging of the Medium hardening fixes (A3–A8)?**
+   - (a) **Recommendation:** one `fix/impl-0017-hardening` PR for
+     A3+A4+A5+A6+A8 with `patch` label and a migration note covering
+     A6's charset change; separate chart-only PR for A7 with
+     `dont-release` (chart cadence is independent). Two PRs total,
+     coherent review scope ("everything the post-ship review found").
+   - (b) One PR per finding — maximal isolation, five-plus PRs of
+     review overhead for changes that are each < ~100 lines.
+   - (c) Fold all into IMPL-0019 — couples shipped-feature fixes to new
+     feature risk; rejected for the same reason as 1(b).
+   - other:
+
+5. **Does A3 get fixed in code or in docs?**
+   - (a) **Recommendation:** code — implement the documented behavior.
+     The reconciler's no-catalog arm already exists and is tested; the
+     change is an engine-side path that invokes the custom_properties
+     reconciler when the rule's file is absent (scoped carefully against
+     the double-iteration counter contract). Docs and migration guide
+     already promise this; A1's fix (parse-failure abort) makes the
+     clear path safe to enable.
+   - (b) Docs retreat — document that file removal does NOT clear.
+     Cheaper, but it breaks the DESIGN-0019 full-state-sync contract and
+     leaves the tested reconciler arm permanently dead.
+   - other:
+
+6. **May the dead-code deletion (B3) ride earlier than the rest of
+   Group B?**
+   - (a) **Recommendation:** no — hold ALL of Group B until after
+     IMPL-0019 proves out, per the explicit review constraint. Deleting
+     `sweep.go` touches the scheduler package IMPL-0019 doesn't, but
+     "no structural churn during feature work" is simpler to hold as a
+     bright line than to litigate per-file.
+   - (b) Allow B3 only in the hardening PR — it's zero-risk deletion of
+     unreferenced code and shrinks future review noise; the bright line
+     costs us carrying dead code a few more weeks.
+   - other:
 
 ## References
 
-<!-- Links to parent docs, related investigations, issues, external sources -->
+- [IMPL-0019](../impl/0019-absent-check-mode-and-conditional-file-rules.md) — Resolved Decision 1 defers B1 here
+- [DESIGN-0020](../design/0020-absent-check-mode-and-conditional-file-rules.md) — the feature that must prove out before Group B starts
+- [DESIGN-0019](../design/0019-configurable-annotation-sourced-custom-properties.md) / IMPL-0017 — the surface Group A hardens
+- [INV-0003](0003-pre-existing-branch-422-on-subsequent-reconciles.md) — precedent for investigation → small fix PR without a full IMPL
+- GitHub docs — [Managing custom properties for repositories](https://docs.github.com/en/organizations/managing-organization-settings/managing-custom-properties-for-repositories-in-your-organization) (property-name charset verified 2026-07-23)
+- Operator code review of PR #164 head `79fd16a` (8 findings, folded in verbatim as Group A)

--- a/docs/investigation/0011-tech-debt-cleanup-inventory-post-impl-0019.md
+++ b/docs/investigation/0011-tech-debt-cleanup-inventory-post-impl-0019.md
@@ -255,6 +255,14 @@ Three tracks, sequenced around the IMPL-0019 constraint:
    land; flip to Resolved when the last track-3 item merges or is
    explicitly descoped.
 
+These tracks are now planned as two IMPL docs:
+[IMPL-0020](../impl/0020-pre-impl-0019-high-severity-fixes-inv-0011-group-a-high.md)
+covers track 1 (the A1+A2 High fixes, before IMPL-0019);
+[IMPL-0021](../impl/0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md)
+covers tracks 2 and 3 (Group A Mediums + Group B structural, after
+IMPL-0019). Open Question 5 in IMPL-0021 revisits whether Group B should
+later split into its own IMPL.
+
 ## Open Questions
 
 1. **Sequencing of the High fixes (A1+A2) relative to IMPL-0019?**

--- a/docs/investigation/README.md
+++ b/docs/investigation/README.md
@@ -23,6 +23,7 @@ Design docs, plans, and implementation docs can reference investigations by ID
 | INV-0008 | Annotation-sourced custom properties should be configurable, not hardcoded | Resolved | 2026-07-19 | Donald Gifford | [0008-annotation-sourced-custom-properties-should-be-configurable-not.md](0008-annotation-sourced-custom-properties-should-be-configurable-not.md) |
 | INV-0009 | Read-only status API and web UI options | Open | 2026-07-19 | Donald Gifford | [0009-read-only-status-api-and-web-ui-options.md](0009-read-only-status-api-and-web-ui-options.md) |
 | INV-0010 | Silently ignored operator config: auto_close_pr HCL attribute and cross-mode existingSecret | Resolved | 2026-07-20 | Donald Gifford | [0010-silently-ignored-operator-config-autoclosepr-hcl-attribute-and.md](0010-silently-ignored-operator-config-autoclosepr-hcl-attribute-and.md) |
+| INV-0011 | Tech debt cleanup inventory post IMPL-0019 | Open | 2026-07-23 | Donald Gifford | [0011-tech-debt-cleanup-inventory-post-impl-0019.md](0011-tech-debt-cleanup-inventory-post-impl-0019.md) |
 <!-- END DOCZ AUTO-GENERATED -->
 <!-- BEGIN DOCZ AUTO-GENERATED -->
 <!-- END DOCZ AUTO-GENERATED -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,8 @@ nav:
         - 'IMPL-0017: Configurable annotation-sourced custom properties': impl/0017-configurable-annotation-sourced-custom-properties.md
         - 'IMPL-0018: Fix silently ignored operator config': impl/0018-fix-silently-ignored-operator-config.md
         - 'IMPL-0019: Absent check mode and conditional file rules': impl/0019-absent-check-mode-and-conditional-file-rules.md
+        - 'IMPL-0020: Pre-IMPL-0019 high-severity fixes (INV-0011 Group A High)': impl/0020-pre-impl-0019-high-severity-fixes-inv-0011-group-a-high.md
+        - 'IMPL-0021: Post-IMPL-0019 hardening and structural cleanup (INV-0011 Group A Medium + Group B)': impl/0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md
     - Investigations:
         - Overview: investigation/README.md
         - 'INV-0001: Tailscale Funnel for Webhook Testing': investigation/0001-tailscale-funnel-for-webhook-testing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
         - 'INV-0008: Annotation-sourced custom properties should be configurable, not hardcoded': investigation/0008-annotation-sourced-custom-properties-should-be-configurable-not.md
         - 'INV-0009: Read-only status API and web UI options': investigation/0009-read-only-status-api-and-web-ui-options.md
         - 'INV-0010: Silently ignored operator config: auto_close_pr HCL attribute and cross-mode existingSecret': investigation/0010-silently-ignored-operator-config-autoclosepr-hcl-attribute-and.md
+        - 'INV-0011: Tech debt cleanup inventory post IMPL-0019': investigation/0011-tech-debt-cleanup-inventory-post-impl-0019.md
     - Plans:
         - Overview: plan/README.md
     - RFCs:


### PR DESCRIPTION
## Summary
- **INV-0011** inventories tech debt post-IMPL-0017 (appVersion 1.9.0). Two groups:
  - **Group A** — the operator code review of PR #164 (2 High, 6 Medium), all re-verified on current `main`. A1 (invalid catalog YAML destructively clears mapped properties) and A2 (repo-controlled annotation values interpolated into shell in the generated workflow → command execution with `GITHUB_TOKEN`) are High. A3 found worse than reported: the documented clear-on-file-removal is unreachable code.
  - **Group B** — structural debt deferred by explicit constraint until DESIGN-0020/IMPL-0019 proves out: `engine_policy.go` split, hand-written mocks → mockery, dead `scheduler/sweep.go`, standing WARNs/fragility.
- A6's charset claim cross-checked against GitHub docs (period invalid; `$` and `#` valid).
- Recommends three tracks: immediate `fix/` PR for A1+A2 before IMPL-0019 starts, a hardening PR for the Mediums, and Group B post-feature.
- Also folds the one directly-relevant finding into the feature docs: IMPL-0019 Phase 0 task 0.3 now requires `decodeWhenBlock` to guard against the A8 typed-null decode panic, and DESIGN-0020 cross-references A1's fail-safe principle.

## Open questions (pending review)
Six, all `(a)`-recommendation format — sequencing of the High fixes, A1 parse-failure semantics, A2 fix mechanism, Medium packaging, A3 code-vs-docs, and whether dead-code deletion may ride early.

## Test plan
- [x] All 8 findings re-verified on merged `main` (`b3350ef`); line numbers current
- [x] `docz update` indices regenerated; docs-only change, `dont-release` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)