### PR TITLE
docs: INV-0012/0013 investigations, DESIGN-0021/0022 + IMPL-0022/0023 planning arc, enterprise ops guides, contrib refresh

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -10,8 +10,8 @@ to match your environment.
 
 | Path | Purpose |
 |------|---------|
-| `prometheus/alerts.yaml` | Alerting rules for availability, error rate, GitHub rate limiting, latency, webhooks, and strict-mode scope misconfigurations. |
-| `grafana/repo-guardian-dashboard.json` | Grafana dashboard with overview, repo checks, compliance, webhook, custom-properties, error/rate-limit panels, plus per-org activity panels. |
+| `prometheus/alerts.yaml` | Alerting rules for availability, error rate, GitHub rate limiting, latency, webhooks, strict-mode scope misconfigurations, PR convergence, and custom-property sync (schema preflight + catalog parse failures). |
+| `grafana/repo-guardian-dashboard.json` | Grafana dashboard with overview, repo checks, compliance, webhook, custom-properties, error/rate-limit, multi-replica/queue, PR-convergence, and absent-rule/when-gate/property-sync panels, plus per-org activity panels. |
 
 ## Exposed Metrics
 
@@ -42,6 +42,8 @@ histogram_quantile(0.99,
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
 | `files_missing_total` | CounterVec | `rule_name`, `org` | Number of times a file rule found a missing file requiring action. |
+| `files_forbidden_present_total` | CounterVec | `rule_name`, `org` | Forbidden files detected present by an `absent`-mode rule (IMPL-0019). The absent-rule analogue of `files_missing_total`. |
+| `rule_gate_closed_total` | CounterVec | `rule_name`, `org`, `reason` | File-rule evaluations skipped because a `when { rule_satisfied }` gate was closed (IMPL-0019). `reason=not_satisfied` is normal operation; `reason=error` means the referee rule's evaluation failed and the gate failed closed. |
 | `prs_created_total` | CounterVec | `org` | Pull requests created by repo-guardian for missing files. |
 | `prs_updated_total` | CounterVec | `org` | Existing PRs updated with new files. |
 
@@ -53,6 +55,12 @@ sum by (org) (rate(repo_guardian_prs_created_total[5m]))
 
 # Top 10 rules by missing-file detections
 topk(10, sum by (rule_name) (rate(repo_guardian_files_missing_total[1h])))
+
+# Forbidden files still present, by absent-mode rule (IMPL-0019)
+sum by (rule_name, org) (rate(repo_guardian_files_forbidden_present_total[1h]))
+
+# Gate fail-closed errors — referee rule evaluation failing (should be ~zero)
+sum by (rule_name, org) (rate(repo_guardian_rule_gate_closed_total{reason="error"}[1h]))
 ```
 
 ### PR drift and convergence (IMPL-0013 Phase 1)
@@ -144,6 +152,24 @@ sum by (org) (rate(repo_guardian_files_missing_total[1h])) > 0
 | `properties_set_total` | Counter | — | Repositories where properties were set via API. |
 | `properties_already_correct_total` | Counter | — | Repositories where properties already matched. |
 
+### Custom-property sync (DESIGN-0019 / IMPL-0017 / IMPL-0020)
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `custom_property_cleared_total` | CounterVec | `org` | Managed properties cleared (JSON `null`) because their source annotation was removed from `catalog-info.yaml` — the DESIGN-0019 full-state-sync contract. A sustained rate here with no catalog edits suggests a fight with an org-schema `default_value` (clears re-inherit the default and re-trigger drift). |
+| `custom_property_missing_schema_total` | CounterVec | `org`, `property` | Sync attempts for a managed property the org's custom-property schema does not define. The preflight skips these (rest of the payload still syncs) and warns once per org per 30-minute schema-cache window. |
+| `catalog_parse_failed_total` | CounterVec | `org` | Custom-properties reconciles skipped because `catalog-info.yaml` failed to parse (IMPL-0020 A1 — malformed files are never overwritten with defaults). |
+
+Example:
+
+```promql
+# Which properties are missing from which org's schema
+sum by (org, property) (increase(repo_guardian_custom_property_missing_schema_total[24h]))
+
+# Repos drifting because their catalog-info.yaml is broken
+sum by (org) (increase(repo_guardian_catalog_parse_failed_total[24h]))
+```
+
 ### Multi-replica / scheduler / store / queue (IMPL-0011)
 
 | Metric | Type | Labels | Description |
@@ -231,6 +257,15 @@ sum by (endpoint) (rate(repo_guardian_discovery_api_calls_total[1h]))
 ```
 
 ### BudgetTracker (IMPL-0015 Phase 1)
+
+> **Inert in production (INV-0012).** Nothing outside tests calls
+> `Tracker.RefreshFromAPI`, so no snapshot is ever cached: every gate
+> falls open, all six metrics below stay unpublished (or zero), and
+> `enqueue_gated_by_budget_total` can never increment. Do not build
+> paging alerts on these — an empty budget dashboard means "not
+> wired", not "healthy". DESIGN-0021 replaces this mechanism with
+> measured queue-delay metrics; the tables below document the intended
+> semantics until then.
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|

--- a/contrib/grafana/repo-guardian-dashboard.json
+++ b/contrib/grafana/repo-guardian-dashboard.json
@@ -2543,7 +2543,7 @@
     {
       "id": 113,
       "type": "row",
-      "title": "BudgetTracker (IMPL-0015 Phase 1)",
+      "title": "BudgetTracker (IMPL-0015 Phase 1 \u2014 INERT, no producer; see INV-0012 / DESIGN-0021)",
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -2717,6 +2717,278 @@
           },
           "expr": "sum by (installation_id) (rate(repo_guardian_enqueue_gated_by_budget_total[5m]))",
           "legendFormat": "{{ installation_id }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 114,
+      "type": "row",
+      "title": "Absent Rules, When-Gates & Custom-Property Sync (IMPL-0017/0019/0020)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 136
+      }
+    },
+    {
+      "id": 115,
+      "type": "timeseries",
+      "title": "Forbidden Files Detected by Rule",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 137
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (rule_name) (rate(repo_guardian_files_forbidden_present_total[5m]))",
+          "legendFormat": "{{ rule_name }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 116,
+      "type": "timeseries",
+      "title": "When-Gate Closed by Reason",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 137
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (reason) (rate(repo_guardian_rule_gate_closed_total[5m]))",
+          "legendFormat": "{{ reason }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 117,
+      "type": "timeseries",
+      "title": "Custom Properties Cleared by Org",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 137
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (org) (rate(repo_guardian_custom_property_cleared_total[5m]))",
+          "legendFormat": "{{ org }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 118,
+      "type": "timeseries",
+      "title": "Properties Missing From Org Schema",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 145
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (org, property) (rate(repo_guardian_custom_property_missing_schema_total[5m]))",
+          "legendFormat": "{{ org }}/{{ property }}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 119,
+      "type": "timeseries",
+      "title": "Catalog Parse Failures by Org",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 145
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "sum"
+          ]
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (org) (rate(repo_guardian_catalog_parse_failed_total[5m]))",
+          "legendFormat": "{{ org }}",
           "refId": "A"
         }
       ]

--- a/contrib/prometheus/alerts.yaml
+++ b/contrib/prometheus/alerts.yaml
@@ -288,12 +288,18 @@ groups:
       # A rule is consistently producing rule-level out-of-scope events,
       # meaning it applies to no in-scope orgs. This usually indicates a
       # typo in the rule's scope.orgs list — the rule will never fire.
+      #
+      # Window/for shape (INV-0012): out_of_scope_total increments in
+      # bursts at sweep time, so the window must outlive the gap between
+      # bursts AND the `for` period. The original rate[1h] + for: 6h
+      # could never fire on a weekly sweep cadence — the 1h window went
+      # quiet long before the 6h pending period elapsed.
       - alert: RepoGuardianRuleNeverApplies
         expr: |
-          sum by (org) (rate(repo_guardian_out_of_scope_total{level="rule"}[1h])) > 0
+          sum by (org) (increase(repo_guardian_out_of_scope_total{level="rule"}[24h])) > 0
           and
-          sum by (org) (rate(repo_guardian_files_missing_total[1h])) == 0
-        for: 6h
+          sum by (org) (increase(repo_guardian_files_missing_total[24h])) == 0
+        for: 2h
         labels:
           severity: warning
           service: repo-guardian
@@ -432,24 +438,78 @@ groups:
             is enabled (chart) or `AUTO_CLOSE_PR=true` (env).
 
   # =====================================================================
-  # Discoverer + BudgetTracker (IMPL-0015 Phase 1)
+  # Custom-property sync (DESIGN-0019 / IMPL-0017 / IMPL-0020)
   # =====================================================================
-  - name: repo-guardian.discovery
+  - name: repo-guardian.custom-property-sync
     rules:
-      # The BudgetTracker has been blocking enqueues for 30+ minutes.
-      # The deployment is rate-limit-bound: either reduce sweep
-      # frequency, reduce rule count, or move to per-org App
-      # credentials (INV-0006).
-      - alert: RepoGuardianBudgetGated
-        expr: sum(rate(repo_guardian_enqueue_gated_by_budget_total[15m])) > 0
-        for: 30m
+      # A managed custom property (from annotation_properties or the
+      # built-in Owner/Component pair) is not defined in the org's
+      # custom-property schema, so the preflight is skipping its sync.
+      # Mirrors the chart's starter alert of the same name.
+      #
+      # increase(...[1h]) with a short `for`, not rate(...[15m]) with
+      # for: 30m: a schema mismatch is observed once per repo per sweep,
+      # so a short window goes quiet before a long pending period
+      # elapses and the alert can never fire (INV-0011 A7).
+      - alert: RepoGuardianPropertySchemaMissing
+        expr: increase(repo_guardian_custom_property_missing_schema_total[1h]) > 0
+        for: 5m
         labels:
           severity: warning
           service: repo-guardian
         annotations:
-          summary: "repo-guardian budget-gating enqueues (rate-limit bound)"
+          summary: "repo-guardian custom property missing from org schema"
           description: >-
-            The BudgetTracker has been blocking enqueues for 30+
-            minutes; the deployment is rate-limit-bound. See
-            docs/operations/scaling.md §Discoverer + BudgetTracker
-            for remediation.
+            A managed custom property has no matching definition in the
+            org's custom-property schema; its sync is being skipped.
+            Define the property at the org (or enterprise) level, or
+            remove it from annotation_properties. The structured log
+            line "custom properties missing from org schema" carries
+            the org and property names.
+
+      # A repo's catalog-info.yaml failed to parse, so its
+      # custom-properties reconcile was skipped entirely (IMPL-0020 A1:
+      # a malformed file must never overwrite the managed set with
+      # defaults). Sustained failures mean repos are drifting from
+      # their catalog metadata. Same sparse-metric shape as above.
+      - alert: RepoGuardianCatalogParseFailures
+        expr: increase(repo_guardian_catalog_parse_failed_total[1h]) > 0
+        for: 5m
+        labels:
+          severity: warning
+          service: repo-guardian
+        annotations:
+          summary: "repo-guardian skipping repos with unparseable catalog-info.yaml"
+          description: >-
+            At least one repo's catalog-info.yaml failed to parse in the
+            last hour; custom-property sync for those repos is skipped
+            (never overwritten). The structured log line "catalog-info
+            parse failed" names the repo — fix the YAML there.
+
+  # =====================================================================
+  # Discoverer + BudgetTracker (IMPL-0015 Phase 1)
+  # =====================================================================
+  # DISABLED (INV-0012): the BudgetTracker is inert in production —
+  # nothing calls RefreshFromAPI outside tests, so
+  # enqueue_gated_by_budget_total has no producer and this alert can
+  # never fire. Importing it would ship a permanently-silent alert that
+  # reads as "we're never rate-limit-bound", which is not established.
+  # DESIGN-0021 replaces the mechanism with measured queue-delay
+  # metrics (queue_delayed_total{reason}); re-enable the equivalent
+  # alert when that lands.
+  #
+  # - name: repo-guardian.discovery
+  #   rules:
+  #     - alert: RepoGuardianBudgetGated
+  #       expr: sum(rate(repo_guardian_enqueue_gated_by_budget_total[15m])) > 0
+  #       for: 30m
+  #       labels:
+  #         severity: warning
+  #         service: repo-guardian
+  #       annotations:
+  #         summary: "repo-guardian budget-gating enqueues (rate-limit bound)"
+  #         description: >-
+  #           The BudgetTracker has been blocking enqueues for 30+
+  #           minutes; the deployment is rate-limit-bound. See
+  #           docs/operations/scaling.md §Discoverer + BudgetTracker
+  #           for remediation.

--- a/docs/design/0015-per-installation-valkey-queue-partitioning.md
+++ b/docs/design/0015-per-installation-valkey-queue-partitioning.md
@@ -19,6 +19,7 @@ created: 2026-06-22
   - [Goals](#goals)
   - [Non-Goals](#non-goals)
 - [Background](#background)
+- [Relationship to DESIGN-0021 (re-baselined 2026-07-29)](#relationship-to-design-0021-re-baselined-2026-07-29)
 - [Detailed Design](#detailed-design)
   - [Key layout](#key-layout)
   - [Worker scheduling strategies](#worker-scheduling-strategies)
@@ -35,7 +36,7 @@ created: 2026-06-22
 - [Data Model](#data-model)
 - [Testing Strategy](#testing-strategy)
   - [Unit tests (internal/queue/valkey/)](#unit-tests-internalqueuevalkey)
-  - [Contract tests (contract_test.go extension)](#contract-tests-contracttestgo-extension)
+  - [Behaviour tests (inline in valkeyintegrationtest.go)](#behaviour-tests-inline-in-valkeyintegrationtestgo)
   - [Integration tests (integrationtest.go)](#integration-tests-integrationtestgo)
   - [Chaos tests](#chaos-tests)
 - [Migration / Rollout Plan](#migration--rollout-plan)
@@ -78,24 +79,27 @@ cluster-mode sharding. See `docs/operations/aws.md` for the distinction.
   doesn't require redesign.
 - Per-installation priority weights or QoS tiers. Future enhancement; the initial
   scheduler is round-robin with a uniform cap.
-- Cross-installation work stealing. Strategy A (BLPOP-many) is naturally
+- Cross-installation work stealing. Strategy A (BRPOP-many) is naturally
   work-conserving; explicit work-stealing is out of scope for v1.
-- Memory-backend partitioning. Memory mode is single-replica and the noisy-org
-  problem doesn't arise there.
 
 ## Background
 
-repo-guardian's queue today is a single LIST + ZSET pair:
+repo-guardian's queue today is a LIST + two ZSETs (the delayed set arrives with
+DESIGN-0021):
 
-```
-repo-guardian:queue:jobs        LIST  (FIFO of pending jobs)
-repo-guardian:queue:inflight    ZSET  (jobID → dispatch_ts; reaper input)
+```text
+repo-guardian:queue:jobs        LIST   (FIFO of pending jobs; LPUSH / BRPOP)
+repo-guardian:queue:in-flight   ZSET   (member = job JSON, score = claim nanos)
+repo-guardian:queue:delayed     ZSET   (member = job JSON, score = due nanos — DESIGN-0021)
+repo-guardian:lock:reaper       STRING (reaper leader lock, SETNX)
 ```
 
-`Queue.Enqueue(job)` LPUSHes onto `jobs`. `Subscribe`-driven workers BRPOPLPUSH from
-`jobs` into `inflight`, process, then ZREM the in-flight entry. The reaper goroutine
-scans `inflight` periodically and requeues jobs whose dispatch_ts is older than
-`JOB_ACK_TIMEOUT`.
+`Queue.Enqueue(job)` LPUSHes onto `jobs`. `Subscribe` consumers `BRPOP` a job, then
+`ZADD` it into `in-flight` to claim it; a nil handler return ZREMs the entry (ack).
+The reaper — one pod at a time, leader-elected via `lock:reaper` — ticks every
+`REAPER_INTERVAL` (default 1m) and atomically requeues in-flight entries older than
+`JOB_ACK_TIMEOUT` (default 5m) via a Lua script; under DESIGN-0021 the same tick also
+promotes due entries from `delayed` back to `jobs`.
 
 At fleet scale (3000 repos across 25 GitHub orgs — see `docs/operations/aws.md`), one
 large org can have 500+ actionable repos per sweep while smaller orgs have only a
@@ -108,6 +112,57 @@ fairness — every org's work clears within a sweep cycle — but not strict rou
 For operators with per-org SLAs or sensitive webhook-driven workflows, eventual
 fairness is insufficient.
 
+## Relationship to DESIGN-0021 (re-baselined 2026-07-29)
+
+[DESIGN-0021](0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md)
+was drafted after this design and changes both the facts underneath it and part of
+its motivation. This design now sequences **after** 0021, and its go/no-go becomes
+data-driven rather than speculative.
+
+**What 0021 removes from the motivation.** The worst starvation mode in the original
+framing was a *rate-limited* noisy org: workers pull its jobs and block in the
+transport's pre-emptive sleep, so one org's exhausted budget parks the entire worker
+pool. 0021 eliminates that mode outright. Because installation clients are cached
+(`client.go.getInstallClient` — one `rateLimitTransport` per installation, shared
+across jobs), once one job observes exhaustion every subsequent job for that
+installation gets `ThrottledError` from cached state with **zero API calls**, defers
+to the delayed set, and frees its worker slot in milliseconds. The residual
+motivation for this design is narrower: plain FIFO burst starvation by a large org
+doing *real, unthrottled* work.
+
+**The go/no-go datum.** 0021 Phase 5 adds `queue_wait_seconds{installation_id}`
+(enqueue→dispatch latency, measurable today because `Job` carries both
+`InstallationID` and `EnqueuedAt`). That histogram directly measures the starvation
+this design exists to fix, without partitioning anything. Proceed with this design
+only if soak data shows small installations' wait times degrading under large
+installations' bursts; otherwise it stays Draft.
+
+**Mechanical deltas this design must absorb from 0021:**
+
+- **A third per-installation key.** Each installation gets
+  `{install-N}:delayed` alongside `jobs` and `inflight`, sharing the installation's
+  hash tag — 0021's `deferScript` is a multi-key Lua across in-flight + delayed, so
+  the pair must co-locate in cluster mode exactly like the requeue pair.
+- **Scripts are already partition-ready.** `deferScript` / `promoteScript` /
+  `requeueScript` take their keys as `KEYS[]` parameters, so partitioning changes
+  only Go-side key selection (the `installKeys` helper), not the Lua.
+- **Promotion joins the reaper's per-installation iteration.** The reaper loop that
+  scans each installation's inflight ZSET also promotes each installation's delayed
+  ZSET. Same O(installations)-per-tick cost analysis; still negligible.
+- **`EnqueueAfter` routes like `Enqueue`.** Key selection by `job.InstallationID`
+  applies to both producer methods.
+- **`Attempts`/`AvailableAt`** travel inside the job JSON and are key-layout
+  agnostic — no interaction.
+
+**New capability unlocked (future extension, not v1).** Once queues are
+per-installation, a deferral for installation N can pause N's *entire queue*: record
+`paused_until = ThrottledError.ResetAt` and drop N from the BRPOP-many key list until
+it passes. Today each of N's queued jobs must individually claim → defer; with
+partitioning one deferral parks all of them for free. This subsumes Strategy C's
+"rate-limit headroom" weighting with a measured signal instead of a modelled one,
+and is the strongest 0021-era argument *for* this design if the wait-time data ever
+justifies it.
+
 ## Detailed Design
 
 ### Key layout
@@ -115,19 +170,22 @@ fairness is insufficient.
 Each known installation gets its own LIST + ZSET. A registry SET tracks known
 installation IDs so workers and the reaper can iterate.
 
-```
+```text
 repo-guardian:queue:{install-12345}:jobs       LIST
 repo-guardian:queue:{install-12345}:inflight   ZSET
+repo-guardian:queue:{install-12345}:delayed    ZSET  (DESIGN-0021 delayed set)
 repo-guardian:queue:{install-67890}:jobs       LIST
 repo-guardian:queue:{install-67890}:inflight   ZSET
+repo-guardian:queue:{install-67890}:delayed    ZSET
 repo-guardian:queue:installations              SET  (member: stringified install ID)
 ```
 
 Note the `{install-N}` hash-tag braces. Valkey treats text inside `{ }` as the hash
-slot key in cluster mode. Tagging the LIST and ZSET for installation N together
-guarantees they land on the same shard — required for multi-key Lua scripts that
-operate atomically across the pair. The installations-registry SET has no tag because
-no multi-key operation needs it alongside the per-installation keys.
+slot key in cluster mode. Tagging all three keys for installation N together
+guarantees they land on the same shard — required for the multi-key Lua scripts that
+operate atomically across pairs (`requeueScript`: inflight→jobs; `deferScript`:
+inflight→delayed; `promoteScript`: delayed→jobs). The installations-registry SET has
+no tag because no multi-key operation needs it alongside the per-installation keys.
 
 `Enqueue(job)` becomes:
 
@@ -146,14 +204,14 @@ per-installation soft cap**; B and C are future extensions if A proves insuffici
 
 | Strategy | How it works | Pros | Cons |
 |---|---|---|---|
-| **A. BLPOP across all keys** | Worker reads `SMEMBERS installations`, issues `BLPOP key1 key2 … keyN <timeout>` — Valkey returns from whichever queue has work first | Trivial code; natural fairness for ready work; no extra coordination state | No strict cap on per-installation parallelism — a noisy org can still claim every worker slot |
+| **A. BRPOP across all keys** | Worker reads `SMEMBERS installations`, issues `BRPOP key1 key2 … keyN <timeout>` — Valkey returns from whichever queue has work first | Trivial code; natural fairness for ready work; no extra coordination state | No strict cap on per-installation parallelism — a noisy org can still claim every worker slot |
 | **B. Round-robin with per-installation concurrency cap** | Maintain `repo-guardian:queue:{install-N}:in_flight_count` counter; worker iterates installations in round-robin order, skips any at cap | Strict fairness; bounds noisy-installation parallelism | More state; atomic check-and-incr Lua script required |
 | **C. Weighted random by depth + rate-limit headroom** | Worker picks an installation at random, weighted by `(queue_depth × rate_limit_remaining)` | Adapts dynamically to rate limits; statistically fair | Most state; depth + headroom snapshots; harder to reason about |
 
-**Recommendation: A with a soft cap.** Combines BLPOP-many's simplicity with an
+**Recommendation: A with a soft cap.** Combines BRPOP-many's simplicity with an
 explicit per-installation in-flight ceiling. The cap is enforced application-side:
-when a worker successfully BLPOPs from installation N's queue, it increments a local
-counter for N; subsequent BLPOPs exclude N from the key list once N is at cap. The
+when a worker successfully BRPOPs from installation N's queue, it increments a local
+counter for N; subsequent BRPOPs exclude N from the key list once N is at cap. The
 counter decrements on job completion. No Valkey-side coordination needed.
 
 ```go
@@ -164,7 +222,7 @@ func (w *Worker) loop(ctx context.Context) {
         eligible := w.filterAtCap(installs)                // exclude installations at perInstallationCap
         if len(eligible) == 0 { time.Sleep(idleBackoff); continue }
         keys := installToKeys(eligible)
-        result, err := w.redis.BLPop(ctx, w.blpopTimeout, keys...).Result()
+        result, err := w.redis.BRPop(ctx, w.brpopTimeout, keys...).Result()
         // ... dispatch
     }
 }
@@ -174,7 +232,7 @@ func (w *Worker) loop(ctx context.Context) {
 
 Default formula:
 
-```
+```text
 perInstallationCap = max(2, ceil(workerCount / max(installations_count, 1)))
 ```
 
@@ -188,33 +246,36 @@ Operator override: `queue.partitioning.perInstallationCap` in values.yaml.
 
 ### Reaper changes
 
-The current reaper scans one ZSET (`inflight`) on every tick. With partitioning, it
-scans all per-installation inflight ZSETs:
+The current reaper scans two ZSETs on every tick: `in-flight` (requeue expired
+claims) and, post-DESIGN-0021, `delayed` (promote due jobs). With partitioning, it
+scans both per installation:
 
 ```go
 installs, err := r.redis.SMembers(ctx, "repo-guardian:queue:installations").Result()
 for _, install := range installs {
-    expired, err := r.redis.ZRangeByScore(ctx, fmt.Sprintf("repo-guardian:queue:{install-%s}:inflight", install), ...)
-    // ... requeue expired
+    jobs, inflight, delayed := installKeys(install)
+    // requeueScript: expired inflight entries → jobs (existing)
+    // promoteScript: due delayed entries → jobs (DESIGN-0021)
 }
 ```
 
-Per-tick cost grows O(installations). At 25 installations × 1 ZRANGEBYSCORE call = 25
-Valkey ops per tick. With the default 30-second reaper interval, that's <1 op/sec.
+Per-tick cost grows O(installations). At 25 installations × 2 script calls = 50
+Valkey ops per tick. With the default 1-minute `REAPER_INTERVAL`, that's <1 op/sec.
 Negligible.
 
 ### Installation lifecycle
 
 **Discovery:** installations are added to the registry on first Enqueue (idempotent
-SADD). The legacy `Sweeper` (and the proposed replacement per DESIGN-0017) handles
-populating the registry initially.
+SADD). The `Discoverer` (shipped in IMPL-0015 Phase 1, replacing the legacy
+`Sweeper` this draft originally referenced) populates `repo_state`, and the
+`StaleSweeper`'s enqueues populate the registry from there.
 
 **Removal:** uninstalling a GitHub App should remove the installation from the
 registry. Handled via the existing `installation.deleted` webhook event — webhook
 handler issues `SREM` and deletes the per-installation LIST + ZSET keys.
 
 **Stale registry entries:** if a worker crashes mid-removal, an installation may
-linger in the registry with no LIST. BLPOP on a non-existent key blocks waiting for
+linger in the registry with no LIST. BRPOP on a non-existent key blocks waiting for
 LPUSH; this is fine — no jobs ever arrive, the worker times out and moves on. A
 janitor goroutine could periodically `EXISTS` each registry entry and SREM stale
 ones, but it's not on the critical path.
@@ -223,9 +284,12 @@ ones, but it's not on the critical path.
 
 The hash-tag layout (`{install-N}`) ensures cluster-mode safety even though this
 design doesn't target cluster mode in v1. If a future operator deploys against
-ElastiCache cluster-mode-enabled, the per-installation keys still co-locate on one
-shard (required for the multi-key BLPOP across multiple keys in a single ZRANGE+ZREM
-Lua script).
+ElastiCache cluster-mode-enabled, each installation's three keys still co-locate on
+one shard — required for every multi-key Lua transition (`requeueScript`,
+`deferScript`, `promoteScript`) and for multi-key `BRPOP` within that installation.
+Note the *global* keys of the pre-partitioned layout are cluster-mode-unsafe for the
+same scripts; partitioning is what makes cluster mode possible at all, which is why
+the tags are in the v1 layout despite v1 not targeting cluster mode.
 
 Also requires the `cmd/repo-guardian/main.go` wiring to use `redis.NewUniversalClient`
 (or detect cluster topology) instead of `redis.NewClient`. Out of scope for this
@@ -235,32 +299,36 @@ DESIGN — captured as a follow-up.
 
 ### `internal/queue/Queue` interface
 
-Unchanged externally:
+Unchanged externally — this design adds no methods to the post-DESIGN-0021 surface:
 
 ```go
 type Queue interface {
-    Enqueue(ctx context.Context, job Job) error
-    Subscribe(ctx context.Context, handler Handler) error
+    Enqueue(ctx context.Context, j Job) error
+    Subscribe(ctx context.Context, handler func(context.Context, Job) error) error
     Close() error
+    EnqueueAfter(ctx context.Context, j Job, at time.Time) error // DESIGN-0021
 }
 ```
 
-The `Job` struct already carries `InstallationID`. The implementation selects the key
-based on this field.
+The `Job` struct already carries `InstallationID`. The implementation selects keys
+from this field — for `Enqueue`, `EnqueueAfter`, claim, defer, and promote alike.
 
 ### `internal/queue/valkey/`
 
-- LUA scripts rewritten to operate on per-installation keys.
-- New private method `installKeys(installationID int64) (jobsKey, inflightKey string)`
-  centralises key naming.
-- BLPOP-multi loop in `Subscribe` polls all installations registered in
+- Lua scripts need **no rewrite** — `requeueScript`, `deferScript`, and
+  `promoteScript` take their keys as `KEYS[]` parameters. Only the Go-side key
+  selection changes.
+- The key-naming helper (`installKeys(installationID) (jobs, inflight, delayed
+  string)`) extends the single key-construction point DESIGN-0021 Phase 2
+  establishes.
+- BRPOP-multi loop in `Subscribe` polls all installations registered in
   `repo-guardian:queue:installations`.
 
 ### `internal/worker/`
 
 - Per-worker local state: `inFlightByInstall map[int64]int`.
 - Configurable `PerInstallationCap` (default per formula above).
-- Filter eligible installations before BLPOP.
+- Filter eligible installations before BRPOP.
 
 ### `internal/metrics/`
 
@@ -284,7 +352,8 @@ queue:
 
 No schema changes (queue is Valkey, not Postgres). Key namespace evolves as
 described in [Key layout](#key-layout). Existing single-queue deployments retain the
-`repo-guardian:queue:jobs` and `repo-guardian:queue:inflight` keys until the
+`repo-guardian:queue:jobs`, `repo-guardian:queue:in-flight`, and
+`repo-guardian:queue:delayed` keys until the
 [migration](#migration--rollout-plan) drains them.
 
 ## Testing Strategy
@@ -293,11 +362,14 @@ described in [Key layout](#key-layout). Existing single-queue deployments retain
 
 - Key-name selector correctness for various `installationID` values.
 - Idempotent SADD on repeated Enqueue.
-- BLPOP-multi returns from any non-empty installation queue.
+- BRPOP-multi returns from any non-empty installation queue.
 
-### Contract tests (`contract_test.go` extension)
+### Behaviour tests (inline in `valkey_integration_test.go`)
 
-Add fairness assertions to the existing Queue contract suite:
+The multi-backend contract suite this draft originally targeted is gone —
+post-IMPL-0016 there is one Queue backend and contract assertions live inline under
+the `integration` build tag (see `internal/queue/valkey/valkey_integration_test.go`).
+Add fairness assertions there:
 
 - **Strict fairness under burst:** enqueue 100 jobs for install-A, 1 job for
   install-B; with `perInstallationCap=2` and 5 workers, install-B's job dispatches
@@ -370,9 +442,9 @@ of the Phase 2 drain).
 
 **(b)** Worker scheduling strategy at GA.
 
-- **(a) = Strategy A (BLPOP-many) with soft cap (recommended).** Simplest implementation;
+- **(a) = Strategy A (BRPOP-many) with soft cap (recommended).** Simplest implementation;
   good enough for the vast majority of fleets.
-- (b) Strategy B (round-robin with hard cap). Reach for it if BLPOP-many's
+- (b) Strategy B (round-robin with hard cap). Reach for it if BRPOP-many's
   "exclude-at-cap" application-side check proves insufficient (e.g., under sustained
   noisy-org bursts where the local cap counter races against worker startup).
 - (c) Strategy C (weighted random by depth + headroom). Future enhancement only.
@@ -381,7 +453,7 @@ of the Phase 2 drain).
 **(c)** Installation registry consistency mechanism.
 
 - **(a) = Idempotent SADD on Enqueue, SREM on `installation.deleted` webhook, no
-  periodic janitor (recommended).** Simplest; stale entries cause BLPOP timeouts
+  periodic janitor (recommended).** Simplest; stale entries cause BRPOP timeouts
   but no correctness issue.
 - (b) Periodic janitor SCAN/EXISTS pass. Defensive but more code. Easy to add later
   if stale entries accumulate.
@@ -414,5 +486,12 @@ of the Phase 2 drain).
 - [IMPL-0011: Persistent reconcile state and multi-replica coordination](../impl/0011-persistent-reconcile-state-and-multi-replica-coordination.md)
   — implementation of DESIGN-0012; baseline for this design's deltas
 - [DESIGN-0017: Stale-sweep cutover and repository discovery](0017-stale-sweep-cutover-and-repository-discovery.md)
-  — sibling design; partitioning + discovery cutover together close out the
-  multi-replica scaling story
+  — shipped via IMPL-0015; its Discoverer populates the repo_state this design's
+  registry hangs off
+- [DESIGN-0021: Delayed-requeue job contract and rate-limit consolidation](0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md)
+  — sequences before this design; supplies the delayed set, the key-naming
+  centralisation, and the `queue_wait_seconds{installation_id}` go/no-go datum (see
+  [Relationship to DESIGN-0021](#relationship-to-design-0021-re-baselined-2026-07-29))
+- [INV-0012](../investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md)
+  — the investigation that produced DESIGN-0021; finding I (lease-outliving sleeps)
+  is the starvation mode 0021 removes from this design's motivation

--- a/docs/design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md
+++ b/docs/design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md
@@ -99,9 +99,18 @@ modelled from a hand-tuned cost estimate that has never been calibrated.
 - Rewriting the worker pool's concurrency model. `WORKER_COUNT`
   goroutines consuming `Subscribe` stays.
 - Per-installation fair scheduling or priority queues. A single FIFO with
-  a delayed side-set is the scope; fairness is a separate design if
-  observed data ever justifies it (see
-  [DESIGN-0015](0015-per-installation-valkey-queue-partitioning.md)).
+  a delayed side-set is the scope; fairness is
+  [DESIGN-0015](0015-per-installation-valkey-queue-partitioning.md)'s
+  territory (re-baselined against this design 2026-07-29). This design
+  deliberately stays partition-compatible — key construction is
+  centralised (task 2.1), the Lua scripts are key-parametric, and under
+  partitioning the delayed set splits per installation inside the same
+  hash tag — and Phase 5's `queue_wait_seconds{installation_id}` supplies
+  the measurement that decides whether 0015 is ever needed. Worth noting:
+  this design also *narrows* 0015's motivation — a rate-limited noisy org
+  can no longer park the worker pool, because its jobs defer from cached
+  transport state with zero API calls; what remains for 0015 is plain
+  FIFO burst starvation by an unthrottled large org.
 - Removing the transport's 403 retry handling. Retrying a *rejected*
   request is a transport concern and stays there — only the pre-emptive
   sleep moves.
@@ -396,6 +405,14 @@ New metrics:
 | `queue_delayed_depth` | Gauge | — | how much work is parked right now |
 | `queue_delay_seconds` | Histogram | `reason` | how long are the deferrals |
 | `queue_attempts_exhausted_total` | Counter | `installation_id` | is anything being dropped |
+| `queue_wait_seconds` | Histogram | `installation_id` | enqueue→dispatch latency per tenant — the [DESIGN-0015](0015-per-installation-valkey-queue-partitioning.md) go/no-go datum |
+
+`queue_wait_seconds` is cheap to add here (the job already carries
+`InstallationID` and `EnqueuedAt`; the worker observes the delta at
+claim time) and does double duty: it directly measures the FIFO
+starvation DESIGN-0015 exists to fix, so that design proceeds or stays
+Draft on soak data instead of speculation. Cardinality is
+installations × buckets (~25 × 12), well within budget.
 
 Together these answer the question the BudgetTracker was built for — "are
 we hitting API limits, how hard, and for whom" — from measurement rather
@@ -484,7 +501,11 @@ the real fix.
 #### Tasks
 
 - [ ] 2.1 Add `DelayedKey` to `valkey.Options`, defaulting to
-      `repo-guardian:queue:delayed`.
+      `repo-guardian:queue:delayed`, and centralise construction of all
+      queue keys (jobs, in-flight, delayed, reaper lock) in one helper —
+      DESIGN-0015's per-installation partitioning then changes key
+      selection in exactly one place, since the Lua scripts already take
+      their keys as `KEYS[]` parameters.
 - [ ] 2.2 Implement `deferScript` (ZREM in-flight + ZADD delayed, atomic)
       and wire it to `EnqueueAfter`.
 - [ ] 2.3 Implement `promoteScript` (ZRANGEBYSCORE due + ZREM + LPUSH,
@@ -571,6 +592,9 @@ the real fix.
       `queue_delay_seconds{reason}`, and
       `queue_attempts_exhausted_total{installation_id}`
       (`queue_delayed_depth` lands in 2.4).
+- [ ] 5.1b Add `queue_wait_seconds{installation_id}` — observed at claim
+      time as `now - EnqueuedAt`. This is the DESIGN-0015 go/no-go
+      measurement; no partitioning is needed to collect it.
 - [ ] 5.2 Add `RepoGuardianQueueBackpressure` and
       `RepoGuardianJobsExhausted` to the chart's `prometheusrule.yaml`
       **and** `contrib/prometheus/alerts.yaml` (INV-0012 finding F: the
@@ -795,7 +819,9 @@ why it ships on its own.
 - [DESIGN-0017](0017-stale-sweep-cutover-and-repository-discovery.md)
   — Layer 1/Layer 2 budget design whose BudgetTracker is removed here
 - [DESIGN-0015](0015-per-installation-valkey-queue-partitioning.md)
-  — adjacent queue work; fairness is explicitly out of scope here
+  — adjacent queue work, re-baselined 2026-07-29 against this design;
+  fairness stays out of scope here, but task 2.1 (key centralisation) and
+  task 5.1b (`queue_wait_seconds`) are its forward hooks
 - [IMPL-0011](../impl/0011-persistent-reconcile-state-and-multi-replica-coordination.md)
   — introduced the queue, lease, and reaper
 - [IMPL-0015](../impl/0015-stale-sweep-cutover-and-repository-discovery.md)

--- a/docs/design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md
+++ b/docs/design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md
@@ -205,15 +205,31 @@ if resetAt, remaining, limit, throttled := t.shouldThrottle(); throttled {
 }
 ```
 
-`net/http.Client` wraps a `RoundTrip` error in `*url.Error`, which
-implements `Unwrap`, and the client and engine wrap with `%w` throughout
-(45 sites in `internal/github/client.go` alone). So `errors.As` at the
-worker should recover the typed error through the whole chain.
+The chain from `RoundTrip` to the worker was audited rather than assumed,
+because a break in it is silent — the job would nack normally instead of
+deferring, which reads as ordinary retry rather than a bug. Three hops,
+all verified:
 
-**Phase 3 must prove that end to end with a test rather than assume it.**
-A single `fmt.Errorf` without `%w` anywhere on the path silently breaks
-it, and the failure mode is subtle: the job nacks normally instead of
-deferring, which looks like ordinary retry rather than a bug.
+1. **`net/http.Client.Do`** wraps a `RoundTrip` error in `*url.Error`,
+   which implements `Unwrap`.
+2. **go-github's `BareDo`** returns that `*url.Error` unchanged apart
+   from URL sanitisation (`github.go:856`), so the chain survives the
+   third-party hop. One exception, benign: on a cancelled context it
+   discards the transport error and returns `ctx.Err()` instead
+   (`github.go:850`). Deferral is moot during shutdown, so this needs no
+   handling — but it does mean a cancelled job nacks rather than defers.
+3. **Our client and engine** wrap with `%w`. Of the 102 `fmt.Errorf`
+   calls across `internal/{github,checker,worker,queue}`, 8 omit `%w` and
+   all 8 originate a new error with no cause in scope to discard (e.g.
+   `unsupported property: %s`). Zero broken wraps.
+
+The chain is also lint-enforced going forward: `errorlint` is enabled
+with `errorf: true`, so formatting an error with `%v` instead of `%w`
+fails the build. What no enabled linter catches is *discarding* an error
+and originating a fresh one — which is exactly why task 3.4 pins the
+invariant with an end-to-end test instead of an audit. A test that drives
+a real throttle through the real path fails if any link breaks, whichever
+link it is; an audit only proves the state of the code on the day it ran.
 
 `internal/github` must not import `internal/queue` — the client is the
 lower layer. The worker performs the translation:
@@ -501,13 +517,16 @@ the real fix.
       `github_rate_limit_wait_seconds` by recording the *would-be* delay
       at the point of the return, so the three existing rate-limit alerts
       keep receiving samples.
-- [ ] 3.4 **Prove the error survives the full chain**: drive a real
+- [ ] 3.4 **Pin the chain with an end-to-end test**: drive a real
       `Engine.CheckRepo` against an `httptest` server returning
       rate-limit headers and assert `errors.As` recovers
-      `*ThrottledError` at the worker boundary. Most likely task to
-      surface a missing `%w`.
-- [ ] 3.5 Audit the client and engine error paths for non-`%w`
-      `fmt.Errorf`; fix whatever 3.4 exposes.
+      `*ThrottledError` at the worker boundary. This is a permanent
+      invariant test, not a one-off check — it fails if any link in the
+      chain breaks later, whichever link it is.
+- [ ] 3.5 Verify the test is non-vacuous by neutralising one `%w` on the
+      path, confirming the test fails, and restoring it. Without this the
+      assertion can pass by constructing the error too close to the
+      assertion rather than driving it through the real chain.
 
 #### Success Criteria
 
@@ -672,7 +691,7 @@ why it ships on its own.
 
 | Risk | Likelihood | Mitigation |
 |---|---|---|
-| The typed error does not survive the wrap chain | medium | Task 3.4 proves it end to end before Phase 4 depends on it |
+| The typed error does not survive the wrap chain | low — audited clean across all three hops, and `errorlint` guards the common regression | Task 3.4 pins it as a permanent invariant test so a later break fails CI rather than degrading silently |
 | Promotion granularity (60s) too coarse | low | Open Question 3; reconcile work is measured in hours |
 | A job defers forever without progressing | low | Attempt cap (4.4) plus `queue_attempts_exhausted_total` |
 | Partial work repeated after deferral | certain, low impact | The engine is idempotent by design (INV-0003); wasted calls are bounded |

--- a/docs/design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md
+++ b/docs/design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md
@@ -1,0 +1,785 @@
+---
+id: DESIGN-0021
+title: "Delayed-requeue job contract and rate-limit consolidation"
+status: Draft
+author: Donald Gifford
+created: 2026-07-26
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# DESIGN 0021: Delayed-requeue job contract and rate-limit consolidation
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-07-26
+
+<!--toc:start-->
+- [Overview](#overview)
+- [Goals and Non-Goals](#goals-and-non-goals)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Background](#background)
+- [Detailed Design](#detailed-design)
+  - [The contract](#the-contract)
+  - [Signal path: transport to worker](#signal-path-transport-to-worker)
+  - [Valkey key layout](#valkey-key-layout)
+  - [Promotion](#promotion)
+  - [Backoff and attempt cap](#backoff-and-attempt-cap)
+  - [Interaction with the in-flight lease](#interaction-with-the-in-flight-lease)
+  - [Layer disposition](#layer-disposition)
+- [API / Interface Changes](#api--interface-changes)
+- [Data Model](#data-model)
+- [Observability](#observability)
+- [Implementation Phases](#implementation-phases)
+  - [Phase 0: Stop the bleeding](#phase-0-stop-the-bleeding)
+    - [Tasks](#tasks)
+    - [Success Criteria](#success-criteria)
+  - [Phase 1: Job contract](#phase-1-job-contract)
+    - [Tasks](#tasks-1)
+    - [Success Criteria](#success-criteria-1)
+  - [Phase 2: Delayed set and promotion](#phase-2-delayed-set-and-promotion)
+    - [Tasks](#tasks-2)
+    - [Success Criteria](#success-criteria-2)
+  - [Phase 3: Throttle signal path](#phase-3-throttle-signal-path)
+    - [Tasks](#tasks-3)
+    - [Success Criteria](#success-criteria-3)
+  - [Phase 4: Worker requeue and attempt cap](#phase-4-worker-requeue-and-attempt-cap)
+    - [Tasks](#tasks-4)
+    - [Success Criteria](#success-criteria-4)
+  - [Phase 5: Observability](#phase-5-observability)
+    - [Tasks](#tasks-5)
+    - [Success Criteria](#success-criteria-5)
+  - [Phase 6: Remove the superseded layers](#phase-6-remove-the-superseded-layers)
+    - [Tasks](#tasks-6)
+    - [Success Criteria](#success-criteria-6)
+  - [Phase 7: Docs and chart](#phase-7-docs-and-chart)
+    - [Tasks](#tasks-7)
+    - [Success Criteria](#success-criteria-7)
+- [Testing Strategy](#testing-strategy)
+- [Migration / Rollout Plan](#migration--rollout-plan)
+- [Risks](#risks)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Overview
+
+repo-guardian has three independent mechanisms for handling GitHub API
+rate limits. They were built against two different execution models three
+months apart, they do not compose, and the oldest actively breaks the
+newest: the HTTP transport sleeps in-handler for up to an hour, while the
+durable queue it now runs under considers a job abandoned after five
+minutes and hands it to another worker.
+
+This design replaces all three with one mechanism. A worker that cannot
+proceed because of rate limits **returns the job to the queue with a
+due-time and frees its slot** instead of blocking. The queue grows a
+delayed set, promoted by the reaper that already exists. `queue.Job`
+grows the fields a retry contract needs, and the `queue.Queue` doc
+comment stops gesturing at retry semantics and starts specifying them.
+
+The observability the inert BudgetTracker was built to provide falls out
+of this for free, and is better: deferred work is *measured* rather than
+modelled from a hand-tuned cost estimate that has never been calibrated.
+
+## Goals and Non-Goals
+
+### Goals
+
+- No worker ever blocks on a rate limit while holding a queue lease.
+- A defined retry contract — delay, backoff, attempt cap, terminal
+  disposition — specified on the interface rather than implied.
+- One rate-limit mechanism instead of three.
+- The operator can answer "are we hitting API limits, how hard, for which
+  installation" from metrics, and alert before backpressure bites.
+- No regression in the at-least-once delivery guarantee.
+
+### Non-Goals
+
+- Rewriting the worker pool's concurrency model. `WORKER_COUNT`
+  goroutines consuming `Subscribe` stays.
+- Per-installation fair scheduling or priority queues. A single FIFO with
+  a delayed side-set is the scope; fairness is a separate design if
+  observed data ever justifies it (see
+  [DESIGN-0015](0015-per-installation-valkey-queue-partitioning.md)).
+- Removing the transport's 403 retry handling. Retrying a *rejected*
+  request is a transport concern and stays there — only the pre-emptive
+  sleep moves.
+- Changing the Store, the scheduler, or the discovery path beyond
+  deleting the budget gate.
+- Adding a second queue backend. Valkey remains the only one (IMPL-0016).
+
+## Background
+
+[INV-0012](../investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md)
+established the following, all verified against the code rather than
+inferred.
+
+**Three layers exist and do not compose.**
+
+| # | Layer | Introduced | Behaviour under pressure | Status |
+|---|---|---|---|---|
+| 1 | Transport limiter (`internal/github/ratelimit.go`) | 2026-02-10 `7c777e5`, per [DESIGN-0002](0002-github-api-rate-limit-handling.md) | pre-emptively *sleeps* `untilReset / remaining`; retries 403s | works |
+| 2 | Sweep reserve gate (`StaleSweeper.allowedByRateLimit`) | 2026-05-06, IMPL-0011 P5 | *skips* the repo | works |
+| 3 | BudgetTracker (`internal/budget`) | IMPL-0015 P1 | would *decline* the enqueue | **inert** — `RefreshFromAPI` has no production caller |
+
+**Layer 1 predates the queue by three months.** DESIGN-0002 specified
+"sleep to spread budget until reset… if `remaining == 0`, sleep until
+reset" in a world where work was an in-process buffered channel
+(`internal/checker/queue.go`, 2026-02-08). Blocking a goroutine cost one
+goroutine, and there was no lease to hold. The durable queue, leases, and
+reaper arrived 2026-05-06 (IMPL-0011) and nothing revisited the
+assumption. DESIGN-0002 is not *wrong*; it is correct for a system that
+no longer exists.
+
+**The consequence is duplicate amplification.** No handler timeout exists
+anywhere. With `JOB_ACK_TIMEOUT=5m`, `REAPER_INTERVAL=1m`,
+`WORKER_COUNT=5`, and a transport sleep of up to `untilReset` (1h when
+`remaining == 0`):
+
+```text
+t=0     worker A claims J, ZADD in-flight, transport sleeps 50m
+t=5m    reaper: J older than ack timeout → LPUSH + ZREM (atomic)
+t=5m    worker B claims J, also sleeps
+t=10m   reaper requeues again → worker C …
+```
+
+Roughly ten clones of one job over a 50-minute exhaustion window against
+five worker slots, each waking to issue *more* calls against the
+exhausted budget. Positive feedback triggered by exactly the condition
+layer 3 was designed to prevent.
+
+**There is no contract to break.** `queue.Queue` is three methods, and
+the only statement of nack semantics is a parenthetical:
+
+```go
+// A nil return from handler is an implicit ack; an error is a nack
+// (durable implementations may retry; the in-memory implementation
+// logs and drops).
+```
+
+Stale on both halves — IMPL-0016 deleted the in-memory implementation,
+and "may retry" specifies no delay, no backoff, and no attempt cap.
+`queue.Job` carries neither `Attempts` nor `AvailableAt`, and `reapOnce`
+has no attempt cap and no dead-letter path.
+
+## Detailed Design
+
+### The contract
+
+Three handler outcomes replace today's two:
+
+| Handler returns | Meaning | Queue action |
+|---|---|---|
+| `nil` | done | `ZREM` in-flight (ack) |
+| `error` | failed, retry promptly | leave in-flight; reaper resurfaces after `JOB_ACK_TIMEOUT` |
+| `*queue.RetryAfterError` | cannot proceed yet | move to the delayed set with a due-time, free the slot **now** |
+
+The third is new. It is a *deliberate deferral* carrying a due-time,
+distinct from a failure: the job did not fail, it is not yet runnable.
+
+```go
+// RetryAfterError signals that a job could not proceed and must not be
+// retried before After. Returning it is not a failure — the job is
+// deferred rather than nacked, and Attempts is incremented.
+type RetryAfterError struct {
+    After  time.Time
+    Reason string // "rate_limit", "secondary_limit", … — used as a metric label
+    Err    error  // optional underlying cause
+}
+```
+
+### Signal path: transport to worker
+
+The transport knows about throttling; the worker owns the queue
+interaction. They are separated by the whole engine and the go-github
+client, so the signal has to travel.
+
+The transport's pre-emptive branch stops calling `sleepWithContext` and
+returns a typed error carrying GitHub's own reset time:
+
+```go
+// internal/github/ratelimit.go — RoundTrip
+if resetAt, remaining, limit, throttled := t.shouldThrottle(); throttled {
+    return nil, &ThrottledError{ResetAt: resetAt, Remaining: remaining, Limit: limit}
+}
+```
+
+`net/http.Client` wraps a `RoundTrip` error in `*url.Error`, which
+implements `Unwrap`, and the client and engine wrap with `%w` throughout
+(45 sites in `internal/github/client.go` alone). So `errors.As` at the
+worker should recover the typed error through the whole chain.
+
+**Phase 3 must prove that end to end with a test rather than assume it.**
+A single `fmt.Errorf` without `%w` anywhere on the path silently breaks
+it, and the failure mode is subtle: the job nacks normally instead of
+deferring, which looks like ordinary retry rather than a bug.
+
+`internal/github` must not import `internal/queue` — the client is the
+lower layer. The worker performs the translation:
+
+```go
+// internal/worker — processJob
+var thr *ghclient.ThrottledError
+if errors.As(err, &thr) {
+    return &queue.RetryAfterError{After: thr.ResetAt, Reason: "rate_limit", Err: err}
+}
+```
+
+### Valkey key layout
+
+One new key alongside the existing three:
+
+| Key | Type | Purpose |
+|---|---|---|
+| `repo-guardian:queue:jobs` | LIST | pending (existing) |
+| `repo-guardian:queue:in-flight` | ZSET, score = claim nanos | claimed, awaiting ack (existing) |
+| `repo-guardian:lock:reaper` | STRING | leader lock (existing) |
+| **`repo-guardian:queue:delayed`** | **ZSET, score = due-time nanos** | **deferred, awaiting promotion** |
+
+The delayed set is the same primitive as in-flight with a different score
+meaning: in-flight scores are "claimed at", delayed scores are "runnable
+at".
+
+### Promotion
+
+Deferral and promotion are Lua scripts, mirroring the existing
+`requeueScript`, so each transition is atomic:
+
+```lua
+-- deferScript: KEYS[1]=in-flight, KEYS[2]=delayed
+--              ARGV[1]=member, ARGV[2]=due-nanos
+redis.call("ZREM", KEYS[1], ARGV[1])
+redis.call("ZADD", KEYS[2], ARGV[2], ARGV[1])
+return 1
+```
+
+```lua
+-- promoteScript: KEYS[1]=delayed, KEYS[2]=jobs, ARGV[1]=now-nanos
+local due = redis.call("ZRANGEBYSCORE", KEYS[1], "0", "(" .. ARGV[1])
+for _, m in ipairs(due) do
+  redis.call("ZREM", KEYS[1], m)
+  redis.call("LPUSH", KEYS[2], m)
+end
+return #due
+```
+
+Promotion runs in the reaper, which is already leader-elected via
+`lock:reaper` and already ticks on `REAPER_INTERVAL`. Reusing it means no
+new leader election, no new goroutine, and no new failure mode — at the
+cost of promotion granularity being bounded by `REAPER_INTERVAL` (60s
+default). A job due at t+61s runs at t+120s worst case. That is fine for
+reconcile work measured in hours; Open Question 3 covers whether it
+should be independently tunable.
+
+### Backoff and attempt cap
+
+The delay comes from GitHub when GitHub supplies one — `resetAt` on the
+primary limit, `Retry-After` on the secondary. That is authoritative and
+should not be second-guessed. Jitter is then applied so a fleet throttled
+simultaneously does not stampede at the same instant, reusing the pattern
+`Discoverer` already uses for `LastCheckedAt`:
+
+```text
+delay = resetAt - now
+due   = now + delay + rand[0, min(delay/4, 60s))
+```
+
+For deferrals with no server-supplied time, exponential backoff on
+`Attempts` with the same jitter.
+
+`Attempts` increments on every deferral and every reaper requeue. On
+exceeding `MAX_JOB_ATTEMPTS` the job takes the terminal disposition —
+Open Question 2, the one part of this design with no obviously correct
+answer.
+
+### Interaction with the in-flight lease
+
+Deferral removes the in-flight entry, so the reaper never sees a deferred
+job and the amplification loop cannot form. A job is in exactly one of
+`jobs`, `in-flight`, or `delayed`, and every transition between them is a
+single Lua script.
+
+This also resolves INV-0012 finding J incidentally. Duplicate claims
+today share a ZSET member because `Job.ID` is a deterministic hash of
+`(InstallationID, Owner, Repo)`, so the first worker to wake `ZREM`s the
+other's claim. Once nothing sleeps in-handler, jobs leave in-flight in
+bounded time and the overlap window closes. It does not *fix* the shared
+member — two genuinely concurrent claims of the same repo would still
+collide — so Open Question 5 asks whether the member should carry a claim
+nonce.
+
+### Layer disposition
+
+| Layer | Disposition | Rationale |
+|---|---|---|
+| 1 — transport | **Keep, minus the sleep.** 403 retries stay; the pre-emptive sleep becomes `ThrottledError`. | Retrying a rejected request is a transport concern. Blocking a leased worker is not. |
+| 2 — sweep reserve gate | **Remove** (Open Question 4 offers keeping it). | Skipping and deferring converge, except deferral does not silently drop the repo until the next sweep. |
+| 3 — BudgetTracker | **Delete.** | Its unique value was keeping depleted-budget work out of the queue; deferral does that structurally. Its other value — forward-looking capacity — is replaced by measured `queue_delayed_depth`. |
+
+## API / Interface Changes
+
+```go
+// internal/queue — Job gains two fields
+type Job struct {
+    ID             string
+    InstallationID int64
+    Owner          string
+    Repo           string
+    Trigger        string
+    EnqueuedAt     time.Time
+    Attempts       int       // NEW — incremented on defer and on reaper requeue
+    AvailableAt    time.Time // NEW — zero means "runnable now"
+}
+
+// internal/queue — Queue gains one method
+type Queue interface {
+    Enqueue(ctx context.Context, j Job) error
+    Subscribe(ctx context.Context, handler func(context.Context, Job) error) error
+    Close() error
+
+    // EnqueueAfter schedules j to become runnable no earlier than at.
+    // Implementations MUST NOT deliver j before at. An at in the past
+    // is equivalent to Enqueue.
+    EnqueueAfter(ctx context.Context, j Job, at time.Time) error // NEW
+}
+
+// internal/github — new exported error type
+type ThrottledError struct {
+    ResetAt   time.Time
+    Remaining int
+    Limit     int
+}
+```
+
+The `Queue` doc comment is rewritten to specify the three outcomes,
+attempt counting, and the terminal disposition — the contract INV-0012
+finding K established does not exist today.
+
+**Backward compatibility.** `Job` is serialised as JSON into Valkey, and
+`encoding/json` tolerates missing fields on decode, so jobs enqueued by
+the previous version decode with `Attempts=0` and a zero `AvailableAt`,
+both of which are correct. No queue drain is required on upgrade.
+
+## Data Model
+
+No Postgres schema change. `repo_state` is untouched unless Open
+Question 2 resolves to (a), which writes terminal failures to
+`last_check_status` using the existing `StatusError` value.
+
+Valkey gains one key (`queue:delayed`). Existing keys are unchanged in
+type and semantics.
+
+## Observability
+
+New metrics:
+
+| Metric | Type | Labels | Answers |
+|---|---|---|---|
+| `queue_delayed_total` | Counter | `reason`, `installation_id` | how often is work deferred, and why |
+| `queue_delayed_depth` | Gauge | — | how much work is parked right now |
+| `queue_delay_seconds` | Histogram | `reason` | how long are the deferrals |
+| `queue_attempts_exhausted_total` | Counter | `installation_id` | is anything being dropped |
+
+Together these answer the question the BudgetTracker was built for — "are
+we hitting API limits, how hard, and for whom" — from measurement rather
+than from a modelled estimate.
+
+Removed: the nine `api_budget_*` / `enqueue_gated_by_budget_total`
+metrics and the `RepoGuardianBudgetGated` alert, none of which has ever
+emitted a sample in production.
+
+Retained: `github_rate_remaining`, `github_rate_limit_waits_total`,
+`github_rate_limit_wait_seconds` and their three alerts. These are
+layer 1's accounting and stay meaningful — Phase 3 task 3.3 keeps them
+fed at the point the sleep is replaced.
+
+Two new starter alerts:
+
+- `RepoGuardianQueueBackpressure` — `queue_delayed_depth` sustained above
+  a threshold: deferrals accumulating faster than they drain.
+- `RepoGuardianJobsExhausted` — any increase in
+  `queue_attempts_exhausted_total`: work is being dropped.
+
+Per INV-0012 findings C and E, both must be authored with a lookback
+window that outlives `for` and is compatible with the metric's real
+emission cadence.
+
+## Implementation Phases
+
+Each phase is independently mergeable. Phase 0 ships alone and
+immediately; phases 1–5 are the build; phase 6 removes what they replace;
+phase 7 is documentation. Run `make lint` and `make fmt` after each task;
+commit per numbered task.
+
+### Phase 0: Stop the bleeding
+
+The amplification hazard is live today and must not wait for the
+redesign. This is a hotfix, mergeable on its own, and deliberately *not*
+the real fix.
+
+#### Tasks
+
+- [ ] 0.1 Cap the transport's pre-emptive delay safely below
+      `JOB_ACK_TIMEOUT` (proposed `min(computed, 60s)`), so a sleeping
+      worker can never outlive its lease.
+- [ ] 0.2 When the computed delay exceeds the cap, return an error
+      instead of sleeping the remainder — the job nacks and the reaper
+      retries it. Crude but correct until Phase 4.
+- [ ] 0.3 Test: a computed delay above the cap does not sleep past it.
+- [ ] 0.4 Test reproducing the INV-0012 finding I timeline against a fake
+      clock — a handler outliving `JOB_ACK_TIMEOUT` is claimed twice —
+      and assert the cap prevents it.
+
+#### Success Criteria
+
+- No code path can sleep longer than `JOB_ACK_TIMEOUT` while holding an
+  in-flight claim.
+- The finding I timeline test fails without 0.1 and passes with it.
+- `make ci` passes.
+
+### Phase 1: Job contract
+
+#### Tasks
+
+- [ ] 1.1 Add `Attempts int` and `AvailableAt time.Time` to `queue.Job`.
+- [ ] 1.2 Add `queue.RetryAfterError` with `After`, `Reason`, `Err`, and
+      an `Unwrap`.
+- [ ] 1.3 Rewrite the `queue.Queue` doc comment to specify all three
+      handler outcomes, attempt counting, and the terminal disposition.
+      Delete the stale in-memory-implementation parenthetical.
+- [ ] 1.4 Add `EnqueueAfter` to the `Queue` interface and implement it in
+      the Valkey backend (Phase 2 supplies the mechanism; a stub is
+      acceptable at this task boundary only if 1.5 lands in the same PR).
+- [ ] 1.5 Regenerate mocks (`make mocks`) and fix fallout in the
+      test-local `recordingQueue` fakes.
+- [ ] 1.6 Test: a `Job` JSON-encoded by the previous version decodes with
+      `Attempts=0` and zero `AvailableAt` (upgrade compatibility).
+
+#### Success Criteria
+
+- The interface documents delay, backoff, attempt cap, and terminal
+  disposition — the contract INV-0012 finding K found missing.
+- Old-format job payloads decode correctly; no queue drain on upgrade.
+- `make ci` passes.
+
+### Phase 2: Delayed set and promotion
+
+#### Tasks
+
+- [ ] 2.1 Add `DelayedKey` to `valkey.Options`, defaulting to
+      `repo-guardian:queue:delayed`.
+- [ ] 2.2 Implement `deferScript` (ZREM in-flight + ZADD delayed, atomic)
+      and wire it to `EnqueueAfter`.
+- [ ] 2.3 Implement `promoteScript` (ZRANGEBYSCORE due + ZREM + LPUSH,
+      atomic) and call it from `reapOnce` under the existing leader lock.
+- [ ] 2.4 Publish `queue_delayed_depth` from the reaper tick (`ZCARD`).
+- [ ] 2.5 Integration test (`integration` tag): a job deferred 2s is not
+      delivered before its due-time and is delivered after.
+- [ ] 2.6 Integration test: a job is in exactly one of `jobs`,
+      `in-flight`, `delayed` at every point in its lifecycle.
+- [ ] 2.7 Integration test: promotion is leader-gated — two reapers, one
+      promotion.
+
+#### Success Criteria
+
+- A deferred job is never delivered before `available_at`.
+- No job is ever simultaneously present in two of the three keys.
+- Promotion happens exactly once per job with multiple replicas running.
+- `make ci` passes; integration tests pass against a real Valkey.
+
+### Phase 3: Throttle signal path
+
+#### Tasks
+
+- [ ] 3.1 Add `github.ThrottledError` carrying `ResetAt`, `Remaining`,
+      `Limit`.
+- [ ] 3.2 Replace the transport's pre-emptive `sleepWithContext` with a
+      `ThrottledError` return. Leave the 403 primary/secondary retry
+      paths untouched.
+- [ ] 3.3 Preserve `github_rate_limit_waits_total` and
+      `github_rate_limit_wait_seconds` by recording the *would-be* delay
+      at the point of the return, so the three existing rate-limit alerts
+      keep receiving samples.
+- [ ] 3.4 **Prove the error survives the full chain**: drive a real
+      `Engine.CheckRepo` against an `httptest` server returning
+      rate-limit headers and assert `errors.As` recovers
+      `*ThrottledError` at the worker boundary. Most likely task to
+      surface a missing `%w`.
+- [ ] 3.5 Audit the client and engine error paths for non-`%w`
+      `fmt.Errorf`; fix whatever 3.4 exposes.
+
+#### Success Criteria
+
+- The transport never sleeps pre-emptively.
+- `errors.As` recovers `*ThrottledError` from a fully-wrapped `CheckRepo`
+  error, proven by test rather than assumed.
+- The three existing rate-limit alerts still receive samples.
+- `make ci` passes.
+
+### Phase 4: Worker requeue and attempt cap
+
+#### Tasks
+
+- [ ] 4.1 `processJob` translates `*github.ThrottledError` into
+      `*queue.RetryAfterError` with the jittered due-time.
+- [ ] 4.2 The Valkey `Subscribe` loop handles `*RetryAfterError` via the
+      defer path rather than the ack or nack paths.
+- [ ] 4.3 Increment `Attempts` on defer and on reaper requeue.
+- [ ] 4.4 Add `MAX_JOB_ATTEMPTS` config (proposed default 10) with the
+      terminal disposition from Open Question 2.
+- [ ] 4.5 Exponential backoff with jitter for deferrals lacking a
+      server-supplied time.
+- [ ] 4.6 Test: a throttled job is deferred, not nacked — in-flight is
+      empty, delayed has one entry.
+- [ ] 4.7 Test: the worker slot is released immediately on deferral (a
+      second job is processed while the first is parked).
+- [ ] 4.8 Test: attempts accumulate across defers and the cap triggers
+      the terminal disposition exactly once.
+
+#### Success Criteria
+
+- A throttled job never occupies a worker slot while waiting.
+- Attempts are counted across both the defer and reaper-requeue paths.
+- A job cannot retry forever.
+- `make ci` passes.
+
+### Phase 5: Observability
+
+#### Tasks
+
+- [ ] 5.1 Add `queue_delayed_total{reason, installation_id}`,
+      `queue_delay_seconds{reason}`, and
+      `queue_attempts_exhausted_total{installation_id}`
+      (`queue_delayed_depth` lands in 2.4).
+- [ ] 5.2 Add `RepoGuardianQueueBackpressure` and
+      `RepoGuardianJobsExhausted` to the chart's `prometheusrule.yaml`
+      **and** `contrib/prometheus/alerts.yaml` (INV-0012 finding F: the
+      two packs are near-duplicates with no drift gate).
+- [ ] 5.3 Verify both alerts against INV-0012 finding C — window outlives
+      `for`, and the window suits the metric's real emission cadence.
+- [ ] 5.4 helm-unittest assertions on the rendered expressions, not just
+      the alert names (the IMPL-0021 A7 convention).
+- [ ] 5.5 Document the new metrics in `docs/operations/scaling.md`,
+      including what healthy vs. backpressured looks like.
+
+#### Success Criteria
+
+- An operator can answer "are we hitting API limits, how hard, for whom"
+  from metrics alone.
+- Both new alerts are fireable under realistic emission cadence, reasoned
+  explicitly in the PR rather than assumed.
+- `make ci` and helm-unittest pass.
+
+### Phase 6: Remove the superseded layers
+
+Only after phases 1–5 are merged and the new path has been observed
+working — see the rollout plan.
+
+#### Tasks
+
+- [ ] 6.1 Delete `internal/budget` (223 LOC + 242 test LOC + `labels.go`).
+- [ ] 6.2 Remove `Budget` from `StaleSweeperOptions` and
+      `DiscovererOptions`, and both `budgetAllows` gates.
+- [ ] 6.3 Remove the nine `api_budget_*` /
+      `enqueue_gated_by_budget_total` metrics and
+      `RepoGuardianBudgetGated` from both alert files.
+- [ ] 6.4 Remove `DISCOVERY_RESERVE_FRACTION` and
+      `DISCOVERY_ESTIMATED_COST_PER_REPO` from config, their validation,
+      and their tests.
+- [ ] 6.5 Remove `discovery.reserveFraction` and
+      `discovery.estimatedCostPerRepo` from `values.yaml`,
+      `values.schema.json`, and `tests/deployment_env_test.yaml`.
+- [ ] 6.6 Resolve Open Question 4 for the layer-2 sweep gate; remove or
+      annotate accordingly.
+- [ ] 6.7 `make ci` and a `deadcode` pass clean after removal.
+- [ ] 6.8 Mark [DESIGN-0002](0002-github-api-rate-limit-handling.md)
+      Superseded by this document, and update the CLAUDE.md architecture
+      notes describing the BudgetTracker.
+
+#### Success Criteria
+
+- Exactly one rate-limit mechanism remains in the codebase.
+- No dangling config, chart value, schema entry, metric, or alert
+  referencing the removed layers.
+- `make ci` passes; `helm template` renders without the removed values.
+
+### Phase 7: Docs and chart
+
+#### Tasks
+
+- [ ] 7.1 Chart version + appVersion bump; `make helm-docs` (edit
+      `README.md.gotmpl`, never the rendered README).
+- [ ] 7.2 New `MAX_JOB_ATTEMPTS` chart value with `values.schema.json`
+      validation.
+- [ ] 7.3 Operator runbook: what a deferred job looks like, how to read
+      the new metrics, what to do when backpressure alerts fire.
+- [ ] 7.4 Update `docs/operations/scaling.md` and
+      `docs/operations/migrations.md` for the removed knobs.
+- [ ] 7.5 CLAUDE.md: record the delayed-requeue contract and the
+      one-mechanism rule, so a future change does not reintroduce
+      in-handler blocking.
+- [ ] 7.6 Flip INV-0012 to Concluded and this doc to Implemented; run
+      `docz update design inv`.
+
+#### Success Criteria
+
+- Chart renders and installs with the new values.
+- mkdocs holds at its 14-warning baseline.
+- Every removed knob has a documented upgrade path.
+
+## Testing Strategy
+
+- **Unit** — contract translation (`ThrottledError` → `RetryAfterError`),
+  backoff and jitter bounds, attempt accounting. Table-driven.
+- **Integration (`integration` build tag, real Valkey)** — due-time
+  honouring, the exactly-one-key invariant, leader-gated promotion. This
+  is where the Lua atomicity claims are actually tested; unit tests
+  against a fake cannot establish them. Follows the existing convention
+  in `internal/queue/valkey/valkey_integration_test.go`.
+- **Regression** — the INV-0012 finding I timeline (task 0.4) is the
+  canonical test for this whole design and should survive every later
+  phase.
+- **Non-vacuity** — per standing practice, each behavioural test is
+  verified by neutralising its fix and confirming the test fails. Task
+  3.4 especially: an `errors.As` assertion passes trivially if the test
+  constructs the error directly instead of driving it through the real
+  wrap chain.
+- **Mock fidelity** — promotion-then-delivery is a list-then-act path.
+  Per CLAUDE.md, any fake used here must reflect prior writes, or the
+  "not delivered before due-time" assertion is vacuous.
+
+## Migration / Rollout Plan
+
+1. **Phase 0 ships first, alone**, as a patch. It defuses the live hazard
+   and is safe to deploy immediately.
+2. **Phases 1–5 ship as a minor.** New behaviour, no removals — the inert
+   budget gates and the new delayed path coexist harmlessly.
+3. **Soak.** Observe `queue_delayed_total` and `queue_delayed_depth` in
+   the homelab across at least one full reconcile cycle. At current scale
+   deferrals may never trigger naturally; forcing one with a deliberately
+   low `RATE_LIMIT_THRESHOLD` is the practical check.
+4. **Phase 6 ships separately** (Open Question 7 covers major vs. minor),
+   since it removes published chart values.
+5. **No queue drain required** at any step — old payloads decode with
+   zero-valued new fields (task 1.6).
+
+Rollback: phases 1–5 are additive, so reverting the binary suffices.
+After phase 6, rollback also requires restoring chart values, which is
+why it ships on its own.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| The typed error does not survive the wrap chain | medium | Task 3.4 proves it end to end before Phase 4 depends on it |
+| Promotion granularity (60s) too coarse | low | Open Question 3; reconcile work is measured in hours |
+| A job defers forever without progressing | low | Attempt cap (4.4) plus `queue_attempts_exhausted_total` |
+| Partial work repeated after deferral | certain, low impact | The engine is idempotent by design (INV-0003); wasted calls are bounded |
+| Removing layer 2 leaves an enqueue-side gap | low | Open Question 4 offers keeping it; deferral covers the same ground downstream |
+| Reaper becomes a bottleneck doing both jobs | low | Both operations are single Lua scripts; measure before splitting |
+| Deferrals never occur at current scale, so the path is under-exercised in production | high | Rollout step 3 forces one deliberately; integration tests cover the mechanics |
+
+## Open Questions
+
+1. **Phase 0 hotfix shape.**
+   (a) Cap the transport's pre-emptive delay at `min(computed, 60s)` and
+   return an error beyond it — smallest change, lives entirely in the
+   layer that already computes the delay, and Phase 3 supersedes it
+   cleanly.
+   (b) Wrap each job in `context.WithTimeout(JOB_ACK_TIMEOUT)` at the
+   worker — catches *any* long handler, not just throttle sleeps, but
+   changes cancellation semantics for every job and risks aborting
+   legitimate slow work mid-PR-creation.
+   (c) Both.
+   other:
+
+2. **Terminal disposition at the attempt cap.**
+   (a) Write terminal failure to `repo_state.last_check_status` and drop
+   the job — reuses the store as the dead-letter record, keeps Valkey
+   free of graveyard keys, and the next sweep re-enqueues naturally if
+   the repo is still stale, which is the self-healing behaviour we
+   already rely on.
+   (b) Move to a `queue:dead` ZSET for manual inspection — better
+   forensics, but a new key nothing prunes, duplicating state the store
+   already holds.
+   (c) Drop with a counter only — cheapest, no forensics.
+   other:
+
+3. **Promotion cadence.**
+   (a) Reuse `REAPER_INTERVAL` (60s) — no new knob, no new goroutine, and
+   60s granularity is irrelevant for work scheduled in hours.
+   (b) A separate `PROMOTION_INTERVAL` — finer control, one more knob to
+   document and validate.
+   (c) Promote opportunistically on every `Subscribe` poll as well as on
+   the reaper tick — lowest latency, but every worker then does ZSET
+   scans and the leader-election guarantee is lost.
+   other:
+
+4. **Layer 2, the sweep reserve gate.**
+   (a) Remove it in Phase 6 — deferral covers the same ground and does
+   not silently drop the repo until the next sweep, so the gate is
+   redundant once Phase 4 lands.
+   (b) Keep it as cheap enqueue-side admission control — one API call per
+   installation per sweep to avoid enqueueing work that will immediately
+   defer; costs a call, saves queue churn.
+   (c) Decide after observing `queue_delayed_total` in production.
+   other:
+
+5. **In-flight member identity (INV-0012 finding J).**
+   (a) Leave it — once nothing sleeps in-handler the overlap window
+   closes on its own, and the residual case (two genuinely concurrent
+   claims of the same repo) is harmless because reconcile is idempotent.
+   (b) Add a claim nonce to the ZSET member so concurrent claims are
+   distinct — correct, but changes the member format and therefore the
+   reaper's requeue payload, and needs an upgrade story.
+   (c) Deduplicate at claim time by refusing to claim a repo already
+   in-flight — strongest, but adds a read to the hot path.
+   other:
+
+6. **Shape of the `Queue` interface change.**
+   (a) Add `EnqueueAfter` as a fourth method — explicit at the call site,
+   and the mock regenerates cleanly.
+   (b) Overload `Enqueue` to honour a non-zero `Job.AvailableAt` — no
+   interface change at all, but makes the delay invisible at the call
+   site and easy to set by accident.
+   (c) Return the due-time from the handler and let `Subscribe` own
+   scheduling entirely — smallest producer surface, but couples deferral
+   to the subscribe path so nothing else can ever defer.
+   other:
+
+7. **Phase 6 release shape.**
+   (a) Minor with a prominent upgrade note — the removed knobs were
+   provably inert, so no operator's actual behaviour changes; a major for
+   a no-op removal overstates the impact.
+   (b) Major — it removes published chart values and a documented
+   feature, which is what major is for.
+   (c) Keep the knobs as accepted-but-ignored no-ops for one release,
+   warn on use, then remove.
+   other:
+
+8. **Does Phase 0 ship before the rest of this design is approved?**
+   (a) Yes — it is an independent hotfix for a live hazard and should not
+   wait on decisions about the redesign.
+   (b) No — bundle it with Phase 1 so there is one review of the whole
+   change in the rate-limit path.
+   other:
+
+## References
+
+- [INV-0012](../investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md)
+  — findings A–K; this design implements its recommendation
+- [DESIGN-0002](0002-github-api-rate-limit-handling.md) — layer 1, the
+  pre-emptive throttle being superseded (Phase 6 task 6.8)
+- [DESIGN-0012](0012-persistent-reconcile-state-and-multi-replica-coordination.md)
+  — the Store/Queue/Scheduler interfaces this extends
+- [DESIGN-0017](0017-stale-sweep-cutover-and-repository-discovery.md)
+  — Layer 1/Layer 2 budget design whose BudgetTracker is removed here
+- [DESIGN-0015](0015-per-installation-valkey-queue-partitioning.md)
+  — adjacent queue work; fairness is explicitly out of scope here
+- [IMPL-0011](../impl/0011-persistent-reconcile-state-and-multi-replica-coordination.md)
+  — introduced the queue, lease, and reaper
+- [IMPL-0015](../impl/0015-stale-sweep-cutover-and-repository-discovery.md)
+  — introduced the BudgetTracker being removed
+- [INV-0003](../investigation/0003-pre-existing-branch-422-on-subsequent-reconciles.md)
+  — the engine idempotency this design relies on for safe re-runs

--- a/docs/design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md
+++ b/docs/design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md
@@ -463,16 +463,17 @@ emission cadence.
 
 ## Implementation Phases
 
-Each phase is independently mergeable. Phase 0 ships alone and
-immediately; phases 1–5 are the build; phase 6 removes what they replace;
-phase 7 is documentation. Run `make lint` and `make fmt` after each task;
-commit per numbered task.
+Each phase is independently mergeable. Phase 0 is bundled with Phase 1
+for review (OQ8 → b); phases 1–5 are the build; phase 6 removes what
+they replace; phase 7 is documentation. Run `make lint` and `make fmt`
+after each task; commit per numbered task.
 
 ### Phase 0: Stop the bleeding
 
-The amplification hazard is live today and must not wait for the
-redesign. This is a hotfix, mergeable on its own, and deliberately *not*
-the real fix.
+The amplification hazard is live today. Per OQ8 → (b) this lands
+bundled with Phase 1 so one review covers the whole rate-limit-path
+change — but it remains deliberately *not* the real fix; Phase 3
+supersedes it.
 
 #### Tasks
 
@@ -666,8 +667,13 @@ working — see the rollout plan.
 - [ ] 6.5 Remove `discovery.reserveFraction` and
       `discovery.estimatedCostPerRepo` from `values.yaml`,
       `values.schema.json`, and `tests/deployment_env_test.yaml`.
-- [ ] 6.6 Resolve Open Question 4 for the layer-2 sweep gate; remove or
-      annotate accordingly.
+- [ ] 6.6 Remove the layer-2 sweep reserve gate (`allowedByRateLimit`)
+      and `rate_limit_reserve_blocked_total` (OQ4 → a), preserving a
+      producer for `rate_limit_remaining{installation_id}`: keep the
+      per-installation sampling call in the sweep loop with no gating
+      decision, or retire the gauge together with
+      `RepoGuardianRateLimitNearExhaustion` — never leave the alert
+      consuming an unfed gauge (the INV-0012 A7 class).
 - [ ] 6.7 `make ci` and a `deadcode` pass clean after removal.
 - [ ] 6.8 Mark [DESIGN-0002](0002-github-api-rate-limit-handling.md)
       Superseded by this document, and update the CLAUDE.md architecture
@@ -691,7 +697,9 @@ working — see the rollout plan.
 - [ ] 7.3 Operator runbook: what a deferred job looks like, how to read
       the new metrics, what to do when backpressure alerts fire.
 - [ ] 7.4 Update `docs/operations/scaling.md` and
-      `docs/operations/migrations.md` for the removed knobs.
+      `docs/operations/migrations.md` for the removed knobs, and
+      document `REAPER_INTERVAL`'s dual duty — lease reaping *and*
+      delayed-set promotion cadence (OQ3 → a).
 - [ ] 7.5 CLAUDE.md: record the delayed-requeue contract and the
       one-mechanism rule, so a future change does not reintroduce
       in-handler blocking.
@@ -727,8 +735,9 @@ working — see the rollout plan.
 
 ## Migration / Rollout Plan
 
-1. **Phase 0 ships first, alone**, as a patch. It defuses the live hazard
-   and is safe to deploy immediately.
+1. **Phases 0–1 land together** as the first PR of the sequence
+   (OQ8 → b: one review of the whole rate-limit path). Phase 0's cap
+   defuses the live hazard from the first release that carries it.
 2. **Phases 1–5 ship as a minor.** New behaviour, one scrape-visible
    removal: the wait pair stops receiving samples (task 3.3), and its
    only consuming alert is re-pointed in the same release (task 5.2b).
@@ -761,6 +770,7 @@ why it ships on its own.
 ## Open Questions
 
 1. **Phase 0 hotfix shape.**
+   **Resolved 2026-08-02 → (a).**
    (a) Cap the transport's pre-emptive delay at `min(computed, 60s)` and
    return an error beyond it — smallest change, lives entirely in the
    layer that already computes the delay, and Phase 3 supersedes it
@@ -792,6 +802,9 @@ why it ships on its own.
    other:
 
 3. **Promotion cadence.**
+   **Resolved 2026-08-02 → (a)**, with the rider that the knob's dual
+   duty is documented: `REAPER_INTERVAL` now controls both lease
+   reaping and delayed-set promotion cadence (task 7.4).
    (a) Reuse `REAPER_INTERVAL` (60s) — no new knob, no new goroutine, and
    60s granularity is irrelevant for work scheduled in hours.
    (b) A separate `PROMOTION_INTERVAL` — finer control, one more knob to
@@ -802,6 +815,16 @@ why it ships on its own.
    other:
 
 4. **Layer 2, the sweep reserve gate.**
+   **Resolved 2026-08-02 → (a)**, with one rider (task 6.6): the
+   gate's `RateLimitRemaining` call is the only live producer feeding
+   `rate_limit_remaining{installation_id}` — the gauge is set inside
+   `Client.RateLimitRemaining` (client.go), and the only other caller
+   is the inert BudgetTracker, also deleted in Phase 6. Removing the
+   gate must not orphan the gauge: keep the per-installation sampling
+   call in the sweep loop (observability-only, no gating decision), or
+   retire the gauge together with `RepoGuardianRateLimitNearExhaustion`
+   and the DESIGN-0022 E1 headroom panel source. Recommended: keep the
+   sampling.
    (a) Remove it in Phase 6 — deferral covers the same ground and does
    not silently drop the repo until the next sweep, so the gate is
    redundant once Phase 4 lands.
@@ -812,6 +835,7 @@ why it ships on its own.
    other:
 
 5. **In-flight member identity (INV-0012 finding J).**
+   **Resolved 2026-08-02 → (a).**
    (a) Leave it — once nothing sleeps in-handler the overlap window
    closes on its own, and the residual case (two genuinely concurrent
    claims of the same repo) is harmless because reconcile is idempotent.
@@ -823,6 +847,7 @@ why it ships on its own.
    other:
 
 6. **Shape of the `Queue` interface change.**
+   **Resolved 2026-08-02 → (a).**
    (a) Add `EnqueueAfter` as a fourth method — explicit at the call site,
    and the mock regenerates cleanly.
    (b) Overload `Enqueue` to honour a non-zero `Job.AvailableAt` — no
@@ -834,6 +859,7 @@ why it ships on its own.
    other:
 
 7. **Phase 6 release shape.**
+   **Resolved 2026-08-02 → (a).**
    (a) Minor with a prominent upgrade note — the removed knobs were
    provably inert, so no operator's actual behaviour changes; a major for
    a no-op removal overstates the impact.
@@ -844,6 +870,9 @@ why it ships on its own.
    other:
 
 8. **Does Phase 0 ship before the rest of this design is approved?**
+   **Resolved 2026-08-02 → (b)** — bundled with Phase 1, one review of
+   the whole rate-limit path (reflected in the phases intro, the
+   Phase 0 preamble, and rollout step 1).
    (a) Yes — it is an independent hotfix for a live hazard and should not
    wait on decisions about the redesign.
    (b) No — bundle it with Phase 1 so there is one review of the whole

--- a/docs/design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md
+++ b/docs/design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md
@@ -240,6 +240,15 @@ invariant with an end-to-end test instead of an audit. A test that drives
 a real throttle through the real path fails if any link breaks, whichever
 link it is; an audit only proves the state of the code on the day it ran.
 
+One adjacency to keep straight:
+[DESIGN-0022](0022-compliance-posture-state-dashboard-suite-and-otel-first.md)
+Phase 3 wraps this same installation transport with `otelhttp` client
+instrumentation. The ordering contract, specified in both documents:
+`otelhttp` outermost, this design's rate-limit transport inside it,
+`ghinstallation` innermost — so a `ThrottledError` return surfaces as
+an errored client measurement, which is exactly the residual signal
+that replaces the retired wait pair.
+
 `internal/github` must not import `internal/queue` — the client is the
 lower layer. The worker performs the translation:
 
@@ -422,10 +431,24 @@ Removed: the nine `api_budget_*` / `enqueue_gated_by_budget_total`
 metrics and the `RepoGuardianBudgetGated` alert, none of which has ever
 emitted a sample in production.
 
-Retained: `github_rate_remaining`, `github_rate_limit_waits_total`,
-`github_rate_limit_wait_seconds` and their three alerts. These are
-layer 1's accounting and stay meaningful — Phase 3 task 3.3 keeps them
-fed at the point the sleep is replaced.
+Retained: `github_rate_remaining` and its two threshold alerts
+(`RepoGuardianRateLimitLow`, `RepoGuardianRateLimitNearExhaustion`) —
+quota headroom stays layer 1's accounting.
+
+Also removed (INV-0013 Finding G amendment, 2026-08-02):
+`github_rate_limit_waits_total` and `github_rate_limit_wait_seconds`.
+Once nothing sleeps, "wait" semantics vanish, and the earlier plan to
+keep the pair fed by recording the *would-be* delay was rejected as a
+duplicate: the same deferral event would be measured by both the wait
+pair and Phase 5's `queue_delayed_total{reason}` /
+`queue_delay_seconds{reason}`, violating the one-source-per-signal
+rule. The single alert consuming the pair
+(`RepoGuardianRateLimitThrottling`, contrib pack only) is re-pointed
+at `queue_delayed_total{reason="rate_limit"}` in task 5.2b; the
+residual "slow GitHub call by status" signal arrives with
+[DESIGN-0022](0022-compliance-posture-state-dashboard-suite-and-otel-first.md)'s
+`otelhttp` client histograms. Phases 1–5 ship as one minor, so metric
+death and alert re-point land in the same release — no coverage gap.
 
 Two new starter alerts:
 
@@ -534,10 +557,10 @@ the real fix.
 - [ ] 3.2 Replace the transport's pre-emptive `sleepWithContext` with a
       `ThrottledError` return. Leave the 403 primary/secondary retry
       paths untouched.
-- [ ] 3.3 Preserve `github_rate_limit_waits_total` and
-      `github_rate_limit_wait_seconds` by recording the *would-be* delay
-      at the point of the return, so the three existing rate-limit alerts
-      keep receiving samples.
+- [ ] 3.3 Remove the wait-pair recording along with the sleep — no
+      would-be-delay bridge. It would double-measure the deferral that
+      Phase 5's `queue_delayed_total` / `queue_delay_seconds` own (see
+      Observability). `github_rate_remaining` emission is untouched.
 - [ ] 3.4 **Pin the chain with an end-to-end test**: drive a real
       `Engine.CheckRepo` against an `httptest` server returning
       rate-limit headers and assert `errors.As` recovers
@@ -554,7 +577,9 @@ the real fix.
 - The transport never sleeps pre-emptively.
 - `errors.As` recovers `*ThrottledError` from a fully-wrapped `CheckRepo`
   error, proven by test rather than assumed.
-- The three existing rate-limit alerts still receive samples.
+- The two retained quota alerts (`RepoGuardianRateLimitLow`,
+  `RepoGuardianRateLimitNearExhaustion`) still receive samples; nothing
+  feeds the wait pair.
 - `make ci` passes.
 
 ### Phase 4: Worker requeue and attempt cap
@@ -599,6 +624,10 @@ the real fix.
       `RepoGuardianJobsExhausted` to the chart's `prometheusrule.yaml`
       **and** `contrib/prometheus/alerts.yaml` (INV-0012 finding F: the
       two packs are near-duplicates with no drift gate).
+- [ ] 5.2b Re-point `RepoGuardianRateLimitThrottling` (contrib pack
+      only) from the removed `github_rate_limit_waits_total` to
+      `queue_delayed_total{reason="rate_limit"}`, under the same
+      window/`for` discipline as 5.3.
 - [ ] 5.3 Verify both alerts against INV-0012 finding C — window outlives
       `for`, and the window suits the metric's real emission cadence.
 - [ ] 5.4 helm-unittest assertions on the rendered expressions, not just
@@ -626,7 +655,11 @@ working — see the rollout plan.
       `DiscovererOptions`, and both `budgetAllows` gates.
 - [ ] 6.3 Remove the nine `api_budget_*` /
       `enqueue_gated_by_budget_total` metrics and
-      `RepoGuardianBudgetGated` from both alert files.
+      `RepoGuardianBudgetGated` from both alert files, plus the
+      now-unfed `github_rate_limit_waits_total` /
+      `github_rate_limit_wait_seconds` definitions from
+      `internal/metrics` (emission stopped in task 3.3; the sole
+      consuming alert was re-pointed in 5.2b).
 - [ ] 6.4 Remove `DISCOVERY_RESERVE_FRACTION` and
       `DISCOVERY_ESTIMATED_COST_PER_REPO` from config, their validation,
       and their tests.
@@ -696,8 +729,10 @@ working — see the rollout plan.
 
 1. **Phase 0 ships first, alone**, as a patch. It defuses the live hazard
    and is safe to deploy immediately.
-2. **Phases 1–5 ship as a minor.** New behaviour, no removals — the inert
-   budget gates and the new delayed path coexist harmlessly.
+2. **Phases 1–5 ship as a minor.** New behaviour, one scrape-visible
+   removal: the wait pair stops receiving samples (task 3.3), and its
+   only consuming alert is re-pointed in the same release (task 5.2b).
+   The inert budget gates and the new delayed path coexist harmlessly.
 3. **Soak.** Observe `queue_delayed_total` and `queue_delayed_depth` in
    the homelab across at least one full reconcile cycle. At current scale
    deferrals may never trigger naturally; forcing one with a deliberately
@@ -738,6 +773,13 @@ why it ships on its own.
    other:
 
 2. **Terminal disposition at the attempt cap.**
+   **Resolved 2026-08-02 → (a)**, on live evidence: during the
+   enterprise-app cutover, jobs for a deleted installation nack-looped
+   indefinitely and had to be cleared by hand (Valkey flush +
+   `repo_state` row deletion, `docs/operations/ent-setup.md`).
+   Disposition (a) makes exactly that incident self-healing — the
+   attempt cap fires, the failure is written to the store, and the job
+   drops.
    (a) Write terminal failure to `repo_state.last_check_status` and drop
    the job — reuses the store as the dead-letter record, keeps Valkey
    free of graveyard keys, and the next sweep re-enqueues naturally if
@@ -812,6 +854,14 @@ why it ships on its own.
 
 - [INV-0012](../investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md)
   — findings A–K; this design implements its recommendation
+- [INV-0013](../investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md)
+  — Finding G's one-source-per-signal rule drives the wait-pair
+  retirement (tasks 3.3 / 5.2b / 6.3); Finding I slots this design's
+  queue metrics into the service tier
+- [DESIGN-0022](0022-compliance-posture-state-dashboard-suite-and-otel-first.md)
+  — shared installation-transport ordering contract (its Phase 3, this
+  design's task 3.3 note); consumes the Phase 5 metrics on its E3
+  system dashboard
 - [DESIGN-0002](0002-github-api-rate-limit-handling.md) — layer 1, the
   pre-emptive throttle being superseded (Phase 6 task 6.8)
 - [DESIGN-0012](0012-persistent-reconcile-state-and-multi-replica-coordination.md)

--- a/docs/design/0022-compliance-posture-state-dashboard-suite-and-otel-first.md
+++ b/docs/design/0022-compliance-posture-state-dashboard-suite-and-otel-first.md
@@ -213,7 +213,9 @@ propagated**. A `rule_state` write failure logs Warn, counts
 the queue job remains the source of truth for "did we do the work"
 (IMPL-0015 Phase 0 contract). The upsert is one batched statement per
 job, executed in a single transaction that also reconciles rows for
-rules no longer in the evaluated set (Open Question 3).
+rules no longer in the evaluated set (OQ3 → a: delete-not-in within
+the same transaction; a background GC pass is the documented fallback
+if post-policy-change convergence proves too slow).
 
 Posture is then one indexed query:
 
@@ -242,7 +244,7 @@ that disappears from the fleet stops emitting stale series instead of
 freezing at its last value. Non-leader replicas never serve the
 series; dashboards aggregate with `max by (...)`, exactly as
 `scheduler_is_leader` panels already do. Compliance ratio is computed
-in PromQL from the two gauges (Open Question 2).
+in PromQL from the two gauges (OQ2 → a).
 
 The GitHub-owned posture reading from Finding B — org schema gaps —
 gets its projection at the source that already knows: the
@@ -325,7 +327,7 @@ renders one report per org — compliance percentage per rule, trend
 versus the previous snapshot, and the table a metric can never hold:
 *which* repos, failing *which* rules, since *when*. Open-PR links are
 fetched live from GitHub at generation time (low volume, installation
-client). Output shape is Open Question 6.
+client). Output is markdown per org written to `--out` (OQ6 → a).
 
 ### Config-generated monitoring (Finding H, shape H1)
 
@@ -358,13 +360,13 @@ Grafana schema versions is handled by pinning and a render test
 (Grafana ≥ 10 required; acceptable — the homelab runs
 kube-prometheus-stack).
 
-Format `k8s` wraps the dashboard JSON for in-cluster consumption
-(Open Question 7 picks ConfigMap-sidecar vs grafana-operator CRs) and
-emits the PrometheusRule as a CR. Format `json` emits plain files for
+Format `k8s` emits grafana-operator `GrafanaDashboard` CRs (OQ7 → b —
+the cluster's kube-prometheus-stack deployment runs grafana-operator)
+plus the PrometheusRule CR. Format `json` emits plain files for
 manual import.
 
-Where the generator lives (main binary vs a separate `cmd/`) is Open
-Question 5.
+The generator and report live as subcommands on the main binary
+(OQ5 → a, with a size-delta check before merge).
 
 ### Dashboard suite (Finding E)
 
@@ -444,7 +446,7 @@ with no new knobs; the standard `OTEL_SDK_DISABLED=true` escape hatch
 is honoured.
 
 New CLI surface: `repo-guardian monitoring generate` and
-`repo-guardian report` subcommands (placement per Open Question 5).
+`repo-guardian report` subcommands on the main binary (OQ5 → a).
 
 Mock/fake fallout: `make mocks` regenerates the Store mock; the
 test-local `recordingQueue` / `fakeStore` recorders and the
@@ -522,7 +524,7 @@ New metrics (all on the existing `/metrics` endpoint):
 | `repo_guardian_posture_export_duration_seconds` | Histogram | — | exporter query cost |
 | semconv HTTP server/client, redis, pgx series | (bridge) | per semconv | Finding F's USE/RED gaps |
 
-Removed (Phase 7, per Open Question 4): the four legacy unlabeled
+Removed (Phase 7, OQ4 → a): the four legacy unlabeled
 `properties_*` counters, superseded by real posture.
 
 One new starter alert: `RepoGuardianPostureExportStalled` — no
@@ -550,9 +552,8 @@ numbered task.
       rules (BP gains an actionable verdict — its first posture
       signal) and the catalog-parse fact.
 - [ ] 1.3 `Store.UpsertRuleStates`: single-transaction batched upsert
-      with the `actionable_since` transition CASE, plus reconciliation
-      of rows absent from the evaluated set (per Open Question 3
-      resolution).
+      with the `actionable_since` transition CASE, plus delete-not-in
+      reconciliation of rows absent from the evaluated set (OQ3 → a).
 - [ ] 1.4 Worker write-back: persist the `CheckResult` in the existing
       `writeBack` path — best-effort, `store_writeback_total` outcome
       accounting, never propagated.
@@ -725,9 +726,8 @@ numbered task.
 
 #### Tasks
 
-- [ ] 7.1 Remove the four legacy `properties_*` counters (per Open
-      Question 4 resolution) with migration notes in
-      `contrib/README.md`.
+- [ ] 7.1 Remove the four legacy `properties_*` counters (OQ4 → a)
+      with migration notes in `contrib/README.md`.
 - [ ] 7.2 `docs/operations/scaling.md`: posture architecture, exporter
       leader semantics, OTEL series catalog, dedup rule.
 - [ ] 7.3 Chart: version + appVersion bump, new values documented via
@@ -808,6 +808,7 @@ numbered task.
 ## Open Questions
 
 1. **Posture storage shape.**
+   **Resolved 2026-08-02 → (a).**
    (a) C1 — the `rule_state` per-rule table as specified. The report
    requirement (repo identity + missing-since) already settled this
    in INV-0013 Finding C; JSONB cannot express `actionable_since`
@@ -821,6 +822,7 @@ numbered task.
    other:
 
 2. **Compliance ratio computation.**
+   **Resolved 2026-08-02 → (a).**
    (a) Export the two raw gauges (`repos_actionable`,
    `repos_tracked`) and compute the ratio in PromQL
    (`1 - actionable/tracked`) — raw series compose into any panel,
@@ -835,6 +837,9 @@ numbered task.
    other:
 
 3. **`rule_state` reconciliation when rules leave the policy.**
+   **Resolved 2026-08-02 → (a)**, with (b) — the background GC pass —
+   as the documented fallback if convergence after a policy change
+   proves too slow in practice.
    (a) Reconcile in the write-back transaction: after the batched
    upsert, delete this repo's rows whose `rule_name` is not in the
    evaluated set. Exact, incremental, no background job, and the
@@ -848,6 +853,7 @@ numbered task.
    other:
 
 4. **Legacy `properties_*` counters (4 unlabeled Counters).**
+   **Resolved 2026-08-02 → (a).**
    (a) Remove in Phase 7, same minor that completes the suite —
    they are posture-shaped (Finding B), unlabeled (pre-IMPL-0009),
    and fully superseded by `repos_actionable` + the property-sync
@@ -861,6 +867,8 @@ numbered task.
    other:
 
 5. **Generator and report binary placement.**
+   **Resolved 2026-08-02 → (a)** — the size-delta check before merge
+   stands; fall back to (b) only if the delta is egregious.
    (a) Subcommands on the main `repo-guardian` binary — one artifact,
    one version, the policy loader is already linked, and operators
    run it from the same image in CI. Measure the foundation-sdk size
@@ -872,6 +880,7 @@ numbered task.
    other:
 
 6. **Report output shape.**
+   **Resolved 2026-08-02 → (a).**
    (a) Markdown files per org written to `--out` — simplest, renders
    everywhere (GitHub, Slack paste, Backstage TechDocs), delivery
    stays a human/automation choice outside the binary.
@@ -884,6 +893,9 @@ numbered task.
    other:
 
 7. **`--format k8s` dashboard artifact shape.**
+   **Resolved 2026-08-02 → (b)** — the cluster's kube-prometheus-stack
+   deployment runs grafana-operator, so `GrafanaDashboard` CRs cover
+   both consumption paths.
    (a) ConfigMaps with the `grafana_dashboard: "1"` sidecar label —
    the kube-prometheus-stack convention already running in the
    homelab; no new operator, kustomize-native.
@@ -918,5 +930,7 @@ numbered task.
   <https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp>
 - `redisotel`: <https://github.com/redis/go-redis/tree/master/extra/redisotel>
 - `otelpgx`: <https://github.com/exaring/otelpgx>
+- grafana-operator (`GrafanaDashboard` CRs, OQ7 → b):
+  <https://github.com/grafana/grafana-operator>
 - kube-prometheus-stack dashboard sidecar convention:
   <https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack>

--- a/docs/design/0022-compliance-posture-state-dashboard-suite-and-otel-first.md
+++ b/docs/design/0022-compliance-posture-state-dashboard-suite-and-otel-first.md
@@ -356,9 +356,9 @@ dashboard JSON anywhere**. The static `contrib/` tier is the
 generator's output for a default (empty-scope) config, regenerated in
 CI with a fail-on-diff gate — the same drift convention `helm-docs`
 and `docz update` already use in this repo. The SDK's coupling to
-Grafana schema versions is handled by pinning and a render test
-(Grafana ≥ 10 required; acceptable — the homelab runs
-kube-prometheus-stack).
+Grafana schema versions is handled by pinning and a render test —
+Grafana ≥ 13 is the supported floor for the generated suite
+(IMPL-0023 OQ3, resolved 2026-08-02).
 
 Format `k8s` emits grafana-operator `GrafanaDashboard` CRs (OQ7 → b —
 the cluster's kube-prometheus-stack deployment runs grafana-operator)

--- a/docs/design/0022-compliance-posture-state-dashboard-suite-and-otel-first.md
+++ b/docs/design/0022-compliance-posture-state-dashboard-suite-and-otel-first.md
@@ -1,0 +1,922 @@
+---
+id: DESIGN-0022
+title: "Compliance posture state, dashboard suite, and OTEL-first observability"
+status: Draft
+author: Donald Gifford
+created: 2026-08-02
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# DESIGN 0022: Compliance posture state, dashboard suite, and OTEL-first observability
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-08-02
+
+<!--toc:start-->
+- [Overview](#overview)
+- [Goals and Non-Goals](#goals-and-non-goals)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Background](#background)
+- [Detailed Design](#detailed-design)
+  - [Per-rule posture state (Finding C, shape C1)](#per-rule-posture-state-finding-c-shape-c1)
+  - [Leader-scoped posture exporter (Finding D, shape D1)](#leader-scoped-posture-exporter-finding-d-shape-d1)
+  - [The org↔installation join metric (Finding E2)](#the-orginstallation-join-metric-finding-e2)
+  - [OTEL metrics-first instrumentation (Finding G)](#otel-metrics-first-instrumentation-finding-g)
+  - [Compliance snapshots and the per-org report (Finding C rider)](#compliance-snapshots-and-the-per-org-report-finding-c-rider)
+  - [Config-generated monitoring (Finding H, shape H1)](#config-generated-monitoring-finding-h-shape-h1)
+  - [Dashboard suite (Finding E)](#dashboard-suite-finding-e)
+- [API / Interface Changes](#api--interface-changes)
+- [Data Model](#data-model)
+- [Observability](#observability)
+- [Implementation Phases](#implementation-phases)
+  - [Phase 1: Per-rule posture state](#phase-1-per-rule-posture-state)
+    - [Tasks](#tasks)
+    - [Success Criteria](#success-criteria)
+  - [Phase 2: Leader-scoped posture exporter and join metrics](#phase-2-leader-scoped-posture-exporter-and-join-metrics)
+    - [Tasks](#tasks-1)
+    - [Success Criteria](#success-criteria-1)
+  - [Phase 3: OTEL metrics-first](#phase-3-otel-metrics-first)
+    - [Tasks](#tasks-2)
+    - [Success Criteria](#success-criteria-2)
+  - [Phase 4: Compliance snapshots and the report CLI](#phase-4-compliance-snapshots-and-the-report-cli)
+    - [Tasks](#tasks-3)
+    - [Success Criteria](#success-criteria-3)
+  - [Phase 5: Monitoring generator foundation](#phase-5-monitoring-generator-foundation)
+    - [Tasks](#tasks-4)
+    - [Success Criteria](#success-criteria-4)
+  - [Phase 6: Dashboard suite content](#phase-6-dashboard-suite-content)
+    - [Tasks](#tasks-5)
+    - [Success Criteria](#success-criteria-5)
+  - [Phase 7: Cleanup, deprecations, docs, chart](#phase-7-cleanup-deprecations-docs-chart)
+    - [Tasks](#tasks-6)
+    - [Success Criteria](#success-criteria-6)
+- [Testing Strategy](#testing-strategy)
+- [Migration / Rollout Plan](#migration--rollout-plan)
+- [Risks](#risks)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Overview
+
+This design implements the full
+[INV-0013](../investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md)
+recommendation as one effort. INV-0013 proposed three follow-ups
+(posture-state persistence, a dashboard suite with a config-driven
+generator, and metrics-first OTEL adoption); they are designed together
+because they share every load-bearing surface: the posture exporter
+feeds the KPI dashboard, the Finding I taxonomy decides every panel's
+source, the generator and the report CLI load the same policy config,
+and OTEL cancels the hand-rolled collectors the system dashboard would
+otherwise need.
+
+Three things ship. **Persisted per-rule check outcomes** — the facts
+the engine computes today and throws away — in a new `rule_state`
+table, projected to Prometheus by a leader-scoped exporter so
+"how many repos are missing CODEOWNERS *right now*" finally has an
+honest answer. **OTEL instrumentation at the four transport
+boundaries** (inbound HTTP, GitHub client, Valkey, Postgres), exported
+through the existing `/metrics` endpoint via the OTel prometheus
+bridge — zero new infrastructure. **A four-dashboard suite generated
+from `guardian.hcl`** by a new `repo-guardian monitoring generate`
+subcommand, so a configured-but-silent org renders as a no-data
+panel instead of a blind spot, plus a `repo-guardian report` sibling
+that turns the same posture tables into per-org owner reports.
+
+## Goals and Non-Goals
+
+### Goals
+
+- Posture questions ("how many repos fail rule X, per org, now") are
+  answerable from a gauge and from SQL — not inferred from event
+  counters that a restart zeroes and a fixed repo never decrements.
+- Exactly one replica runs posture queries, at one cadence,
+  independent of scrape rate and replica count (the 1+N fan-out from
+  INV-0013 Finding D never materialises).
+- Compliance history survives Prometheus retention
+  (`compliance_snapshot`), and a per-org report with repo identity and
+  missing-since durations can be generated from it.
+- USE/RED coverage for the service's own hops — inbound HTTP
+  (including the currently-uncounted HMAC 401s), GitHub client,
+  Valkey, Postgres — with no collector, no Tempo, no new cluster
+  infra.
+- Dashboards and alerts are generated from the operator's actual
+  config: a row exists for every org that *should* report, panels
+  exist only for mechanisms in use, and the generator doubles as a CI
+  config check.
+- One source of truth for dashboards: the static `contrib/` tier is
+  the generator's output for a default config, not a hand-maintained
+  fork.
+
+### Non-Goals
+
+- **Tracing infrastructure.** No collector, no Tempo, no OTLP
+  exporter configuration. The instrumentation added here emits spans
+  to a no-op TracerProvider; turning them on is a later, purely
+  additive design (INV-0013 effort 3's second half, deliberately
+  decoupled).
+- **`repo` as a metric label.** Never, at any cardinality. Repo
+  identity lives in Postgres (this design) and in Loki fields
+  (Finding E4), not in Prometheus series.
+- **Changing DESIGN-0021's queue observability.** The delayed-requeue
+  metrics are complementary and land there; this design is written
+  against the post-0021 metric surface (budget series and the
+  rate-limit wait pair treated as gone).
+- **Loki as a posture source.** Rejected as primary in Finding C4 —
+  weekly sweep cadence forces 7d+ log windows. Loki-derived metrics
+  stay scoped to log-shaped event signals in E4.
+- **Real-time posture.** The exporter reflects the last completed
+  check per repo and refreshes on its own cadence; sub-minute
+  freshness is not a requirement.
+- **Grafana Enterprise reporting.** The report path is a CLI
+  rendering markdown; scheduled PDF delivery is Enterprise-licensed
+  and out of scope.
+- **Per-org report *delivery*** beyond writing files (Open
+  Question 6 picks the shape; automation of sending is follow-up).
+
+## Background
+
+INV-0013 established, verified against code:
+
+- **Eight metrics are posture masquerading as events** (Finding B).
+  `files_missing_total` and friends count check-events; a repo fixed
+  yesterday still counts in `increase(...[7d])`, a repo checked twice
+  counts twice, and a restart just makes the wrongness visible. The
+  one in-tree metric doing posture correctly is `open_prs_by_rule` —
+  a sweep-snapshot gauge.
+- **Postgres cannot serve posture today** (Finding C). The worker
+  write-back persists `{status, error, policy_version}` only;
+  `findActionableRules`' per-rule outcomes are computed, used, and
+  discarded. The downstream report requirement (repo identity +
+  missing-since durations) settles the storage shape as a per-rule
+  table (C1), not a JSONB blob (C2).
+- **The 1+N scrape fan-out dissolves with leader-scoped export**
+  (Finding D1). The Valkey scheduler's SETNX election already
+  designates one replica; a leader-gated `Schedule` handler queries
+  at its own cadence and `Set()`s gauges. No Valkey query cache
+  needed unless a second consumer appears (D3).
+- **The system-level gaps are enumerable** (Finding F) and — after
+  Finding G — mostly *cancelled* rather than built: `otelhttp` (both
+  directions), `redisotel`, and `otelpgx` replace the planned
+  hand-rolled GitHub RoundTripper histogram, webhook duration
+  middleware, and go-redis collector. The OTel prometheus bridge
+  exports through the existing endpoint, so metrics-first OTEL costs
+  zero new infra.
+- **Config-generated monitoring is an established pattern**
+  (Finding H: mixins, Sloth/Pyrra, beats `setup --dashboards`), with
+  an unusually strong fit: `label_values(...)` template variables can
+  only show orgs that have emitted data, and "configured but silent"
+  was exactly the enterprise-migration failure mode. The
+  grafana-foundation-sdk provides official, typed Go builders.
+- **Finding I's taxonomy** (business / service / infra) gives each
+  dashboard a closed source list: E1 KPI = business, E2 detailed =
+  business + service sliced by org, E3 = service + infra, E4 = Loki
+  evidence.
+
+**Relationship to DESIGN-0021.** The delayed-requeue design removes
+the seven dead budget series and (per its INV-0013-driven amendment)
+retires `github_rate_limit_waits_total` / `_wait_seconds` in favour of
+its own `queue_delayed_*` metrics. Nothing in this design references
+any of those series; the E3 dashboard consumes 0021's queue metrics as
+planned service-tier signals. The two designs share one physical
+surface — the installation transport — where 0021's throttle transport
+must sit *inside* this design's `otelhttp` client wrapper (ordering
+specified in Phase 3).
+
+## Detailed Design
+
+### Per-rule posture state (Finding C, shape C1)
+
+A new `rule_state` table records the outcome of every rule evaluation,
+written in the same worker write-back path that already persists
+`repo_state` — the actionable set is in memory at exactly that point.
+
+One row per `(installation, owner, repo, rule)`. The row carries
+`actionable` (is the rule currently failing for this repo),
+`actionable_since` (set on the false→true transition, cleared on
+true→false — this is the "missing since 2026-06-14" the report needs),
+`rule_kind` (`file` | `setting` | `branch_protection`), and
+`policy_version`. Setting rules and branch-protection rules are
+included from day one — BP currently has *no* mismatch metric at all
+(Finding B), so this closes that hole rather than porting it.
+
+The catalog-parseability fact (Finding B's `catalog_parse_failed_total`
+posture reading) is a per-repo, not per-rule, fact: a nullable
+`catalog_parse_ok` column on `repo_state` (null = no catalog rule
+evaluated / unknown), set from the reconciler outcome.
+
+Write-back semantics are unchanged in spirit: **best-effort, never
+propagated**. A `rule_state` write failure logs Warn, counts
+`store_writeback_total{outcome="error"}`, and does not fail the job —
+the queue job remains the source of truth for "did we do the work"
+(IMPL-0015 Phase 0 contract). The upsert is one batched statement per
+job, executed in a single transaction that also reconciles rows for
+rules no longer in the evaluated set (Open Question 3).
+
+Posture is then one indexed query:
+
+```sql
+SELECT owner AS org, rule_name,
+       count(*) FILTER (WHERE actionable) AS actionable,
+       count(*)                            AS tracked
+FROM rule_state
+GROUP BY 1, 2;
+```
+
+### Leader-scoped posture exporter (Finding D, shape D1)
+
+A new leader-gated schedule handler, `posture-export`, registered via
+the existing `Scheduler.Schedule(ctx, name, interval, handler)`
+surface — the same SETNX election that already serialises
+`stale-sweep`. Every `POSTURE_EXPORT_INTERVAL` (default 60s) the
+leader runs the posture query and populates two GaugeVecs:
+
+- `repo_guardian_repos_actionable{rule_name, org}`
+- `repo_guardian_repos_tracked{org}`
+
+The handler follows the `ResetOpenPRsByRule` precedent: full GaugeVec
+`Reset()` at the top of each tick, then `Set()` — so an org or rule
+that disappears from the fleet stops emitting stale series instead of
+freezing at its last value. Non-leader replicas never serve the
+series; dashboards aggregate with `max by (...)`, exactly as
+`scheduler_is_leader` panels already do. Compliance ratio is computed
+in PromQL from the two gauges (Open Question 2).
+
+The GitHub-owned posture reading from Finding B — org schema gaps —
+gets its projection at the source that already knows: the
+custom-properties schema-preflight cache (30-minute TTL, IMPL-0017)
+sets `repo_guardian_property_schema_missing{org, property}` to 0/1 on
+each refresh. No DB involvement; the cache refresh *is* the check.
+
+### The org↔installation join metric (Finding E2)
+
+`repo_guardian_installation_info{installation_id, org} 1` — a
+constant-value info gauge set when an installation client is
+constructed and during discovery. It exists solely so Grafana can
+`group_left` the `installation_id`-keyed series (discovery,
+rate-limit) into per-org dashboard rows. One line of instrumentation,
+unblocks the E2 layout.
+
+### OTEL metrics-first instrumentation (Finding G)
+
+Four boundaries, four off-the-shelf instrumentation packages, one
+exporter:
+
+| Boundary | Package | Replaces (planned, never built) |
+|---|---|---|
+| Inbound HTTP (webhook server) | `otelhttp` server middleware | hand-rolled `promhttp.InstrumentHandler*` duration middleware |
+| GitHub client | `otelhttp` client transport | hand-rolled RoundTripper RED histogram |
+| Valkey (queue + scheduler clients) | `redisotel` metrics | `redisprometheus.NewCollector` |
+| Postgres (pgxpool) | `otelpgx` | possibly the `pgxpool.Stat()` collector — verified in task 3.5, one source only |
+
+The OTel SDK's `go.opentelemetry.io/otel/exporters/prometheus` bridge
+registers into the same default registry `promhttp` already serves
+(main.go:413), so every semconv series appears on the existing
+`/metrics` endpoint with no collector and no config change for the
+scrape stack. The TracerProvider is the no-op provider — spans are
+structurally emitted but go nowhere until the later tracing design
+turns them on.
+
+What this closes, from the Finding G unmask list: HMAC 401s (counted
+nowhere today — `webhook_rejected_total` lives only in the allowlist
+middleware) become ordinary `http.server.request.duration{status}`
+samples; GitHub status truth (429 vs 403 vs 5xx) appears on the client
+histogram; Valkey command latency (including the reaper Lua and leader
+SETNX) is measured for the first time; pool-acquire wait separates
+from query time.
+
+Instrumentation scope decision: the **webhook server only** for
+inbound. The metrics/health server would mostly instrument Prometheus
+scraping itself — noise, not signal.
+
+Transport ordering with DESIGN-0021 (both designs touch the
+installation transport):
+
+```text
+otelhttp client transport        ← this design, outermost
+  └─ rate-limit transport        ← DESIGN-0021 (ThrottledError source)
+       └─ ghinstallation token transport
+```
+
+Outermost `otelhttp` means a 0021 deferral shows up as an errored
+client span/measurement — which is the residual signal that replaces
+the retiring `github_rate_limit_wait_*` pair.
+
+**Dedup rule (Finding G):** domain metrics stay authoritative for
+domain questions (`store_query_seconds{op}` knows `stale_repos`;
+semconv sees only SQL verbs). Every dashboard panel picks exactly one
+source; no panel may mix a hand-rolled and a semconv series for the
+same signal.
+
+### Compliance snapshots and the per-org report (Finding C rider)
+
+A second leader-gated schedule handler, `compliance-snapshot`
+(default cadence 24h), runs
+`INSERT INTO compliance_snapshot ... SELECT` from the posture query —
+giving quarter-over-quarter history independent of Prometheus
+retention. Volume is trivial: orgs × rules rows per day (~120/day at
+target scale); no retention machinery needed initially.
+
+`repo-guardian report` is a CLI sibling of the generator: loads the
+same `guardian.hcl`, queries `rule_state` + `compliance_snapshot`, and
+renders one report per org — compliance percentage per rule, trend
+versus the previous snapshot, and the table a metric can never hold:
+*which* repos, failing *which* rules, since *when*. Open-PR links are
+fetched live from GitHub at generation time (low volume, installation
+client). Output shape is Open Question 6.
+
+### Config-generated monitoring (Finding H, shape H1)
+
+`repo-guardian monitoring generate --config guardian.hcl --out
+./monitoring/ --format json|k8s`.
+
+The generator `policy.Load()`s the operator's config — which makes
+every invocation a free config validation (the strict-templates
+precedent, extended) — and derives the generation model: the org list
+from `scope`, the enabled rules and their kinds, which reconcilers are
+attached, which mechanisms (custom properties, absent rules, gates)
+are in use. From that model it emits:
+
+- the four dashboards (Finding E), with one E2 row *per configured
+  org* — a silent org renders as a no-data row, a signal instead of a
+  blind spot;
+- a PrometheusRule manifest containing only alerts whose mechanism is
+  configured (no `PropertySchemaMissing` without a `custom_properties`
+  reconciler), each authored against the INV-0012 C/E window rules;
+- panels only for enabled rule kinds (no forbidden-files panels
+  without absent-mode rules).
+
+Dashboards are authored once, in Go, against the
+grafana-foundation-sdk builders — there is **no hand-maintained
+dashboard JSON anywhere**. The static `contrib/` tier is the
+generator's output for a default (empty-scope) config, regenerated in
+CI with a fail-on-diff gate — the same drift convention `helm-docs`
+and `docz update` already use in this repo. The SDK's coupling to
+Grafana schema versions is handled by pinning and a render test
+(Grafana ≥ 10 required; acceptable — the homelab runs
+kube-prometheus-stack).
+
+Format `k8s` wraps the dashboard JSON for in-cluster consumption
+(Open Question 7 picks ConfigMap-sidecar vs grafana-operator CRs) and
+emits the PrometheusRule as a CR. Format `json` emits plain files for
+manual import.
+
+Where the generator lives (main binary vs a separate `cmd/`) is Open
+Question 5.
+
+### Dashboard suite (Finding E)
+
+Four dashboards, sources fixed by the Finding I taxonomy:
+
+- **E1 — KPI / status** (business tier only): compliance % per rule
+  and org (the two Phase 2 gauges), `open_prs_by_rule` ages,
+  convergence rate (`prs_closed_total{reason="satisfied"}`), error
+  budget, rate-limit headroom, queue depth, leader status. The
+  compliance panels consume *real posture*, never
+  `increase(files_missing_total)`.
+- **E2 — detailed, per-org repeated rows** (business + service sliced
+  by org): a fleet section of aggregates (`sum without (org)`), then a
+  generated row per configured org. `installation_id`-keyed series
+  join in via `installation_info` `group_left`. Queue / store /
+  scheduler metrics are deliberately absent here — they are
+  fleet-scoped and belong to E3.
+- **E3 — system / health** (service + infra): go runtime + process,
+  OTEL semconv HTTP server/client, `redisotel`, pgx pool + query
+  latency, queue USE (including DESIGN-0021's `queue_delayed_depth` /
+  `queue_wait_seconds` once landed), the three orphan histograms from
+  Finding A (`scheduler_sweep_batch_size`,
+  `store_writeback_duration_seconds`, `discovery_duration_seconds`)
+  finally get panels, posture-exporter health.
+- **E4 — Loki** (evidence tier): error rate by component, sweep
+  summaries, write-back failures, webhook rejections, top erroring
+  repos (repo identity as a log field, where it belongs). The
+  catalog-parse log line gets test-locked before any panel depends on
+  it; Loki-ruler recording-rule examples ship in `contrib/` for the
+  log-shaped signals.
+
+## API / Interface Changes
+
+```go
+// internal/checker — CheckRepo returns per-rule outcomes.
+// Error paths return (nil, err); the worker then writes status-only,
+// exactly as today.
+type RuleOutcome struct {
+    RuleName   string
+    Kind       string // "file" | "setting" | "branch_protection"
+    Actionable bool
+}
+
+type CheckResult struct {
+    Outcomes       []RuleOutcome
+    CatalogParseOK *bool // nil = no catalog rule evaluated
+}
+
+func (e *Engine) CheckRepo(ctx context.Context, client ghclient.Client,
+    owner, repo string) (*CheckResult, error)
+
+// internal/store — Store gains posture methods (final set is an impl
+// detail; the contract is batched-single-tx upsert + the two query
+// shapes the exporter and report need).
+type RuleState struct {
+    InstallationID  int64
+    Owner, Repo     string
+    RuleName, Kind  string
+    Actionable      bool
+    ActionableSince *time.Time
+    PolicyVersion   string
+}
+
+type Store interface {
+    // ...existing five methods...
+    UpsertRuleStates(ctx context.Context, states []RuleState) error
+    ActionableCounts(ctx context.Context) ([]RuleCount, error)
+    ActionableRepos(ctx context.Context, org string) ([]RuleState, error)
+    InsertComplianceSnapshot(ctx context.Context, at time.Time) error
+}
+```
+
+New config (env → chart values → `values.schema.json`, per
+convention): `POSTURE_EXPORT_INTERVAL` (default `60s`),
+`COMPLIANCE_SNAPSHOT_INTERVAL` (default `24h`). OTEL is on by default
+with no new knobs; the standard `OTEL_SDK_DISABLED=true` escape hatch
+is honoured.
+
+New CLI surface: `repo-guardian monitoring generate` and
+`repo-guardian report` subcommands (placement per Open Question 5).
+
+Mock/fake fallout: `make mocks` regenerates the Store mock; the
+test-local `recordingQueue` / `fakeStore` recorders and the
+checker-package fakes absorb the `CheckRepo` signature change
+(embedded `mocks.MockClient` is unaffected — this is an engine-side
+change, not a `github.Client` change).
+
+## Data Model
+
+Migration `0002` (up + down), additive only:
+
+```sql
+CREATE TABLE rule_state (
+    installation_id  BIGINT      NOT NULL,
+    owner            TEXT        NOT NULL,
+    repo             TEXT        NOT NULL,
+    rule_name        TEXT        NOT NULL,
+    rule_kind        TEXT        NOT NULL,
+    actionable       BOOLEAN     NOT NULL,
+    actionable_since TIMESTAMPTZ,
+    policy_version   TEXT        NOT NULL DEFAULT '',
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (installation_id, owner, repo, rule_name)
+);
+
+-- posture query support: count actionable per (owner, rule)
+CREATE INDEX idx_rule_state_actionable
+    ON rule_state (owner, rule_name) WHERE actionable;
+
+CREATE TABLE compliance_snapshot (
+    org              TEXT        NOT NULL,
+    rule_name        TEXT        NOT NULL,
+    actionable_count INT         NOT NULL,
+    tracked_count    INT         NOT NULL,
+    snapshot_at      TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (org, rule_name, snapshot_at)
+);
+
+ALTER TABLE repo_state ADD COLUMN catalog_parse_ok BOOLEAN;
+```
+
+The upsert preserves `actionable_since` across still-actionable
+checks and manages the transition edges in SQL:
+
+```sql
+INSERT INTO rule_state (...) VALUES (...)
+ON CONFLICT (installation_id, owner, repo, rule_name) DO UPDATE SET
+    actionable = EXCLUDED.actionable,
+    actionable_since = CASE
+        WHEN NOT rule_state.actionable AND EXCLUDED.actionable THEN now()
+        WHEN NOT EXCLUDED.actionable                            THEN NULL
+        ELSE rule_state.actionable_since
+    END,
+    rule_kind      = EXCLUDED.rule_kind,
+    policy_version = EXCLUDED.policy_version,
+    updated_at     = now();
+```
+
+Row volume at target scale: 5k repos × ~6 rules = ~30k rows, upserted
+one batch per check. Dead-installation cleanup follows the existing
+`repo_state` operational recipe (ent-setup.md) — same key prefix, one
+more `DELETE ... WHERE installation_id =` at cutover.
+
+## Observability
+
+New metrics (all on the existing `/metrics` endpoint):
+
+| Metric | Type | Labels | Answers |
+|---|---|---|---|
+| `repo_guardian_repos_actionable` | Gauge | `rule_name`, `org` | posture: repos currently failing each rule |
+| `repo_guardian_repos_tracked` | Gauge | `org` | denominator for compliance % |
+| `repo_guardian_installation_info` | Gauge (=1) | `installation_id`, `org` | Grafana `group_left` join |
+| `repo_guardian_property_schema_missing` | Gauge (0/1) | `org`, `property` | schema gap, as posture |
+| `repo_guardian_posture_export_total` | Counter | `outcome` | is the exporter running |
+| `repo_guardian_posture_export_duration_seconds` | Histogram | — | exporter query cost |
+| semconv HTTP server/client, redis, pgx series | (bridge) | per semconv | Finding F's USE/RED gaps |
+
+Removed (Phase 7, per Open Question 4): the four legacy unlabeled
+`properties_*` counters, superseded by real posture.
+
+One new starter alert: `RepoGuardianPostureExportStalled` — no
+successful `posture_export_total{outcome="success"}` increase over
+several export intervals while a leader exists; the KPI dashboard is
+lying if this fires. Authored under the INV-0012 C/E window rules like
+everything else, and emitted by the generator.
+
+## Implementation Phases
+
+Each phase is independently mergeable, in dependency order:
+2 requires 1; 4 requires 1; 6 requires 5 (and consumes 2–4's series);
+7 is last. Run `make lint` and `make fmt` after each task; commit per
+numbered task.
+
+### Phase 1: Per-rule posture state
+
+#### Tasks
+
+- [ ] 1.1 Migration `0002`: `rule_state` + partial index,
+      `compliance_snapshot`, `repo_state.catalog_parse_ok` (up and
+      down).
+- [ ] 1.2 Change `Engine.CheckRepo` to return `(*CheckResult, error)`
+      with per-rule outcomes for file, setting, and branch-protection
+      rules (BP gains an actionable verdict — its first posture
+      signal) and the catalog-parse fact.
+- [ ] 1.3 `Store.UpsertRuleStates`: single-transaction batched upsert
+      with the `actionable_since` transition CASE, plus reconciliation
+      of rows absent from the evaluated set (per Open Question 3
+      resolution).
+- [ ] 1.4 Worker write-back: persist the `CheckResult` in the existing
+      `writeBack` path — best-effort, `store_writeback_total` outcome
+      accounting, never propagated.
+- [ ] 1.5 `make mocks`; update test-local `fakeStore` recorders and
+      checker-test plumbing for the new `CheckRepo` signature.
+- [ ] 1.6 Tests: `actionable_since` set on false→true, preserved on
+      true→true, cleared on true→false; batched upsert race
+      (concurrent-goroutine pattern from
+      `TestPostgresStore_UpsertIfMissing_ConcurrentRace`); rule-state
+      write failure does not fail the job.
+
+#### Success Criteria
+
+- After a sweep, the posture SQL returns counts matching the engine's
+  in-memory actionable sets for every rule kind.
+- A repo that flips from failing to satisfied has its row updated with
+  `actionable=false, actionable_since=NULL` on the next check.
+- Store write failures never change job outcomes.
+- `make ci` passes; migration applies and rolls back cleanly.
+
+### Phase 2: Leader-scoped posture exporter and join metrics
+
+#### Tasks
+
+- [ ] 2.1 `installation_info{installation_id, org} 1` set at
+      installation-client construction and during discovery.
+- [ ] 2.2 `posture-export` schedule handler: leader-gated via the
+      existing `Scheduler.Schedule`; full `Reset()` + `Set()` of
+      `repos_actionable` and `repos_tracked` each tick
+      (`ResetOpenPRsByRule` precedent).
+- [ ] 2.3 `property_schema_missing{org, property}` 0/1 gauge set at
+      each schema-preflight cache refresh.
+- [ ] 2.4 Exporter health: `posture_export_total{outcome}` +
+      `posture_export_duration_seconds`.
+- [ ] 2.5 Config: `POSTURE_EXPORT_INTERVAL` env +
+      `values.yaml` / `values.schema.json` + helm-unittest cases.
+- [ ] 2.6 Tests: only the leader emits (two schedulers, one series
+      source); a removed org/rule stops emitting after the next tick;
+      gauge values equal SQL truth.
+- [ ] 2.7 `contrib/README.md` rows for all Phase 2 metrics.
+
+#### Success Criteria
+
+- With N replicas, exactly one serves the posture series;
+  `max by (rule_name, org)` is correct and stable across leader
+  failover.
+- No stale series survive an org or rule leaving the fleet.
+- `make ci` and helm-unittest pass.
+
+### Phase 3: OTEL metrics-first
+
+#### Tasks
+
+- [ ] 3.1 OTel SDK + `exporters/prometheus` bridge registered into
+      the default registry; no-op TracerProvider; honour
+      `OTEL_SDK_DISABLED`.
+- [ ] 3.2 `otelhttp` server middleware on the webhook server mux
+      (only) — HMAC 401s and every other status become measured.
+- [ ] 3.3 `otelhttp` client transport wrapping the installation
+      transport, **outermost** (above the rate-limit transport —
+      DESIGN-0021 ordering contract).
+- [ ] 3.4 `redisotel` metrics on both Valkey clients (queue,
+      scheduler).
+- [ ] 3.5 `otelpgx` on the pgxpool; verify whether its pool-stats
+      option covers `pgxpool.Stat()` — if yes use it, if no add the
+      small Stat collector. Exactly one pool-stats source ships.
+- [ ] 3.6 Cardinality audit of the bridge output (no `url.path` on
+      server metrics; bounded label sets) + document the
+      one-source-per-panel dedup rule in
+      `docs/operations/scaling.md`.
+- [ ] 3.7 Tests: `/metrics` contains the semconv series alongside the
+      existing `repo_guardian_*` series in one registry; a webhook
+      request with a bad HMAC increments the server duration
+      histogram with a 401 label.
+
+#### Success Criteria
+
+- Inbound HTTP, GitHub client, Valkey, and Postgres all have RED/USE
+  series on the existing endpoint with zero new cluster infra.
+- The Finding F hand-rolled collector list is fully cancelled or
+  consciously superseded (task 3.5's one-source decision recorded).
+- `make ci` passes.
+
+### Phase 4: Compliance snapshots and the report CLI
+
+#### Tasks
+
+- [ ] 4.1 `compliance-snapshot` schedule handler (leader-gated,
+      `COMPLIANCE_SNAPSHOT_INTERVAL`, default 24h):
+      `INSERT ... SELECT` from the posture query.
+- [ ] 4.2 `repo-guardian report`: per-org output with compliance %
+      per rule, trend vs previous snapshot, and the
+      repo/rule/missing-since table; open-PR links fetched live at
+      generation time.
+- [ ] 4.3 Golden-file tests for report rendering; snapshot-trend test
+      across two synthetic snapshots.
+- [ ] 4.4 Operator doc: generating and distributing reports; snapshot
+      cadence and (non-)retention rationale.
+
+#### Success Criteria
+
+- A generated report for a seeded org matches DB truth exactly
+  (identity, since-dates, percentages).
+- Snapshot rows accumulate at the configured cadence on the leader
+  only.
+- `make ci` passes.
+
+### Phase 5: Monitoring generator foundation
+
+#### Tasks
+
+- [ ] 5.1 `monitoring generate` subcommand skeleton: `policy.Load` →
+      generation model (orgs, rules, kinds, reconcilers, mechanisms);
+      `--out`, `--format json|k8s`.
+- [ ] 5.2 grafana-foundation-sdk dependency (pinned) + the shared
+      panel-library package; render test against the pinned Grafana
+      schema version.
+- [ ] 5.3 PrometheusRule generation: existing starter alerts
+      re-authored as generator output, mechanism-scoped, windows per
+      INV-0012 findings C/E; includes `PostureExportStalled` and the
+      DESIGN-0021 alerts once those metrics exist.
+- [ ] 5.4 CI drift gate: regenerate the static tier from the default
+      config, fail on diff (helm-docs convention).
+- [ ] 5.5 Document generator-as-validation (a failing
+      `policy.Load` fails generation — CI config check for free).
+
+#### Success Criteria
+
+- `monitoring generate` against `examples/guardian-enterprise.hcl`
+  emits dashboards containing a row for every configured org
+  (including orgs with no data) and an alert manifest containing only
+  configured-mechanism alerts.
+- Hand-editing a generated artifact turns CI red.
+- `make ci` passes.
+
+### Phase 6: Dashboard suite content
+
+#### Tasks
+
+- [ ] 6.1 E1 KPI dashboard — business-tier sources only (Finding I);
+      compliance panels read the Phase 2 gauges.
+- [ ] 6.2 E2 detailed dashboard — fleet aggregate section + generated
+      per-org rows; `installation_info` `group_left` joins for
+      `installation_id`-keyed series.
+- [ ] 6.3 E3 system dashboard — service + infra tiers: OTEL semconv
+      series, queue USE (incl. DESIGN-0021 series when present), pgx
+      pool, go runtime, the three orphan histograms, posture-exporter
+      health.
+- [ ] 6.4 E4 Loki dashboard + Loki-ruler recording-rule examples in
+      `contrib/`.
+- [ ] 6.5 Test-lock the catalog-parse log line ("catalog-info parse
+      failed; skipping reconcile to avoid clearing properties" —
+      message + keys) before E4 references it.
+- [ ] 6.6 Commit the generated static tier to `contrib/grafana/`;
+      delete the legacy 61-panel dashboard with a pointer in
+      `contrib/README.md`.
+- [ ] 6.7 Rewrite `contrib/README.md` around the four-dashboard suite
+      and the generated/static two-tier model.
+
+#### Success Criteria
+
+- All four dashboards render against a live stack with no
+  empty-by-construction panels and no references to dead or retiring
+  series (budget pair, rate-limit wait pair).
+- Every panel's source respects the Finding I taxonomy and the
+  one-source-per-panel rule.
+- `make ci` passes; drift gate green on the committed static tier.
+
+### Phase 7: Cleanup, deprecations, docs, chart
+
+#### Tasks
+
+- [ ] 7.1 Remove the four legacy `properties_*` counters (per Open
+      Question 4 resolution) with migration notes in
+      `contrib/README.md`.
+- [ ] 7.2 `docs/operations/scaling.md`: posture architecture, exporter
+      leader semantics, OTEL series catalog, dedup rule.
+- [ ] 7.3 Chart: version + appVersion bump, new values documented via
+      `README.md.gotmpl` (never the rendered README), prometheusrule
+      parity with the generator output.
+- [ ] 7.4 CLAUDE.md: posture-state contract (write-back best-effort,
+      leader-scoped export, taxonomy pointer), transport-ordering
+      contract shared with DESIGN-0021.
+- [ ] 7.5 Flip INV-0013 to Concluded and this design per its
+      lifecycle; `docz update design inv`; mkdocs stays at the
+      14-warning baseline.
+
+#### Success Criteria
+
+- No dangling references to removed counters in code, chart, contrib,
+  or docs.
+- Chart renders and installs with the new values; helm-unittest
+  passes.
+- `make ci` passes.
+
+## Testing Strategy
+
+- **Unit** — upsert transition semantics (the `actionable_since`
+  CASE), exporter reset-then-set behaviour, generation-model
+  derivation from policy configs, report rendering (golden files).
+  Table-driven throughout.
+- **Integration (`integration` build tag, real Postgres)** — migration
+  0002 up/down, batched upsert under concurrency, posture query
+  correctness at realistic row counts, snapshot insert. Follows the
+  existing store integration-test convention.
+- **Leader semantics** — exporter emission is leader-gated; asserted
+  with the two-scheduler pattern from the valkey scheduler
+  integration tests.
+- **Non-vacuity** — per standing practice, every behavioural test is
+  verified by neutralising the fix and confirming failure. Task 2.6's
+  stale-series test especially: it passes trivially if the exporter
+  never `Reset()`s and the test never removes an org.
+- **Mock fidelity** — `UpsertRuleStates` then `ActionableCounts` is a
+  list-then-act shape; any fake must reflect prior writes (CLAUDE.md
+  rule), or exporter tests are vacuous.
+- **Render tests** — generator output parses as valid dashboard JSON
+  for the pinned Grafana schema; a fixture config with zero
+  mechanisms produces zero mechanism panels/alerts.
+
+## Migration / Rollout Plan
+
+1. **Phases 1–2 ship as one minor** (schema + exporter). Migration
+   0002 is additive; old binaries ignore the new tables entirely, so
+   rollback is binary-only.
+2. **Phase 3 ships as a minor.** Purely additive series on the
+   existing endpoint; scrape configs unchanged. Verify scrape size
+   growth is acceptable (semconv adds ~a few hundred series per
+   replica).
+3. **Phases 4–6 ship in any order after their dependencies**; all
+   additive. Dashboards land in `contrib/` and the GitOps repo at the
+   operator's pace.
+4. **Phase 7 ships last as a minor with a prominent note** — it
+   removes the four legacy `properties_*` counters (the only
+   scrape-visible removal in this design; anything scraping them gets
+   the `contrib/README.md` migration recipe).
+5. Coordination with DESIGN-0021: no ordering requirement except
+   E3/alert content — panels referencing 0021's queue series are
+   generated only when those metrics exist (the generator's
+   mechanism-scoping handles this naturally).
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| `rule_state` write amplification slows checks | low | one batched statement per job in the existing write-back; best-effort so it can never fail a job; p99 tracked by `store_writeback_duration_seconds` (which finally gets a panel) |
+| Posture staleness misread as truth | medium | dashboards label posture panels "as of last check per repo"; `updated_at` supports an explicit staleness panel; exporter-stalled alert |
+| Exporter leader flaps → gauge gaps | low | same SETNX machinery as sweeps, already proven; `max by` across replicas; export health metrics |
+| foundation-sdk / Grafana schema drift | medium | pin the SDK, render test in CI, regenerate on upgrade — the drift gate catches silent divergence |
+| Semconv series bloat scrape size | low-medium | task 3.6 cardinality audit; bridge views can drop attributes if needed |
+| Two-tier dashboards fork anyway | low | there is no hand-written JSON — static tier is generator output, enforced by the CI diff gate |
+| Report GitHub calls at generation time hit limits | low | volume is per-open-PR per org, ad-hoc cadence; uses the standard installation client with existing accounting |
+
+## Open Questions
+
+1. **Posture storage shape.**
+   (a) C1 — the `rule_state` per-rule table as specified. The report
+   requirement (repo identity + missing-since) already settled this
+   in INV-0013 Finding C; JSONB cannot express `actionable_since`
+   per rule without contortions, and "show me the repos" was needed
+   twice during the enterprise migration.
+   (b) C2 — `actionable_rules JSONB` on `repo_state`: cheaper
+   migration, no second table, but per-rule timestamps and indexed
+   posture queries get materially worse.
+   (c) C3 only — sweep-snapshot gauges, no schema change: posture
+   lags a sweep, no identity, no report. Kills Phase 4.
+   other:
+
+2. **Compliance ratio computation.**
+   (a) Export the two raw gauges (`repos_actionable`,
+   `repos_tracked`) and compute the ratio in PromQL
+   (`1 - actionable/tracked`) — raw series compose into any panel,
+   recording rules can pre-bake the ratio, and the exporter stays
+   dumb.
+   (b) Export a precomputed `compliance_ratio{org, rule_name}` gauge
+   as well — convenient, but a derived series that can silently
+   disagree with its inputs.
+   (c) Compute in Grafana via the Postgres datasource — no gauges at
+   all for compliance; couples the KPI dashboard to DB credentials
+   in Grafana.
+   other:
+
+3. **`rule_state` reconciliation when rules leave the policy.**
+   (a) Reconcile in the write-back transaction: after the batched
+   upsert, delete this repo's rows whose `rule_name` is not in the
+   evaluated set. Exact, incremental, no background job, and the
+   write-back already holds the full evaluated set. A policy that
+   drops a rule converges repo-by-repo as checks occur.
+   (b) A background GC pass comparing `rule_state` against the loaded
+   policy — converges faster after a policy change, but adds a job
+   and a second writer.
+   (c) Query-time filtering only (`WHERE rule_name IN (...)`) — rows
+   never deleted; table grows with every renamed rule forever.
+   other:
+
+4. **Legacy `properties_*` counters (4 unlabeled Counters).**
+   (a) Remove in Phase 7, same minor that completes the suite —
+   they are posture-shaped (Finding B), unlabeled (pre-IMPL-0009),
+   and fully superseded by `repos_actionable` + the property-sync
+   event counters; `contrib/README.md` carries the migration note.
+   (b) Deprecate for one release (log a warning in docs, keep
+   emitting), remove the next minor — gentler, but nothing external
+   is known to consume them and it drags the cleanup across two
+   releases.
+   (c) Keep indefinitely — cost is small but they contradict the
+   taxonomy and invite wrong panels.
+   other:
+
+5. **Generator and report binary placement.**
+   (a) Subcommands on the main `repo-guardian` binary — one artifact,
+   one version, the policy loader is already linked, and operators
+   run it from the same image in CI. Measure the foundation-sdk size
+   delta on the ~19.5MB distroless image; if it is egregious, fall
+   back to (b) before merging.
+   (b) A separate `cmd/repo-guardian-monitoring` binary sharing
+   `internal/policy` — keeps the server image lean, but two
+   artifacts to version and release.
+   other:
+
+6. **Report output shape.**
+   (a) Markdown files per org written to `--out` — simplest, renders
+   everywhere (GitHub, Slack paste, Backstage TechDocs), delivery
+   stays a human/automation choice outside the binary.
+   (b) Open a GitHub issue per org via the App — delivery built in
+   and org owners are already on GitHub, but it writes to repos we
+   otherwise only remediate, and needs an issue-target convention.
+   (c) HTML + SMTP email — the classic compliance-report shape, but
+   brings mail configuration and templating for marginal gain at
+   current scale.
+   other:
+
+7. **`--format k8s` dashboard artifact shape.**
+   (a) ConfigMaps with the `grafana_dashboard: "1"` sidecar label —
+   the kube-prometheus-stack convention already running in the
+   homelab; no new operator, kustomize-native.
+   (b) grafana-operator `GrafanaDashboard` CRs — cleaner ownership
+   model, but requires deploying grafana-operator.
+   (c) Plain JSON only; the operator wraps it themselves — smallest
+   generator surface, pushes boilerplate onto every consumer.
+   other:
+
+## References
+
+- [INV-0013](../investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md)
+  — findings A–I; this design implements its full recommendation
+- [INV-0012](../investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md)
+  — alert-window rules (findings C/E) applied to all generated alerts
+- [DESIGN-0021](0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md)
+  — post-0021 metric surface this design is written against; shared
+  installation-transport ordering contract (Phase 3 here, Phase 3
+  there)
+- [DESIGN-0012](0012-persistent-reconcile-state-and-multi-replica-coordination.md)
+  — the Store/Scheduler surfaces extended here
+- [IMPL-0013](../impl/0013-reconcile-open-prs-when-file-rules-become-satisfied.md)
+  — `open_prs_by_rule` snapshot-gauge precedent (`ResetOpenPRsByRule`)
+- [IMPL-0015](../impl/0015-stale-sweep-cutover-and-repository-discovery.md)
+  — write-back best-effort contract this design extends
+- [IMPL-0017](../impl/0017-configurable-annotation-sourced-custom-properties.md)
+  — the schema-preflight cache that feeds `property_schema_missing`
+- grafana-foundation-sdk: <https://github.com/grafana/grafana-foundation-sdk>
+- OTel Go prometheus bridge:
+  <https://pkg.go.dev/go.opentelemetry.io/otel/exporters/prometheus>
+- `otelhttp`:
+  <https://pkg.go.dev/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp>
+- `redisotel`: <https://github.com/redis/go-redis/tree/master/extra/redisotel>
+- `otelpgx`: <https://github.com/exaring/otelpgx>
+- kube-prometheus-stack dashboard sidecar convention:
+  <https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack>

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -52,4 +52,5 @@ docz create design "Your Design Title"
 | DESIGN-0018 | Deprecate memory backend | Approved | 2026-06-22 | Donald Gifford | [0018-deprecate-memory-backend.md](0018-deprecate-memory-backend.md) |
 | DESIGN-0019 | Configurable annotation-sourced custom properties | Implemented | 2026-07-19 | Donald Gifford | [0019-configurable-annotation-sourced-custom-properties.md](0019-configurable-annotation-sourced-custom-properties.md) |
 | DESIGN-0020 | Absent check mode and conditional file rules | Implemented | 2026-07-23 | Donald Gifford | [0020-absent-check-mode-and-conditional-file-rules.md](0020-absent-check-mode-and-conditional-file-rules.md) |
+| DESIGN-0021 | Delayed-requeue job contract and rate-limit consolidation | Draft | 2026-07-26 | Donald Gifford | [0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md](0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -53,4 +53,5 @@ docz create design "Your Design Title"
 | DESIGN-0019 | Configurable annotation-sourced custom properties | Implemented | 2026-07-19 | Donald Gifford | [0019-configurable-annotation-sourced-custom-properties.md](0019-configurable-annotation-sourced-custom-properties.md) |
 | DESIGN-0020 | Absent check mode and conditional file rules | Implemented | 2026-07-23 | Donald Gifford | [0020-absent-check-mode-and-conditional-file-rules.md](0020-absent-check-mode-and-conditional-file-rules.md) |
 | DESIGN-0021 | Delayed-requeue job contract and rate-limit consolidation | Draft | 2026-07-26 | Donald Gifford | [0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md](0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md) |
+| DESIGN-0022 | Compliance posture state, dashboard suite, and OTEL-first observability | Draft | 2026-08-02 | Donald Gifford | [0022-compliance-posture-state-dashboard-suite-and-otel-first.md](0022-compliance-posture-state-dashboard-suite-and-otel-first.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/impl/0022-delayed-requeue-job-contract-and-rate-limit-consolidation.md
+++ b/docs/impl/0022-delayed-requeue-job-contract-and-rate-limit-consolidation.md
@@ -1,0 +1,539 @@
+---
+id: IMPL-0022
+title: "Delayed-requeue job contract and rate-limit consolidation"
+status: Draft
+author: Donald Gifford
+created: 2026-08-02
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# IMPL 0022: Delayed-requeue job contract and rate-limit consolidation
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-08-02
+
+<!--toc:start-->
+- [Objective](#objective)
+- [Scope](#scope)
+  - [In Scope](#in-scope)
+  - [Out of Scope](#out-of-scope)
+- [Sequencing and Release Shape](#sequencing-and-release-shape)
+- [Implementation Phases](#implementation-phases)
+  - [Phase 0: Stop the bleeding (bundled with Phase 1)](#phase-0-stop-the-bleeding-bundled-with-phase-1)
+    - [Tasks](#tasks)
+    - [Success Criteria](#success-criteria)
+  - [Phase 1: Job contract](#phase-1-job-contract)
+    - [Tasks](#tasks-1)
+    - [Success Criteria](#success-criteria-1)
+  - [Phase 2: Delayed set and promotion](#phase-2-delayed-set-and-promotion)
+    - [Tasks](#tasks-2)
+    - [Success Criteria](#success-criteria-2)
+  - [Phase 3: Throttle signal path](#phase-3-throttle-signal-path)
+    - [Tasks](#tasks-3)
+    - [Success Criteria](#success-criteria-3)
+  - [Phase 4: Worker requeue and attempt cap](#phase-4-worker-requeue-and-attempt-cap)
+    - [Tasks](#tasks-4)
+    - [Success Criteria](#success-criteria-4)
+  - [Phase 5: Observability](#phase-5-observability)
+    - [Tasks](#tasks-5)
+    - [Success Criteria](#success-criteria-5)
+  - [Phase 6: Remove the superseded layers](#phase-6-remove-the-superseded-layers)
+    - [Tasks](#tasks-6)
+    - [Success Criteria](#success-criteria-6)
+  - [Phase 7: Docs and chart](#phase-7-docs-and-chart)
+    - [Tasks](#tasks-7)
+    - [Success Criteria](#success-criteria-7)
+- [File Changes](#file-changes)
+- [Testing Plan](#testing-plan)
+- [Dependencies](#dependencies)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Objective
+
+Implement
+[DESIGN-0021](../design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md)
+(all open questions resolved 2026-08-02): replace the three
+non-composing rate-limit layers with one delayed-requeue mechanism. A
+worker that cannot proceed returns the job to a new Valkey delayed
+ZSET with a due-time and frees its slot; the reaper promotes due jobs;
+`queue.Job` gains `Attempts`/`AvailableAt` with a `MAX_JOB_ATTEMPTS`
+cap whose terminal disposition writes to `repo_state` (OQ2 → a). The
+transport's in-handler sleep — the live duplicate-amplification hazard
+(INV-0012 finding I) — is first capped (Phase 0) and then removed
+(Phase 3). The BudgetTracker and the sweep reserve gate are deleted
+(Phase 6), leaving exactly one rate-limit mechanism.
+
+**Implements:** DESIGN-0021 (resolved: 1a, 2a, 3a, 4a+rider, 5a, 6a,
+7a, 8b)
+
+## Scope
+
+### In Scope
+
+- `internal/github/ratelimit.go`: Phase 0 sleep cap, then Phase 3
+  `ThrottledError` return replacing the pre-emptive sleep and the
+  wait-pair recording.
+- `internal/queue`: `Job.Attempts`/`Job.AvailableAt`,
+  `RetryAfterError`, `EnqueueAfter` (OQ6 → a), rewritten interface
+  contract doc.
+- `internal/queue/valkey`: delayed ZSET, `deferScript` /
+  `promoteScript` Lua, promotion from `reapOnce`, key-construction
+  centralisation (DESIGN-0015 forward hook).
+- `internal/worker`: `ThrottledError` → `RetryAfterError` translation,
+  attempt accounting, terminal disposition via the existing
+  `writeBack` path.
+- Phase 5 metrics + alerts (including re-pointing
+  `RepoGuardianRateLimitThrottling`), Phase 6 removals
+  (`internal/budget`, sweep gate, budget metrics/alert/config/chart
+  values, wait-pair definitions), Phase 7 docs/chart.
+
+### Out of Scope
+
+- Per-installation fairness/partitioning (DESIGN-0015 — this work only
+  leaves its forward hooks: key centralisation and
+  `queue_wait_seconds`).
+- The transport's reactive 403 retry handling — stays as-is.
+- Store/scheduler/discovery changes beyond deleting the budget gates.
+- OTEL client instrumentation of the transport
+  (IMPL-0023 Phase 3 — only the ordering contract matters here).
+
+## Sequencing and Release Shape
+
+- **Phases 0+1 land as one PR** (design OQ8 → b): one review of the
+  whole rate-limit-path change. Phase 0 is superseded by Phase 3 and
+  is deliberately crude.
+- **Phases 1–5 ship as one binary minor** (design rollout step 2).
+  Release labeling across the per-phase PRs is Open Question 1.
+- **Soak before Phase 6**: observe `queue_delayed_total` /
+  `queue_delayed_depth` in the homelab across a full reconcile cycle;
+  force a deferral with a deliberately low `RATE_LIMIT_THRESHOLD`
+  since organic deferrals may not occur at current scale.
+- **Phase 6 ships as its own minor** with a prominent upgrade note
+  (OQ7 → a) — it removes published chart values.
+- Coordination with IMPL-0023: whichever of this Phase 3 and
+  IMPL-0023 Phase 3 lands second adds the transport-ordering test
+  (`otelhttp` outermost, rate-limit transport inside).
+
+Run `make fmt` + `make lint` after each task; commit per numbered task
+with conventional commits.
+
+---
+
+## Implementation Phases
+
+### Phase 0: Stop the bleeding (bundled with Phase 1)
+
+The transport (`internal/github/ratelimit.go`) sleeps in-handler for
+up to `untilReset` (1h) inside `waitIfNeeded` and the
+`rateLimitDelay` + `sleepWithContext` retry path (lines 73, 147) while
+`JOB_ACK_TIMEOUT` is 5m — so the reaper clones the sleeping job every
+`REAPER_INTERVAL`. Cap the sleep below the lease.
+
+#### Tasks
+
+- [ ] 0.1 Add a package const `maxPreemptiveSleep = 60 * time.Second`
+      (hardcoded, not a knob — Open Question 2) and cap the
+      pre-emptive sleep site (`waitIfNeeded`) at
+      `min(computed, maxPreemptiveSleep)`. The reactive 403 retry
+      delay is left alone.
+- [ ] 0.2 When the computed delay exceeds the cap, return an error
+      after the capped sleep instead of sleeping the remainder — the
+      job nacks and the reaper retries it. Crude but correct until
+      Phase 4.
+- [ ] 0.3 Test: a computed delay above the cap does not sleep past it
+      (fake clock / injected sleeper).
+- [ ] 0.4 Test reproducing the INV-0012 finding I timeline: a handler
+      outliving `JOB_ACK_TIMEOUT` is claimed twice without the cap,
+      once with it. This is the canonical regression test for the
+      whole design — it must survive every later phase.
+
+#### Success Criteria
+
+- No code path can sleep longer than `JOB_ACK_TIMEOUT` while holding
+  an in-flight claim.
+- The finding-I timeline test fails with task 0.1 reverted, passes
+  with it (non-vacuity verified).
+- `make ci` passes.
+
+---
+
+### Phase 1: Job contract
+
+All changes in `internal/queue/queue.go` plus mock/fake fallout.
+
+#### Tasks
+
+- [ ] 1.1 Add `Attempts int` and `AvailableAt time.Time` to
+      `queue.Job` (JSON-tagged like the existing fields).
+- [ ] 1.2 Add `queue.RetryAfterError{After, Reason, Err}` with an
+      `Unwrap() error` method.
+- [ ] 1.3 Rewrite the `Queue` interface doc comment: the three handler
+      outcomes (ack / nack / defer), attempt counting on both defer
+      and reaper requeue, terminal disposition = write
+      `StatusError` to `repo_state` and drop (design OQ2 → a). Delete
+      the stale in-memory-implementation parenthetical.
+- [ ] 1.4 Add `EnqueueAfter(ctx, j, at)` to the interface (OQ6 → a)
+      with the contract comment: never deliver before `at`; past `at`
+      ≡ `Enqueue`. Valkey implementation may stub until task 2.2 iff
+      it lands in the same PR.
+- [ ] 1.5 `make mocks`; extend the test-local `recordingQueue` fakes
+      (`internal/checker/sweep_test.go`,
+      `internal/scheduler/sweep_test.go`,
+      `internal/webhook/handler_test.go`,
+      `internal/worker/worker_test.go`) with `EnqueueAfter`.
+- [ ] 1.6 Test: a `Job` JSON payload from the previous field set
+      decodes with `Attempts=0` and zero `AvailableAt` (no queue drain
+      on upgrade).
+
+#### Success Criteria
+
+- The interface documents delay, backoff, attempt cap, and terminal
+  disposition — the contract INV-0012 finding K found missing.
+- Old-format payloads decode correctly.
+- `make ci` passes.
+
+---
+
+### Phase 2: Delayed set and promotion
+
+All changes in `internal/queue/valkey/` (`valkey.go`, `reaper.go`).
+
+#### Tasks
+
+- [ ] 2.1 Add `DelayedKey` to `valkey.Options` (default
+      `repo-guardian:queue:delayed`) and centralise construction of
+      all four keys (jobs, in-flight, delayed, reaper lock) in one
+      helper — the DESIGN-0015 partition hook; Lua scripts stay
+      key-parametric via `KEYS[]`.
+- [ ] 2.2 `deferScript` (`ZREM` in-flight + `ZADD` delayed, atomic,
+      mirroring `requeueScript` at valkey.go:90) wired to
+      `EnqueueAfter`.
+- [ ] 2.3 `promoteScript` (`ZRANGEBYSCORE` due + `ZREM` + `LPUSH`,
+      atomic) called from `reapOnce` (reaper.go:107) under the
+      existing leader lock — no new goroutine, no new election.
+- [ ] 2.4 Publish `queue_delayed_depth` from the reaper tick (`ZCARD`,
+      alongside the existing depth accounting).
+- [ ] 2.5 Integration test (`integration` tag, real Valkey): a job
+      deferred 2s is not delivered before due-time, is delivered
+      after.
+- [ ] 2.6 Integration test: a job is in exactly one of `jobs`,
+      `in-flight`, `delayed` at every lifecycle point.
+- [ ] 2.7 Integration test: promotion is leader-gated — two reapers,
+      one promotion.
+
+#### Success Criteria
+
+- A deferred job is never delivered before `AvailableAt`; no job is
+  ever in two keys at once; promotion happens exactly once with
+  multiple replicas.
+- `make ci` passes; integration tests pass against real Valkey.
+
+---
+
+### Phase 3: Throttle signal path
+
+`internal/github/ratelimit.go` + an end-to-end chain test. Removes
+what Phase 0 capped.
+
+#### Tasks
+
+- [ ] 3.1 Add exported `github.ThrottledError{ResetAt, Remaining,
+      Limit}` with an `Error()` naming the reset time.
+- [ ] 3.2 Replace the pre-emptive sleep (`waitIfNeeded` plus the
+      Phase 0 cap) with a `ThrottledError` return from `RoundTrip`.
+      The reactive 403 retry paths stay untouched.
+- [ ] 3.3 Remove the `github_rate_limit_waits_total` /
+      `github_rate_limit_wait_seconds` recording along with the sleep
+      — no would-be-delay bridge (design amendment 2026-08-02; the
+      deferral is measured once, by Phase 5's `queue_delayed_*`).
+      `github_rate_remaining` emission is untouched.
+- [ ] 3.4 End-to-end invariant test: drive `Engine.CheckRepo` against
+      an `httptest` server returning exhausted rate-limit headers and
+      assert `errors.As` recovers `*ThrottledError` at the worker
+      boundary through the full wrap chain (url.Error → go-github →
+      client → engine).
+- [ ] 3.5 Non-vacuity check for 3.4: neutralise one `%w` on the path,
+      confirm the test fails, restore. Record the check in the PR
+      description.
+
+#### Success Criteria
+
+- The transport never sleeps pre-emptively.
+- `errors.As` recovers `*ThrottledError` from a fully-wrapped
+  `CheckRepo` error, proven by the chain test.
+- The two retained quota alerts (`RepoGuardianRateLimitLow`,
+  `RepoGuardianRateLimitNearExhaustion`) still receive samples;
+  nothing feeds the wait pair.
+- `make ci` passes.
+
+---
+
+### Phase 4: Worker requeue and attempt cap
+
+`internal/worker/worker.go` (`processJob`) +
+`internal/queue/valkey/valkey.go` (`processPayload`) + config.
+
+#### Tasks
+
+- [ ] 4.1 `processJob` translates `*github.ThrottledError` into
+      `*queue.RetryAfterError{Reason: "rate_limit"}` with the jittered
+      due-time: `due = now + delay + rand[0, min(delay/4, 60s))`.
+- [ ] 4.2 The Valkey `processPayload` handler-return path recognises
+      `*RetryAfterError` via `errors.As` and takes the defer path
+      (task 2.2) instead of ack or nack-by-leaving-in-flight.
+- [ ] 4.3 Increment `Attempts` on every defer and every reaper
+      requeue (the requeue side re-serialises the payload — extend
+      `requeueScript`'s caller accordingly).
+- [ ] 4.4 `MAX_JOB_ATTEMPTS` config (default 10) in
+      `internal/config/config.go` + validation. On exceeding the cap:
+      write `StatusError` with a descriptive `LastError` to
+      `repo_state` via the existing best-effort `writeBack`, drop the
+      job, increment `queue_attempts_exhausted_total` (OQ2 → a — the
+      next sweep re-enqueues naturally if the repo is still stale;
+      this makes the enterprise-migration nack-loop self-healing).
+- [ ] 4.5 Exponential backoff for deferrals with no server-supplied
+      time: constants per Open Question 3, same jitter shape as 4.1.
+- [ ] 4.6 Test: a throttled job is deferred, not nacked — in-flight
+      empty, delayed has one entry.
+- [ ] 4.7 Test: the worker slot frees immediately on deferral — a
+      second job is processed while the first is parked.
+- [ ] 4.8 Test: attempts accumulate across defers and reaper
+      requeues; the cap triggers the terminal disposition exactly
+      once, and the `repo_state` row carries `StatusError`.
+
+#### Success Criteria
+
+- A throttled job never occupies a worker slot while waiting.
+- Attempts are counted across both paths; no job retries forever.
+- A dead-installation job (the enterprise-migration incident shape)
+  reaches the cap and drops with a store record instead of
+  nack-looping indefinitely.
+- `make ci` passes.
+
+---
+
+### Phase 5: Observability
+
+`internal/metrics/metrics.go`, both alert packs, scaling docs.
+
+#### Tasks
+
+- [ ] 5.1 Add `queue_delayed_total{reason, installation_id}`
+      (Counter), `queue_delay_seconds{reason}` (Histogram),
+      `queue_attempts_exhausted_total{installation_id}` (Counter).
+      (`queue_delayed_depth` landed in 2.4.)
+- [ ] 5.2 Add `queue_wait_seconds{installation_id}` (Histogram)
+      observed at claim time as `now − EnqueuedAt` — the DESIGN-0015
+      go/no-go datum. Bucket layout per Open Question 4.
+- [ ] 5.3 Add `RepoGuardianQueueBackpressure`
+      (`queue_delayed_depth` sustained) and
+      `RepoGuardianJobsExhausted` (any
+      `queue_attempts_exhausted_total` increase) to **both**
+      `charts/repo-guardian/templates/prometheusrule.yaml` and
+      `contrib/prometheus/alerts.yaml`; windows must outlive `for`
+      and match real emission cadence (INV-0012 findings C/E),
+      reasoned explicitly in the PR.
+- [ ] 5.4 Re-point `RepoGuardianRateLimitThrottling`
+      (contrib pack only, alerts.yaml:115) from the removed wait
+      counter to `queue_delayed_total{reason="rate_limit"}`.
+- [ ] 5.5 helm-unittest assertions on rendered alert *expressions*,
+      not just names (IMPL-0021 A7 convention).
+- [ ] 5.6 Document the new metrics in `docs/operations/scaling.md`
+      (healthy vs backpressured reference values) and add
+      `contrib/README.md` rows.
+
+#### Success Criteria
+
+- An operator can answer "are we hitting API limits, how hard, for
+  whom" from metrics alone.
+- All touched alerts are fireable under real emission cadence.
+- `make ci` and helm-unittest pass.
+
+---
+
+### Phase 6: Remove the superseded layers
+
+Only after the soak (see Sequencing). Ships as its own minor.
+
+#### Tasks
+
+- [ ] 6.1 Delete `internal/budget/` (budget.go, labels.go, tests) and
+      its `budget.New` wiring in `cmd/repo-guardian/main.go.bringUp`.
+- [ ] 6.2 Remove `Budget` from `StaleSweeperOptions` and
+      `DiscovererOptions` and both `budgetAllows` gates.
+- [ ] 6.3 Remove the layer-2 sweep gate
+      (`StaleSweeper.allowedByRateLimit`, sweep.go:243) and
+      `rate_limit_reserve_blocked_total` — **preserving the
+      per-installation `RateLimitRemaining` sampling call in the sweep
+      loop** (design OQ4 rider: that call is the only live producer of
+      `rate_limit_remaining{installation_id}`; the gate goes, the
+      sampling stays, `RepoGuardianRateLimitNearExhaustion` keeps its
+      feed).
+- [ ] 6.4 Remove the nine `api_budget_*` /
+      `enqueue_gated_by_budget_total` metric definitions, the now-unfed
+      wait-pair definitions
+      (`github_rate_limit_waits_total` / `_wait_seconds`), and
+      `RepoGuardianBudgetGated` from both alert files (it is already
+      commented out in contrib).
+- [ ] 6.5 Remove `DISCOVERY_RESERVE_FRACTION` and
+      `DISCOVERY_ESTIMATED_COST_PER_REPO` from config, validation, and
+      tests.
+- [ ] 6.6 Remove `discovery.reserveFraction` /
+      `discovery.estimatedCostPerRepo` from `values.yaml`,
+      `values.schema.json`, and `tests/deployment_env_test.yaml`.
+- [ ] 6.7 `make ci` plus a `deadcode` pass clean after removal.
+- [ ] 6.8 Mark DESIGN-0002 Superseded by DESIGN-0021; update the
+      CLAUDE.md BudgetTracker architecture notes.
+
+#### Success Criteria
+
+- Exactly one rate-limit mechanism remains.
+- `rate_limit_remaining{installation_id}` still receives samples
+  every sweep (rider honoured — no unfed-gauge alert).
+- No dangling config, chart value, schema entry, metric, or alert
+  referencing the removed layers; `helm template` renders without the
+  removed values.
+
+---
+
+### Phase 7: Docs and chart
+
+#### Tasks
+
+- [ ] 7.1 Chart version + appVersion bump; `make helm-docs` (edit
+      `README.md.gotmpl`, never the rendered README).
+- [ ] 7.2 `MAX_JOB_ATTEMPTS` chart value with `values.schema.json`
+      range validation and helm-unittest case.
+- [ ] 7.3 Operator runbook: what a deferred job looks like in
+      Valkey/metrics/logs, reading the new metrics, responding to the
+      backpressure and exhausted alerts.
+- [ ] 7.4 Update `docs/operations/scaling.md` and
+      `docs/operations/migrations.md` for the removed knobs, and
+      document `REAPER_INTERVAL`'s dual duty — lease reaping *and*
+      promotion cadence (design OQ3 → a).
+- [ ] 7.5 CLAUDE.md: the delayed-requeue contract and the
+      one-mechanism rule (no future in-handler blocking).
+- [ ] 7.6 Flip INV-0012 to Concluded and DESIGN-0021 to Implemented;
+      `docz update design inv impl`.
+
+#### Success Criteria
+
+- Chart renders and installs with the new values.
+- mkdocs holds the 14-warning baseline.
+- Every removed knob has a documented upgrade path.
+
+---
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/github/ratelimit.go` | Modify | P0 sleep cap → P3 `ThrottledError`; wait-pair recording removed |
+| `internal/queue/queue.go` | Modify | Job fields, `RetryAfterError`, `EnqueueAfter`, contract doc |
+| `internal/queue/valkey/valkey.go` | Modify | key centralisation, `deferScript`, `EnqueueAfter`, defer path in `processPayload` |
+| `internal/queue/valkey/reaper.go` | Modify | `promoteScript` in `reapOnce`, delayed-depth gauge, attempt increment on requeue |
+| `internal/worker/worker.go` | Modify | throttle translation, attempt cap, terminal disposition via `writeBack` |
+| `internal/config/config.go` | Modify | `MAX_JOB_ATTEMPTS`; P6 removes two discovery knobs |
+| `internal/metrics/metrics.go` | Modify | P5 adds four queue metrics; P6 removes budget + wait-pair definitions |
+| `internal/checker/sweep.go` | Modify | P6: gate removed, sampling call retained |
+| `internal/scheduler/discoverer.go` | Modify | P6: budget gate removed |
+| `internal/budget/` | Delete | P6 |
+| `charts/repo-guardian/templates/prometheusrule.yaml` | Modify | two new alerts; `BudgetGated` removed |
+| `contrib/prometheus/alerts.yaml` | Modify | two new alerts; `RateLimitThrottling` re-pointed |
+| `charts/repo-guardian/values.yaml` + `values.schema.json` | Modify | `MAX_JOB_ATTEMPTS` in; two discovery knobs out |
+| `docs/operations/scaling.md`, `migrations.md` | Modify | new metrics, removed knobs, `REAPER_INTERVAL` dual duty |
+
+## Testing Plan
+
+- [ ] Phase 0 finding-I timeline regression test (fake clock),
+      preserved through all later phases.
+- [ ] Old-payload JSON decode compatibility test (1.6).
+- [ ] Valkey integration tests: due-time honoured, exactly-one-key
+      invariant, leader-gated promotion (2.5–2.7) — Lua atomicity is
+      only provable against real Valkey.
+- [ ] End-to-end wrap-chain test (3.4) with recorded non-vacuity
+      check (3.5).
+- [ ] Worker defer/attempt/terminal tests (4.6–4.8), including the
+      dead-installation self-heal shape.
+- [ ] Mock fidelity: promotion-then-delivery is list-then-act — fakes
+      must reflect prior writes or the due-time assertion is vacuous
+      (CLAUDE.md rule).
+- [ ] helm-unittest on rendered alert expressions.
+- [ ] Each behavioural test neutralise-verify-restore per standing
+      practice.
+
+## Dependencies
+
+- INV-0012 (Concluded by Phase 7) — findings A–K are the evidence
+  base.
+- No dependency on IMPL-0023 except the transport-ordering test
+  (whichever Phase 3 lands second adds it).
+- DESIGN-0015 stays Draft; this work only leaves its hooks.
+
+## Open Questions
+
+1. **Release labeling across the per-phase PRs.**
+   (a) Label the Phase 0+1, 2, 3, and 4 PRs `dont-release`; the
+   Phase 5 PR carries `minor` and cuts the one binary release for
+   phases 1–5 (matching the design's rollout step 2). Phase 6's PR
+   carries its own `minor`. Keeps released binaries at exactly the
+   design's two behavioural checkpoints instead of shipping a
+   half-built defer path.
+   (b) Each phase PR carries `patch`/`minor` and releases
+   independently — more releases, each smaller, but versions ship
+   with `EnqueueAfter` present and nothing calling it.
+   (c) One giant PR for phases 1–5 — single review, single release,
+   but far too large to review well.
+   other:
+
+2. **Phase 0 cap: constant or knob.**
+   (a) Hardcoded `maxPreemptiveSleep = 60s` const — it is scaffolding
+   that Phase 3 deletes weeks later; an env knob would need schema,
+   chart plumbing, and a deprecation path for something with a
+   planned lifespan of one phase.
+   (b) `RATE_LIMIT_MAX_SLEEP` env var — tunable if the cap misbehaves
+   in the homelab, at the cost of shipping-then-removing a documented
+   knob.
+   other:
+
+3. **Backoff constants for deferrals with no server-supplied time.**
+   (a) `base 30s, factor 2, cap 30m`, jitter `rand[0, min(delay/4,
+   60s))` — reaches the 30m ceiling on attempt 7 of 10, so a job
+   exhausts in roughly 2–3 hours; hardcoded consts next to the
+   translation in `internal/worker`, no config surface until someone
+   needs one.
+   (b) `base 60s, factor 2, cap 1h` — gentler on the API, but a
+   10-attempt exhaustion stretches past 8 hours, longer than the gap
+   between sweeps' fresh enqueues, muddying "who re-enqueued this."
+   (c) Make base/factor/cap env-configurable now — three knobs nobody
+   has asked for.
+   other:
+
+4. **`queue_wait_seconds` bucket layout.**
+   (a) Custom buckets `[1s, 5s, 15s, 60s, 5m, 15m, 1h, 4h]` — the
+   decision this histogram exists for (DESIGN-0015 go/no-go) lives in
+   the minutes-to-hours range that `prometheus.DefBuckets` (capped at
+   10s) cannot see; 8 buckets × ~25 installations stays well inside
+   cardinality budget.
+   (b) `prometheus.ExponentialBuckets(1, 4, 8)` (1s → ~4.5h) — same
+   coverage, less legible boundaries.
+   other:
+
+## References
+
+- [DESIGN-0021](../design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md)
+  — the design; all OQs resolved 2026-08-02
+- [INV-0012](../investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md)
+  — findings A–K (amplification timeline = finding I; missing
+  contract = finding K)
+- [INV-0013](../investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md)
+  — Finding G one-source rule behind task 3.3
+- [IMPL-0023](0023-compliance-posture-state-dashboard-suite-and-otel-first.md)
+  — shared transport-ordering contract (its Phase 3)
+- [IMPL-0011](0011-persistent-reconcile-state-and-multi-replica-coordination.md)
+  — introduced the queue, lease, and reaper being extended
+- `docs/operations/ent-setup.md` — the dead-installation incident that
+  resolved design OQ2 to (a)

--- a/docs/impl/0022-delayed-requeue-job-contract-and-rate-limit-consolidation.md
+++ b/docs/impl/0022-delayed-requeue-job-contract-and-rate-limit-consolidation.md
@@ -342,7 +342,9 @@ what Phase 0 capped.
 - [ ] 5.5 helm-unittest assertions on rendered alert *expressions*,
       not just names (IMPL-0021 A7 convention).
 - [ ] 5.6 Document the new metrics in `docs/operations/scaling.md`
-      (healthy vs backpressured reference values) and add
+      (healthy vs backpressured reference values, including the
+      expected `queue_wait_seconds` top-bucket skew during fleet
+      onboarding / policy-version upgrades — OQ4 caveat) and add
       `contrib/README.md` rows.
 
 #### Success Criteria
@@ -476,6 +478,7 @@ Only after the soak (see Sequencing). Ships as its own minor.
 ## Open Questions
 
 1. **Release labeling across the per-phase PRs.**
+   **Resolved 2026-08-02 → (a).**
    (a) Label the Phase 0+1, 2, 3, and 4 PRs `dont-release`; the
    Phase 5 PR carries `minor` and cuts the one binary release for
    phases 1–5 (matching the design's rollout step 2). Phase 6's PR
@@ -490,6 +493,7 @@ Only after the soak (see Sequencing). Ships as its own minor.
    other:
 
 2. **Phase 0 cap: constant or knob.**
+   **Resolved 2026-08-02 → (a).**
    (a) Hardcoded `maxPreemptiveSleep = 60s` const — it is scaffolding
    that Phase 3 deletes weeks later; an env knob would need schema,
    chart plumbing, and a deprecation path for something with a
@@ -500,6 +504,7 @@ Only after the soak (see Sequencing). Ships as its own minor.
    other:
 
 3. **Backoff constants for deferrals with no server-supplied time.**
+   **Resolved 2026-08-02 → (a).**
    (a) `base 30s, factor 2, cap 30m`, jitter `rand[0, min(delay/4,
    60s))` — reaches the 30m ceiling on attempt 7 of 10, so a job
    exhausts in roughly 2–3 hours; hardcoded consts next to the
@@ -513,6 +518,14 @@ Only after the soak (see Sequencing). Ships as its own minor.
    other:
 
 4. **`queue_wait_seconds` bucket layout.**
+   **Resolved 2026-08-02 → (a)**, with a caveat to carry into task
+   5.6's docs: during initial fleet onboarding or a policy-version
+   upgrade the entire fleet re-enqueues at once, so waits legitimately
+   pile into the top buckets — that skew is expected, not a
+   regression, and the low-end granularity is mostly noise in those
+   windows. If the fine low-end buckets prove useless once steady
+   state is reached, collapse them in a follow-up (bucket changes are
+   non-breaking; only `histogram_quantile` precision shifts).
    (a) Custom buckets `[1s, 5s, 15s, 60s, 5m, 15m, 1h, 4h]` — the
    decision this histogram exists for (DESIGN-0015 go/no-go) lives in
    the minutes-to-hours range that `prometheus.DefBuckets` (capped at

--- a/docs/impl/0023-compliance-posture-state-dashboard-suite-and-otel-first.md
+++ b/docs/impl/0023-compliance-posture-state-dashboard-suite-and-otel-first.md
@@ -293,11 +293,11 @@ with Phases 1–2.
       model (orgs from `scope`, enabled rules and kinds, attached
       reconcilers, mechanisms in use); flags `--config`, `--out`,
       `--format json|k8s`.
-- [ ] 5.2 grafana-foundation-sdk dependency (pinned; Grafana version
-      target per Open Question 3) + the panel-library package
-      (location per Open Question 2); render test against the pinned
-      schema version; measure the binary size delta (OQ5's escape
-      hatch to a separate `cmd/` if egregious).
+- [ ] 5.2 grafana-foundation-sdk dependency pinned to the Grafana-13
+      cohort (OQ3 — Grafana ≥ 13 is the supported floor) + the
+      panel-library package in `internal/monitoring/` (OQ2); render
+      test against the 13 schema; measure the binary size delta
+      (design OQ5's escape hatch to a separate `cmd/` if egregious).
 - [ ] 5.3 PrometheusRule generation: existing starter alerts
       re-authored as generator output, mechanism-scoped (no
       `PropertySchemaMissing` without a `custom_properties`
@@ -305,8 +305,10 @@ with Phases 1–2.
       `RepoGuardianPostureExportStalled` and — once the metrics
       exist — the IMPL-0022 queue alerts.
 - [ ] 5.4 `--format k8s`: grafana-operator `GrafanaDashboard` CRs
-      (OQ7 → b) + a `PrometheusRule` CR; `--format json` emits plain
-      files. Datasource references per Open Question 4.
+      (design OQ7 → b) + a `PrometheusRule` CR; `--format json` emits
+      plain files. Datasources are concrete UIDs defaulting to
+      `prometheus` and `loki`, overridable via `--prometheus-uid` /
+      `--loki-uid` (OQ4); the static tier carries the defaults.
 - [ ] 5.5 CI drift gate: regenerate the static tier from the default
       config in `ci.yml`, fail on diff (the helm-docs convention);
       wire into the `changes` paths-filter matrix.
@@ -454,13 +456,15 @@ hand-written dashboard JSON anywhere.
 - IMPL-0022 (DESIGN-0021): no ordering requirement except the shared
   transport-ordering test and E3/alert content for its queue metrics
   (generator scoping absorbs the gap).
-- grafana-foundation-sdk requires Grafana ≥ 10 (homelab
-  kube-prometheus-stack satisfies this); grafana-operator present in
-  the cluster for `--format k8s` output (OQ7 → b).
+- grafana-foundation-sdk pinned to the Grafana-13 cohort; Grafana
+  ≥ 13 is the supported floor for the generated suite (OQ3);
+  grafana-operator present in the cluster for `--format k8s` output
+  (design OQ7 → b).
 
 ## Open Questions
 
 1. **CLI subcommand dispatch.**
+   **Resolved 2026-08-02 → (a).**
    (a) Stdlib `flag.FlagSet` per subcommand with an `os.Args[1]`
    switch in `main()` — `run()` keeps today's flat flags for the
    server path (zero behaviour change for existing deployments), and
@@ -476,6 +480,7 @@ hand-written dashboard JSON anywhere.
    other:
 
 2. **Panel-library package location.**
+   **Resolved 2026-08-02 → (a).**
    (a) `internal/monitoring/` — importable by the generator
    subcommand, the render tests, and any future operator/sidecar;
    keeps `cmd/` thin per house convention (`main.go` is already
@@ -486,6 +491,13 @@ hand-written dashboard JSON anywhere.
    other:
 
 3. **Grafana schema/version pin for the foundation SDK.**
+   **Resolved 2026-08-02 → other: Grafana 13+ only.** Pin the SDK's
+   Grafana-13 cohort; Grafana ≥ 13 is the supported floor for the
+   generated suite (record it in the panel-library doc comment,
+   `contrib/README.md`, and the generator's `--help`). Render tests
+   run against the 13 schema. The renovate packageRule against
+   transitive cohort jumps from option (a) still applies — cohort
+   bumps are deliberate, render-tested upgrades.
    (a) Pin the SDK cohort matching the deployed homelab Grafana major
    (verify the running version at task 5.2 time; currently the
    kube-prometheus-stack default, Grafana 11.x) and record it in the
@@ -498,6 +510,15 @@ hand-written dashboard JSON anywhere.
    other:
 
 4. **Datasource references in generated dashboards.**
+   **Resolved 2026-08-02 → other: concrete datasource UIDs,
+   defaulting to `prometheus` and `loki`.** Template-variable
+   datasources were rejected from operator experience (the
+   bind-at-import prompt is the annoyance, recently re-confirmed).
+   The generator emits real UIDs, defaulting to `prometheus` and
+   `loki`, overridable via `--prometheus-uid` / `--loki-uid` flags —
+   zero-flag runs work on conventional kube-prometheus-stack /
+   grafana-operator setups, and the committed static tier carries the
+   defaults.
    (a) Template-variable datasources (`${DS_PROMETHEUS}`,
    `${DS_LOKI}`) declared per dashboard — artifacts stay portable
    across clusters and the operator binds them at import/CR-apply
@@ -511,6 +532,7 @@ hand-written dashboard JSON anywhere.
    other:
 
 5. **Release labeling across the per-phase PRs.**
+   **Resolved 2026-08-02 → (a).**
    (a) `dont-release` on the Phase 1 PR, `minor` on the Phase 2 PR
    (cutting the schema+exporter release), `minor` on Phase 3,
    `dont-release` on Phases 4–6 PRs where they are dashboard/contrib

--- a/docs/impl/0023-compliance-posture-state-dashboard-suite-and-otel-first.md
+++ b/docs/impl/0023-compliance-posture-state-dashboard-suite-and-otel-first.md
@@ -1,0 +1,543 @@
+---
+id: IMPL-0023
+title: "Compliance posture state, dashboard suite, and OTEL-first observability"
+status: Draft
+author: Donald Gifford
+created: 2026-08-02
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# IMPL 0023: Compliance posture state, dashboard suite, and OTEL-first observability
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-08-02
+
+<!--toc:start-->
+- [Objective](#objective)
+- [Scope](#scope)
+  - [In Scope](#in-scope)
+  - [Out of Scope](#out-of-scope)
+- [Sequencing and Release Shape](#sequencing-and-release-shape)
+- [Implementation Phases](#implementation-phases)
+  - [Phase 1: Per-rule posture state](#phase-1-per-rule-posture-state)
+    - [Tasks](#tasks)
+    - [Success Criteria](#success-criteria)
+  - [Phase 2: Leader-scoped posture exporter and join metrics](#phase-2-leader-scoped-posture-exporter-and-join-metrics)
+    - [Tasks](#tasks-1)
+    - [Success Criteria](#success-criteria-1)
+  - [Phase 3: OTEL metrics-first](#phase-3-otel-metrics-first)
+    - [Tasks](#tasks-2)
+    - [Success Criteria](#success-criteria-2)
+  - [Phase 4: Compliance snapshots and the report CLI](#phase-4-compliance-snapshots-and-the-report-cli)
+    - [Tasks](#tasks-3)
+    - [Success Criteria](#success-criteria-3)
+  - [Phase 5: Monitoring generator foundation](#phase-5-monitoring-generator-foundation)
+    - [Tasks](#tasks-4)
+    - [Success Criteria](#success-criteria-4)
+  - [Phase 6: Dashboard suite content](#phase-6-dashboard-suite-content)
+    - [Tasks](#tasks-5)
+    - [Success Criteria](#success-criteria-5)
+  - [Phase 7: Cleanup, deprecations, docs, chart](#phase-7-cleanup-deprecations-docs-chart)
+    - [Tasks](#tasks-6)
+    - [Success Criteria](#success-criteria-6)
+- [File Changes](#file-changes)
+- [Testing Plan](#testing-plan)
+- [Dependencies](#dependencies)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Objective
+
+Implement
+[DESIGN-0022](../design/0022-compliance-posture-state-dashboard-suite-and-otel-first.md)
+(all open questions resolved 2026-08-02): persist per-rule check
+outcomes in a new `rule_state` table and project them to Prometheus
+via a leader-scoped exporter; instrument the four transport boundaries
+with OTEL exported through the existing `/metrics` endpoint; add
+compliance snapshots and a `repo-guardian report` CLI; and build the
+four-dashboard suite through a `repo-guardian monitoring generate`
+subcommand driven by `guardian.hcl`, with the static `contrib/` tier
+as the generator's default-config output.
+
+**Implements:** DESIGN-0022 (resolved: 1a, 2a, 3a, 4a, 5a, 6a, 7b)
+
+## Scope
+
+### In Scope
+
+- Migration 0002 (`rule_state`, `compliance_snapshot`,
+  `repo_state.catalog_parse_ok`), `Engine.CheckRepo` returning
+  `*CheckResult`, `Store.UpsertRuleStates` + posture queries, worker
+  write-back extension.
+- `posture-export` and `compliance-snapshot` leader-gated schedule
+  handlers; `installation_info` and `property_schema_missing` gauges.
+- OTEL SDK + prometheus bridge; `otelhttp` (webhook server + GitHub
+  client transport), `redisotel`, `otelpgx`.
+- `repo-guardian monitoring generate` and `repo-guardian report`
+  subcommands on the main binary (OQ5 → a);
+  grafana-foundation-sdk panel library; E1–E4 dashboards;
+  grafana-operator CR output (OQ7 → b); CI drift gate.
+- Phase 7 removal of the four legacy `properties_*` counters
+  (OQ4 → a).
+
+### Out of Scope
+
+- Tracing infrastructure (collector, Tempo, OTLP config) — spans go
+  to the no-op TracerProvider; later additive design.
+- `repo` as a metric label, Loki as a posture source, Grafana
+  Enterprise reporting, report *delivery* automation — all design
+  non-goals.
+- DESIGN-0021's queue mechanics (IMPL-0022) — only the shared
+  transport-ordering contract touches both.
+
+## Sequencing and Release Shape
+
+- Phase order is dependency order: 2 and 4 require 1; 6 requires 5
+  and consumes 2–4's series; 7 is last. Phase 3 is independent and
+  may run in parallel with 1–2.
+- **Phases 1+2 ship as one binary minor** (schema + exporter;
+  migration 0002 is additive, rollback is binary-only). **Phase 3
+  ships as a minor.** Phases 4–6 are additive and ship at their own
+  pace. **Phase 7 is a minor with a prominent note** — the only
+  scrape-visible removal (the four legacy counters). PR labeling
+  across phases is Open Question 5.
+- Coordination with IMPL-0022: whichever Phase 3 lands second adds
+  the transport-ordering test (`otelhttp` outermost, rate-limit
+  transport inside, `ghinstallation` innermost). Generated
+  panels/alerts referencing IMPL-0022's queue metrics appear only
+  once those metrics exist — the generator's mechanism-scoping
+  handles the gap naturally.
+
+Run `make fmt` + `make lint` after each task; commit per numbered
+task with conventional commits.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Per-rule posture state
+
+The engine computes per-rule outcomes in `findActionableRules` and
+discards them; this phase persists them in the same write-back that
+already stores `{status, error, policy_version}`.
+
+#### Tasks
+
+- [ ] 1.1 Migration `0002` (up + down) in
+      `internal/store/postgres/migrations/`: `rule_state` with the
+      partial index on `(owner, rule_name) WHERE actionable`,
+      `compliance_snapshot`, and
+      `ALTER TABLE repo_state ADD COLUMN catalog_parse_ok BOOLEAN`.
+- [ ] 1.2 Change `Engine.CheckRepo` (engine.go:97) to return
+      `(*CheckResult, error)`: `Outcomes []RuleOutcome{RuleName,
+      Kind, Actionable}` covering file, setting, and
+      branch-protection rules (BP gains its first actionable verdict
+      — it has no mismatch signal today) plus
+      `CatalogParseOK *bool` from the reconciler outcome. Error paths
+      return `(nil, err)`.
+- [ ] 1.3 `Store.UpsertRuleStates(ctx, states)` on the interface +
+      postgres impl: single-transaction batched upsert with the
+      `actionable_since` transition CASE (set on false→true, cleared
+      on true→false, preserved on true→true), then delete-not-in
+      reconciliation of this repo's rows absent from the evaluated
+      set (OQ3 → a).
+- [ ] 1.4 Worker `writeBack` extension: persist the `CheckResult`
+      (rule rows + `catalog_parse_ok`) best-effort in the same call
+      path — failures log Warn + count
+      `store_writeback_total{outcome="error"}`, never fail the job
+      (IMPL-0015 Phase 0 contract).
+- [ ] 1.5 `make mocks` for the Store; update the test-local
+      `fakeStore` recorders and every `CheckRepo` call site
+      (worker, checker tests) for the new signature.
+- [ ] 1.6 Tests: `actionable_since` transition semantics
+      (table-driven over the four edges); delete-not-in removes a
+      renamed rule's row on the next check; concurrent batched
+      upsert race (16-goroutine pattern from
+      `TestPostgresStore_UpsertIfMissing_ConcurrentRace`); rule-state
+      write failure does not change the job outcome.
+
+#### Success Criteria
+
+- After a sweep, `SELECT owner, rule_name, count(*) FILTER (WHERE
+  actionable) FROM rule_state GROUP BY 1,2` matches the engine's
+  in-memory actionable sets for every rule kind.
+- A repo flipping failing → satisfied gets
+  `actionable=false, actionable_since=NULL` on its next check.
+- Store failures never block jobs; migration applies and rolls back
+  cleanly.
+- `make ci` passes (integration tests under the `integration` tag
+  against real Postgres).
+
+---
+
+### Phase 2: Leader-scoped posture exporter and join metrics
+
+#### Tasks
+
+- [ ] 2.1 `repo_guardian_installation_info{installation_id, org} 1`
+      set at installation-client construction
+      (`CreateInstallationClient`) and during discovery.
+- [ ] 2.2 `posture-export` handler registered via
+      `Scheduler.Schedule` (same SETNX election as `stale-sweep`),
+      interval `POSTURE_EXPORT_INTERVAL` (default 60s): full
+      GaugeVec `Reset()` then `Set()` of
+      `repos_actionable{rule_name, org}` and `repos_tracked{org}`
+      (the `ResetOpenPRsByRule` precedent — stale series die on the
+      next tick). Compliance ratio stays in PromQL (OQ2 → a).
+- [ ] 2.3 `property_schema_missing{org, property}` 0/1 gauge set at
+      each schema-preflight cache refresh in
+      `internal/reconciler/custom_properties.go` (the cache already
+      knows; no DB involvement).
+- [ ] 2.4 Exporter health: `posture_export_total{outcome}` +
+      `posture_export_duration_seconds`.
+- [ ] 2.5 Config `POSTURE_EXPORT_INTERVAL` +
+      `values.yaml` / `values.schema.json` + helm-unittest cases.
+- [ ] 2.6 Tests: only the leader emits (two schedulers, one series
+      source); a removed org/rule stops emitting after the next tick
+      (non-vacuity: skip the `Reset()`, watch it fail); gauge values
+      equal SQL truth.
+- [ ] 2.7 `contrib/README.md` rows for all Phase 2 metrics.
+
+#### Success Criteria
+
+- With N replicas exactly one serves the posture series;
+  `max by (rule_name, org)` is stable across leader failover.
+- No stale series survive an org or rule leaving the fleet.
+- `make ci` and helm-unittest pass.
+
+---
+
+### Phase 3: OTEL metrics-first
+
+Four boundaries, one exporter, zero new infra. May run in parallel
+with Phases 1–2.
+
+#### Tasks
+
+- [ ] 3.1 Dependencies + SDK setup in `cmd/repo-guardian/main.go`:
+      MeterProvider with the
+      `go.opentelemetry.io/otel/exporters/prometheus` bridge
+      registered into the default registry `promhttp` already serves;
+      no-op TracerProvider; honour `OTEL_SDK_DISABLED`.
+- [ ] 3.2 `otelhttp` server middleware on the webhook server mux only
+      (not the metrics/health server) — HMAC 401s and every other
+      status become measured for the first time.
+- [ ] 3.3 `otelhttp` client transport wrapping the installation
+      transport, **outermost** (above the rate-limit transport —
+      the IMPL-0022 ordering contract; whichever lands second adds
+      the ordering test).
+- [ ] 3.4 `redisotel` metrics on both Valkey clients (queue,
+      scheduler) — reaper Lua and leader SETNX command latency
+      included.
+- [ ] 3.5 `otelpgx` on the pgxpool; verify whether its pool-stats
+      option covers `pgxpool.Stat()` — use it if yes, add the small
+      Stat collector if no. Exactly one pool-stats source ships;
+      record the verification outcome in the PR.
+- [ ] 3.6 Cardinality audit of the bridge output (no `url.path` on
+      server metrics, bounded label sets; drop attributes via views
+      if needed) + document the one-source-per-panel dedup rule in
+      `docs/operations/scaling.md`.
+- [ ] 3.7 Tests: `/metrics` serves semconv series alongside
+      `repo_guardian_*` in one registry; a bad-HMAC webhook request
+      increments the server duration histogram with a 401 label.
+
+#### Success Criteria
+
+- Inbound HTTP, GitHub client, Valkey, and Postgres all have RED/USE
+  series on the existing endpoint with no collector deployed.
+- The Finding F hand-rolled collector list is cancelled or
+  consciously superseded (3.5's one-source decision recorded).
+- `make ci` passes.
+
+---
+
+### Phase 4: Compliance snapshots and the report CLI
+
+#### Tasks
+
+- [ ] 4.1 `compliance-snapshot` leader-gated handler
+      (`COMPLIANCE_SNAPSHOT_INTERVAL`, default 24h):
+      `INSERT ... SELECT` from the posture query via
+      `Store.InsertComplianceSnapshot`.
+- [ ] 4.2 `repo-guardian report` subcommand (CLI dispatch per Open
+      Question 1): loads `guardian.hcl`, queries `rule_state` +
+      `compliance_snapshot`, renders one markdown file per org to
+      `--out` (OQ6 → a) — compliance % per rule, trend vs previous
+      snapshot, and the repo/rule/missing-since table; open-PR links
+      fetched live via the installation client.
+- [ ] 4.3 Golden-file tests for report rendering; trend test across
+      two synthetic snapshots; empty-org and zero-snapshot edge
+      cases.
+- [ ] 4.4 Operator doc: generating and distributing reports; snapshot
+      cadence and no-retention rationale (~120 rows/day at target
+      scale).
+
+#### Success Criteria
+
+- A generated report for a seeded org matches DB truth exactly
+  (identity, since-dates, percentages).
+- Snapshot rows accumulate at the configured cadence on the leader
+  only.
+- `make ci` passes.
+
+---
+
+### Phase 5: Monitoring generator foundation
+
+#### Tasks
+
+- [ ] 5.1 `repo-guardian monitoring generate` subcommand skeleton
+      (CLI dispatch per Open Question 1): `policy.Load` → generation
+      model (orgs from `scope`, enabled rules and kinds, attached
+      reconcilers, mechanisms in use); flags `--config`, `--out`,
+      `--format json|k8s`.
+- [ ] 5.2 grafana-foundation-sdk dependency (pinned; Grafana version
+      target per Open Question 3) + the panel-library package
+      (location per Open Question 2); render test against the pinned
+      schema version; measure the binary size delta (OQ5's escape
+      hatch to a separate `cmd/` if egregious).
+- [ ] 5.3 PrometheusRule generation: existing starter alerts
+      re-authored as generator output, mechanism-scoped (no
+      `PropertySchemaMissing` without a `custom_properties`
+      reconciler), windows per INV-0012 findings C/E; includes
+      `RepoGuardianPostureExportStalled` and — once the metrics
+      exist — the IMPL-0022 queue alerts.
+- [ ] 5.4 `--format k8s`: grafana-operator `GrafanaDashboard` CRs
+      (OQ7 → b) + a `PrometheusRule` CR; `--format json` emits plain
+      files. Datasource references per Open Question 4.
+- [ ] 5.5 CI drift gate: regenerate the static tier from the default
+      config in `ci.yml`, fail on diff (the helm-docs convention);
+      wire into the `changes` paths-filter matrix.
+- [ ] 5.6 Document generator-as-validation: a failing `policy.Load`
+      fails generation, so running it in CI is a free config check
+      (strict-templates precedent).
+
+#### Success Criteria
+
+- `monitoring generate` against `examples/guardian-enterprise.hcl`
+  emits dashboards with a row for every configured org (including
+  silent ones) and an alert manifest containing only
+  configured-mechanism alerts.
+- Hand-editing a generated artifact turns CI red.
+- `make ci` passes.
+
+---
+
+### Phase 6: Dashboard suite content
+
+All dashboards authored in the Phase 5 panel library — no
+hand-written dashboard JSON anywhere.
+
+#### Tasks
+
+- [ ] 6.1 E1 KPI dashboard — business-tier sources only (INV-0013
+      Finding I): compliance % from the Phase 2 gauges,
+      `open_prs_by_rule` ages, convergence rate, error budget,
+      rate-limit headroom, queue depth, leader status.
+- [ ] 6.2 E2 detailed dashboard — fleet aggregate section
+      (`sum without (org)`) + per-org rows generated per configured
+      org; `installation_info` `group_left` joins for
+      `installation_id`-keyed series; queue/store/scheduler metrics
+      deliberately absent (they are E3's).
+- [ ] 6.3 E3 system dashboard — service + infra tiers: OTEL semconv
+      HTTP server/client, redisotel, pgx pool + `store_query_seconds`,
+      queue USE (including IMPL-0022's series when present), go
+      runtime/process, the three orphan histograms
+      (`scheduler_sweep_batch_size`,
+      `store_writeback_duration_seconds`,
+      `discovery_duration_seconds`), posture-exporter health.
+- [ ] 6.4 E4 Loki dashboard (error rate by component, sweep
+      summaries, write-back failures, webhook rejections, top
+      erroring repos as log fields) + Loki-ruler recording-rule
+      examples in `contrib/`.
+- [ ] 6.5 Test-lock the catalog-parse log line ("catalog-info parse
+      failed; skipping reconcile to avoid clearing properties" —
+      exact message + keys, the same contract style as
+      `TestAPIMode_FiltersUndefinedMappedProperty`) before E4
+      references it.
+- [ ] 6.6 Commit the generated static tier to `contrib/grafana/`;
+      delete the legacy 61-panel dashboard with a pointer in
+      `contrib/README.md`.
+- [ ] 6.7 Rewrite `contrib/README.md` around the four-dashboard suite
+      and the generated/static two-tier model.
+
+#### Success Criteria
+
+- All four dashboards render against a live stack with no
+  empty-by-construction panels and no references to dead or retiring
+  series (budget pair, rate-limit wait pair).
+- Every panel's source respects the Finding I taxonomy and the
+  one-source-per-panel rule.
+- Drift gate green on the committed static tier; `make ci` passes.
+
+---
+
+### Phase 7: Cleanup, deprecations, docs, chart
+
+#### Tasks
+
+- [ ] 7.1 Remove the four legacy counters
+      (`properties_checked_total`, `properties_prs_created_total`,
+      `properties_set_total`, `properties_already_correct_total`;
+      OQ4 → a) with migration notes in `contrib/README.md`.
+- [ ] 7.2 `docs/operations/scaling.md`: posture architecture,
+      exporter leader semantics, OTEL series catalog, dedup rule.
+- [ ] 7.3 Chart: version + appVersion bump, new values documented via
+      `README.md.gotmpl` (never the rendered README), prometheusrule
+      parity with the generator output.
+- [ ] 7.4 CLAUDE.md: posture-state contract (write-back best-effort,
+      leader-scoped export, taxonomy pointer) and the
+      transport-ordering contract shared with IMPL-0022.
+- [ ] 7.5 Flip INV-0013 to Concluded and DESIGN-0022 to Implemented;
+      `docz update design inv impl`; mkdocs stays at the 14-warning
+      baseline.
+
+#### Success Criteria
+
+- No dangling references to removed counters in code, chart,
+  contrib, or docs.
+- Chart renders and installs with the new values; helm-unittest
+  passes.
+- `make ci` passes.
+
+---
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/store/postgres/migrations/0002_*.sql` | Create | `rule_state`, `compliance_snapshot`, `catalog_parse_ok` column |
+| `internal/store/store.go` + `postgres/postgres.go` | Modify | `RuleState`, `UpsertRuleStates`, posture queries, snapshot insert |
+| `internal/checker/engine.go` | Modify | `CheckRepo` returns `*CheckResult` |
+| `internal/worker/worker.go` | Modify | write-back persists `CheckResult` |
+| `internal/checker/` (new file) | Create | `posture-export` + `compliance-snapshot` schedule handlers |
+| `internal/reconciler/custom_properties.go` | Modify | `property_schema_missing` gauge at cache refresh |
+| `internal/metrics/metrics.go` | Modify | P2 gauges + export health; P7 removes 4 legacy counters |
+| `cmd/repo-guardian/main.go` | Modify | subcommand dispatch, OTEL SDK setup, handler wiring |
+| `internal/github/client.go` / transport wiring | Modify | `installation_info` gauge, otelhttp client transport |
+| `internal/monitoring/` (or per OQ2) | Create | generation model + foundation-sdk panel library |
+| `internal/report/` | Create | report rendering |
+| `internal/config/config.go` | Modify | `POSTURE_EXPORT_INTERVAL`, `COMPLIANCE_SNAPSHOT_INTERVAL` |
+| `charts/repo-guardian/` values + schema + tests | Modify | new intervals; P7 bump |
+| `contrib/grafana/` | Replace | four generated dashboards replace the 61-panel legacy |
+| `contrib/prometheus/alerts.yaml` | Modify | generator-authored parity |
+| `.github/workflows/ci.yml` | Modify | drift-gate job in the paths-filter matrix |
+
+## Testing Plan
+
+- [ ] Migration 0002 up/down integration test (real Postgres,
+      `integration` tag).
+- [ ] `actionable_since` transition table-driven tests + delete-not-in
+      + 16-goroutine upsert race.
+- [ ] Exporter leader-gating and stale-series reset tests (non-vacuity:
+      skip the `Reset()`, confirm failure, restore).
+- [ ] Mock fidelity: `UpsertRuleStates` → `ActionableCounts` is
+      list-then-act — fakes must reflect prior writes (CLAUDE.md
+      rule) or exporter tests are vacuous.
+- [ ] `/metrics` bridge coexistence test + bad-HMAC 401 measurement
+      test.
+- [ ] Report golden files; generator render tests against the pinned
+      Grafana schema; zero-mechanism fixture emits zero mechanism
+      panels/alerts.
+- [ ] Catalog-parse log-line contract test (message + keys).
+- [ ] helm-unittest for new chart values; CI drift gate on the static
+      tier.
+- [ ] Each behavioural test neutralise-verify-restore per standing
+      practice.
+
+## Dependencies
+
+- DESIGN-0022 (all OQs resolved 2026-08-02) — this plan tracks it
+  1:1.
+- IMPL-0022 (DESIGN-0021): no ordering requirement except the shared
+  transport-ordering test and E3/alert content for its queue metrics
+  (generator scoping absorbs the gap).
+- grafana-foundation-sdk requires Grafana ≥ 10 (homelab
+  kube-prometheus-stack satisfies this); grafana-operator present in
+  the cluster for `--format k8s` output (OQ7 → b).
+
+## Open Questions
+
+1. **CLI subcommand dispatch.**
+   (a) Stdlib `flag.FlagSet` per subcommand with an `os.Args[1]`
+   switch in `main()` — `run()` keeps today's flat flags for the
+   server path (zero behaviour change for existing deployments), and
+   `monitoring` / `report` each get their own FlagSet. Two
+   subcommands don't justify a framework dependency, and the repo's
+   12-factor/minimal-dep posture holds.
+   (b) `spf13/cobra` — nicer help/completion and room to grow, at the
+   cost of a dependency tree and restructuring `main()` for a binary
+   that is 95% a server.
+   (c) A separate tiny `cmd/` binary per tool instead of subcommands
+   — contradicts the resolved design OQ5 (a) unless the size delta
+   forces it.
+   other:
+
+2. **Panel-library package location.**
+   (a) `internal/monitoring/` — importable by the generator
+   subcommand, the render tests, and any future operator/sidecar;
+   keeps `cmd/` thin per house convention (`main.go` is already
+   coverage-ignored, so testable logic should not live there).
+   (b) Package under `cmd/repo-guardian/` — co-located with the only
+   caller, but untestable-by-convention and unusable if OQ5's
+   escape hatch to a separate binary ever fires.
+   other:
+
+3. **Grafana schema/version pin for the foundation SDK.**
+   (a) Pin the SDK cohort matching the deployed homelab Grafana major
+   (verify the running version at task 5.2 time; currently the
+   kube-prometheus-stack default, Grafana 11.x) and record it in the
+   panel library's doc comment; bump deliberately with a render test,
+   never transitively via renovate (add a packageRule if renovate
+   proposes cohort jumps).
+   (b) Always track the latest SDK cohort — newest panel features,
+   but generated JSON may outrun the deployed Grafana and fail
+   import silently.
+   other:
+
+4. **Datasource references in generated dashboards.**
+   (a) Template-variable datasources (`${DS_PROMETHEUS}`,
+   `${DS_LOKI}`) declared per dashboard — artifacts stay portable
+   across clusters and the operator binds them at import/CR-apply
+   time; the contrib static tier works anywhere.
+   (b) Hardcode the datasource UIDs via generator flags
+   (`--prometheus-uid`, `--loki-uid`) — zero-click imports on the
+   known cluster, but every regeneration is cluster-specific and the
+   static tier stops being portable.
+   (c) Both: variables by default, optional flags to burn in UIDs —
+   more surface, only worth it if (a) proves annoying in ArgoCD.
+   other:
+
+5. **Release labeling across the per-phase PRs.**
+   (a) `dont-release` on the Phase 1 PR, `minor` on the Phase 2 PR
+   (cutting the schema+exporter release), `minor` on Phase 3,
+   `dont-release` on Phases 4–6 PRs where they are dashboard/contrib
+   heavy with `minor` on whichever PR carries the snapshot/report
+   binary changes, `minor` on Phase 7 (the counter removal). Matches
+   the design's rollout checkpoints; chart version bumps stay manual
+   per house rule.
+   (b) `minor` on every phase PR — more releases, each independently
+   shippable, but ships a schema with no exporter and subcommands
+   with no dashboards.
+   other:
+
+## References
+
+- [DESIGN-0022](../design/0022-compliance-posture-state-dashboard-suite-and-otel-first.md)
+  — the design; all OQs resolved 2026-08-02
+- [INV-0013](../investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md)
+  — findings A–I; the Finding I taxonomy fixes every panel's source
+- [INV-0012](../investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md)
+  — alert-window rules (findings C/E) applied to generated alerts
+- [IMPL-0022](0022-delayed-requeue-job-contract-and-rate-limit-consolidation.md)
+  — shared transport-ordering contract; queue metrics consumed by E3
+- [IMPL-0015](0015-stale-sweep-cutover-and-repository-discovery.md)
+  — the write-back best-effort contract Phase 1 extends
+- [IMPL-0013](0013-reconcile-open-prs-when-file-rules-become-satisfied.md)
+  — `ResetOpenPRsByRule` snapshot-gauge precedent for the exporter
+- grafana-foundation-sdk: <https://github.com/grafana/grafana-foundation-sdk>
+- grafana-operator: <https://github.com/grafana/grafana-operator>
+- OTel Go prometheus bridge:
+  <https://pkg.go.dev/go.opentelemetry.io/otel/exporters/prometheus>

--- a/docs/impl/README.md
+++ b/docs/impl/README.md
@@ -53,4 +53,6 @@ docz create impl "Your Implementation Title"
 | IMPL-0019 | Absent check mode and conditional file rules | Completed | 2026-07-23 | Donald Gifford | [0019-absent-check-mode-and-conditional-file-rules.md](0019-absent-check-mode-and-conditional-file-rules.md) |
 | IMPL-0020 | Pre-IMPL-0019 high-severity fixes (INV-0011 Group A High) | Completed | 2026-07-23 | Donald Gifford | [0020-pre-impl-0019-high-severity-fixes-inv-0011-group-a-high.md](0020-pre-impl-0019-high-severity-fixes-inv-0011-group-a-high.md) |
 | IMPL-0021 | Post-IMPL-0019 hardening and structural cleanup (INV-0011 Group A Medium + Group B) | Completed | 2026-07-23 | Donald Gifford | [0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md](0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md) |
+| IMPL-0022 | Delayed-requeue job contract and rate-limit consolidation | Draft | 2026-08-02 | Donald Gifford | [0022-delayed-requeue-job-contract-and-rate-limit-consolidation.md](0022-delayed-requeue-job-contract-and-rate-limit-consolidation.md) |
+| IMPL-0023 | Compliance posture state, dashboard suite, and OTEL-first observability | Draft | 2026-08-02 | Donald Gifford | [0023-compliance-posture-state-dashboard-suite-and-otel-first.md](0023-compliance-posture-state-dashboard-suite-and-otel-first.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md
+++ b/docs/investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md
@@ -13,6 +13,13 @@ created: 2026-07-25
 **Author:** Donald Gifford
 **Date:** 2026-07-25
 
+> **Scope note.** This investigation outgrew its title. It opened on two
+> narrow follow-ups from IMPL-0021 and ended up in the queue's lease
+> semantics (findings I–K), because the inert BudgetTracker turned out to
+> be a symptom of three rate-limit mechanisms that were never reconciled
+> with each other. The title is kept for traceability with PR #171; the
+> recommendation is about the queue.
+
 <!--toc:start-->
 - [Question](#question)
 - [Hypothesis](#hypothesis)
@@ -28,6 +35,9 @@ created: 2026-07-25
   - [F. The chart and contrib alert packs are near-duplicates with no drift gate](#f-the-chart-and-contrib-alert-packs-are-near-duplicates-with-no-drift-gate)
   - [G. Rate-limit protection is three layers, and the other two work](#g-rate-limit-protection-is-three-layers-and-the-other-two-work)
   - [H. HasFreshSnapshot is a phantom method](#h-hasfreshsnapshot-is-a-phantom-method)
+  - [I. In-handler sleeping amplifies duplicates under exhaustion](#i-in-handler-sleeping-amplifies-duplicates-under-exhaustion)
+  - [J. Duplicate claims steal each other's ack](#j-duplicate-claims-steal-each-others-ack)
+  - [K. The nack contract was never defined, and the worker predates the queue](#k-the-nack-contract-was-never-defined-and-the-worker-predates-the-queue)
 - [Conclusion](#conclusion)
 - [Recommendation](#recommendation)
 - [Open Questions](#open-questions)
@@ -36,7 +46,8 @@ created: 2026-07-25
 
 ## Question
 
-Two questions, joined because the first is a worked example of the second:
+Started as two questions and grew a third, which turned out to be the
+one that matters:
 
 1. Is the IMPL-0015 Phase 1 BudgetTracker doing anything in production, and
    if not, what should happen to it?
@@ -44,6 +55,15 @@ Two questions, joined because the first is a worked example of the second:
    green CI run implies every shipped alert is syntactically valid, can
    fire under realistic conditions, and is fed by a metric something
    actually writes?
+3. *(emergent, findings G–K)* How many ways does repo-guardian manage API
+   rate limits, do they compose, and does the answer to Q1 change once
+   they are counted?
+
+Q3 subsumes Q1. The short version: there are three mechanisms, they were
+designed against two different execution models three months apart, and
+the oldest one is actively hostile to the newest one's lease semantics.
+Wiring the inert third mechanism would have been the fourth path through
+the same problem.
 
 ## Hypothesis
 
@@ -94,6 +114,12 @@ what CI would have to do to catch the class.
    establish whether a CI job is even mechanically possible.
 6. Script a window-vs-`for` comparison across both alert files to size the
    class.
+7. *(added mid-investigation)* Read the Valkey claim/ack/reaper protocol
+   and the transport limiter together, to work out what actually happens
+   to a lease held by a worker that is sleeping rather than working.
+8. *(added mid-investigation)* Date the rate limiter, the legacy
+   in-process queue, and the durable queue against each other to test
+   whether the layers were designed for the same execution model.
 
 ## Environment
 
@@ -345,6 +371,97 @@ refreshes by calling a method that does not exist:
 it matters for the wiring option: the guard the design assumed would keep
 a per-tick refresh cheap has to be written, not just called.
 
+### I. In-handler sleeping amplifies duplicates under exhaustion
+
+Finding G.2 named layer 1's degenerate mode in the abstract. Reading the
+lease machinery makes it concrete, and it is worse than "throughput
+collapse". Four defaults collide:
+
+| Knob | Default | Source |
+|---|---|---|
+| `JOB_ACK_TIMEOUT` | 5m | `config.go:298` |
+| `REAPER_INTERVAL` | 1m | `config.go:305` |
+| `WORKER_COUNT` | 5 | `policy/defaults.go:10` |
+| transport sleep when `remaining == 0` | `untilReset` — **up to 1h** | `ratelimit.go:126` |
+
+There is **no handler timeout anywhere** — nothing in `internal/worker`
+or the Valkey `Subscribe` loop wraps the job in a `context.WithTimeout`.
+So a worker that enters the pre-emptive throttle holds its in-flight
+claim for the whole sleep, and the reaper — which cannot distinguish
+"sleeping" from "crashed", and shouldn't have to — resurfaces the job
+every ack timeout:
+
+```text
+t=0     worker A claims J, ZADD in-flight (score t0), transport sleeps 50m
+t=5m    reaper: J is older than JOB_ACK_TIMEOUT → LPUSH J, ZREM J  (atomic)
+t=5m    worker B claims J, ZADD in-flight (score t5), also sleeps
+t=10m   reaper requeues J again → worker C …
+```
+
+One duplicate per ack timeout for as long as the sleep lasts: roughly ten
+clones of the same job over a 50-minute exhaustion window, against a pool
+of five worker slots. Every clone that eventually wakes issues *more* API
+calls against the exhausted budget. It is a positive feedback loop whose
+trigger is exactly the condition layer 3 was designed to prevent.
+
+Two mitigating facts, for honesty: `sleepWithContext` does respect
+context cancellation, so SIGTERM aborts the sleep cleanly and the job is
+left in-flight for the reaper — shutdown behaves correctly. And the
+pathological delay needs `remaining == 0`; the milder branch
+(`untilReset / remaining`, engaged below `RATE_LIMIT_THRESHOLD`, default
+0.10) yields seconds per request, which stays inside the ack timeout at
+the default `estimatedCostPerRepo` of 10 calls per repo. The cliff is
+sharp rather than gradual.
+
+### J. Duplicate claims steal each other's ack
+
+The in-flight ZSET member is the JSON payload, and `Enqueue` rewrites
+`Job.ID` to a SHA-256 of `(InstallationID, Owner, Repo)` — deterministic
+by design, so duplicate enqueues are visible in dedupe-aware metrics.
+The consequence for finding I's timeline is that workers A and B hold the
+*same ZSET member*. When A finally wakes and `ZREM`s, it deletes **B's**
+claim; B is then invisible to the reaper, so if B dies its job is not
+resurfaced. Benign while both do identical idempotent work, but it means
+the in-flight set does not actually track concurrent claims — it tracks
+distinct payloads.
+
+Also worth recording while in here: `reapOnce` has **no attempt cap and
+no dead-letter path**. A job that fails forever requeues forever. Not
+currently a problem (engine errors are per-repo and usually transient),
+but it is the other half of an undefined nack contract — see finding K.
+
+### K. The nack contract was never defined, and the worker predates the queue
+
+The user framing that prompted this section is borne out by the history:
+
+| Component | Introduced | Assumed execution model |
+|---|---|---|
+| `internal/github/ratelimit.go` | 2026-02-10 (`7c777e5`) | in-process buffered channel — blocking a goroutine is free, there is no lease to hold |
+| `internal/checker/queue.go` (legacy) | 2026-02-08 (`11dfb4d`) | same |
+| `internal/queue`, `internal/worker` | 2026-05-06 (`69a5afd`, IMPL-0011) | durable queue, leases, reaper, at-least-once |
+
+The transport limiter's in-handler blocking was correct for the world it
+was written in: sleeping a goroutine that owns nothing but itself costs
+one goroutine. Three months later work became a durable job with a lease
+and a watchdog, and nothing revisited the assumption. Findings I and J
+are the bill for that.
+
+The deeper gap is that the retry contract was never actually specified.
+`queue.Queue` is three methods, and the only statement of nack semantics
+is a parenthetical on the interface doc comment:
+
+```go
+// A nil return from handler is an implicit ack; an error is a nack
+// (durable implementations may retry; the in-memory implementation
+// logs and drops).
+```
+
+That sentence is now stale on both halves: the in-memory implementation
+was deleted in IMPL-0016, and "may retry" specifies nothing — no delay,
+no backoff, no attempt cap, no distinction between *retry this soon*
+and *retry this later*. `queue.Job` carries no `Attempts` and no
+`AvailableAt`. So there is no contract to break here, only one to write.
+
 ## Conclusion
 
 **Answer to Q1: confirmed — the BudgetTracker is inert.** No production
@@ -375,49 +492,81 @@ that motivated the question — it passes A7's exact shape. Trustworthiness
 needs three separate mechanisms, one per class in finding C, and only the
 cheapest is a promtool job.
 
+**Answer to Q3: three mechanisms, they do not compose, and yes it changes
+Q1's answer.** Layer 1 *slows* (transport, 2026-02-10), layer 2 *skips*
+(sweep gate, IMPL-0011), layer 3 *declines* (BudgetTracker, IMPL-0015).
+Layer 1 predates the durable queue by three months and blocks in-handler,
+which was free when work was a buffered channel and is actively harmful
+now that work carries a lease and a watchdog: findings I and J show it
+producing duplicate execution and worker-pool saturation precisely under
+the exhaustion it exists to handle.
+
+So the honest answer to "should we wire the BudgetTracker" is **no —
+delete it, and fix the queue instead.** Its unique value was keeping
+depleted-budget work out of the queue; a delayed-requeue contract does
+that structurally, and yields better observability as a side effect
+because it measures deferred work rather than modelling it from a
+hand-tuned cost estimate. That reverses this document's own earlier
+recommendation, which is what the investigation was for.
+
 ## Recommendation
 
-Split into two efforts; they share only the `RepoGuardianBudgetGated`
+Findings I–K change the shape of this. The original framing — "should we
+wire the third rate-limit mechanism?" — asks the wrong question. Three
+mechanisms already exist, they do not compose (layer 1 *slows*, layer 2
+*skips*, layer 3 *declines*), and layer 1's slowing is precisely what
+breaks the job-duration assumption the queue's lease semantics depend on.
+Adding a fourth path is not the fix; consolidating onto one is.
+
+Split into two efforts. They share only the `RepoGuardianBudgetGated`
 alert and can proceed independently.
 
-**1. Decide the BudgetTracker's fate (needs a decision, not just code).**
+**1. Consolidate rate-limit handling onto a delayed-requeue contract.**
 
-Finding G reframes this. The question is *not* "do we need rate-limit
-protection" — two working layers already provide it, and the operator can
-already see API pressure via `github_rate_limit_waits_total` and
-`rate_limit_reserve_blocked_total`. The question is whether the two things
-only layer 3 offers are worth the wiring: forward-looking spendable
-capacity, and keeping depleted-budget work *out of the queue* rather than
-letting layer 1 park workers in multi-minute sleeps while holding leases.
+The proposal, which subsumes the BudgetTracker question rather than
+answering it:
 
-- *Wire it.* Add a leader-scoped refresh — the natural home is the
-  `stale-sweep` handler refreshing per installation before its enqueue
-  loop, which is what both consumer comments already assume exists.
-  Requires writing the `HasFreshSnapshot` guard the design assumed
-  (finding H) so a per-tick refresh does not itself become the cost it is
-  meant to protect: at the planned 20+ orgs that is 20 extra calls per
-  tick against the very budget in question.
-- *Delete it.* Layers 1 and 2 cover protection; the unique value is
-  narrow. Removes 9 metrics, 1 alert, 4 env vars, 2 chart values, and
-  their schema ranges. Honest about what ships, at the cost of a
-  user-facing removal of published chart values.
-- *Leave it, documented.* Worst option — an operator tuning
-  `DISCOVERY_RESERVE_FRACTION` deserves to know nothing reads it.
+- **Workers never block on rate limits.** When a job cannot proceed
+  because the installation is throttled, the worker *returns the job to
+  the queue with `available_at = now + delay`* and frees its slot
+  immediately. Nothing sleeps while holding a lease.
+- **The queue grows a delayed set.** A `queue:delayed` ZSET scored by
+  due-time, promoted to `queue:jobs` by the reaper — which is already
+  leader-elected and already runs on a timer, so the machinery exists.
+  This is the same primitive the in-flight ZSET uses.
+- **The contract gets written.** `queue.Job` gains `Attempts` and
+  `AvailableAt`; the `Queue` doc comment stops saying "durable
+  implementations may retry" and starts specifying delay, backoff, and
+  an attempt cap with a terminal disposition (finding J notes there is
+  no cap today). Per finding K there is no existing contract to break —
+  only one to define, and Go's interfaces mean this can land under
+  `queue.Queue` without disturbing producers.
+- **The observability falls out of it.** `jobs_delayed_total{reason,
+  installation_id}` and a `queue_delayed_depth` gauge answer "are we
+  hitting API limits, how hard, and for whom" with *better* data than
+  `api_budget_spendable` would have: they measure work actually deferred
+  rather than a modelled estimate built on a hand-tuned
+  `estimatedCostPerRepo`. The goal is watching for backpressure and
+  alerting before it matters — realistically never, at the current or
+  planned fleet size, but with data to reason from if it does.
 
-Recommend **wire it**, but on the queue-health argument (G.2), not the
-"otherwise unprotected" one — that argument does not survive finding G.
-If the wiring turns out to need more than a refresh call plus the
-`HasFreshSnapshot` guard, delete rather than leave: a half-wired budget
-gate is worse than an honest absence, because its metrics look like
-coverage.
+What that implies for the three existing layers:
 
-A cheaper middle option worth considering explicitly: **wire the refresh
-for the metrics and leave both gates falling open.** That buys the
-observability the feature was designed to provide (G.1) with none of the
-behavioural risk of a gate that has never run in production against a
-real fleet — and the gates can be enabled later once
-`estimatedCostPerRepo` has been calibrated against observed consumption,
-which is exactly what the design says the knob is for.
+| Layer | Disposition under this proposal |
+|---|---|
+| 1 — transport pre-emptive sleep | **Remove the sleep, keep the accounting.** The 403 retry paths stay (they are transport concerns); the pre-emptive `sleepWithContext` becomes a typed error the worker translates into a delayed requeue. This alone defuses findings I and J. |
+| 2 — sweep reserve gate | **Probably redundant.** Skipping the enqueue and deferring it converge, except deferral doesn't silently drop the repo until the next sweep. Candidate for removal, but it works today — decide with data, not ahead of it. |
+| 3 — BudgetTracker | **Delete.** Its unique value was G.1 (forward-looking capacity) and G.2 (keeping work out of the queue). The delayed-requeue mechanism delivers G.2 structurally and replaces G.1's modelled estimate with measurement. Wiring it now would be building the fourth path. |
+
+That reverses this document's earlier recommendation to wire it, and the
+reversal is the point: the inert tracker was the symptom that led here,
+but the fix is in the queue, not the tracker.
+
+**Sequencing note.** The unbounded sleep is a live amplification hazard
+independent of any redesign. Capping the transport delay below
+`JOB_ACK_TIMEOUT` (or adding a handler timeout) is a small change that
+defuses findings I and J on its own and should not wait for the
+consolidation work.
 
 **2. Make the alert pack trustworthy, cheapest class first.**
 
@@ -439,33 +588,42 @@ which is exactly what the design says the knob is for.
 
 ## Open Questions
 
-1. **BudgetTracker disposition** — (a) wire the refresh **and** both
-   gates, via a leader-scoped refresh in the `stale-sweep` handler;
-   (b) wire the refresh for metrics only, leaving both gates falling open
-   until `estimatedCostPerRepo` is calibrated against observed
-   consumption; (c) delete the feature and its user-facing knobs;
-   (d) leave it and document that it is inert. other:
-1a. **If wiring — who owns the refresh?** (a) `stale-sweep` refreshes and
-   `Discoverer` reuses the shared snapshot (matches what the
-   `Discoverer` comment already claims); (b) each refreshes
-   independently, doubling the calls but removing the ordering
-   dependency between two separately-scheduled handlers. other:
-1b. **If wiring — refresh cadence.** `HasFreshSnapshot` does not exist
-   (finding H) and must be written. What counts as fresh: (a) one
-   refresh per installation per tick; (b) TTL-based, decoupled from tick
-   cadence; (c) refresh only when `SpendableForEnqueue` reports
-   `ErrNoSnapshot`, which is what the current `resetAt`-elapsed branch
-   already implies. other:
-2. **Alert-pack source of truth** — (a) leave the chart and `contrib/`
+1. **Scope of the consolidation** — (a) one effort covering the delayed
+   requeue, the `queue.Job`/`Queue` contract, and the disposition of all
+   three layers; (b) split the immediate sleep-cap hotfix from the
+   redesign; (c) hotfix only, defer the redesign until a real fleet
+   produces backpressure data. other:
+2. **Layer 2's fate** — the `StaleSweeper` reserve gate becomes largely
+   redundant under delayed requeue: (a) remove it once the requeue path
+   ships; (b) keep it as cheap enqueue-side admission control; (c) decide
+   after observing `jobs_delayed_total` in production. other:
+3. **Attempt cap and terminal disposition** — the contract needs one
+   (finding J: none today): (a) cap attempts and drop with a counter;
+   (b) cap and move to a `queue:dead` ZSET for inspection; (c) cap and
+   write terminal failure to `repo_state` so the existing store is the
+   dead-letter record. other:
+4. **`AvailableAt` ownership** — (a) worker computes the delay and the
+   queue honours it; (b) queue owns backoff policy and the worker only
+   signals "throttled"; (c) transport returns a typed error carrying
+   GitHub's own `resetAt`, which the worker passes through unmodified.
+   other:
+5. **BudgetTracker removal timing** — (a) delete in the same effort as
+   the requeue work, so no window exists where neither mechanism runs;
+   (b) delete immediately as dead code, since it has never run; (c) keep
+   the `internal/budget` package but strip its gates, reusing the
+   snapshot cache for the delayed-requeue delay calculation. other:
+6. **Alert-pack source of truth** — (a) leave the chart and `contrib/`
    packs as independent copies and add a CI drift check; (b) generate
    `contrib/` from the chart template; (c) leave as-is, accept drift.
    other:
-3. **Class-3 detection** — is a "every alerted metric has a production
+7. **Class-3 detection** — is a "every alerted metric has a production
    writer" check worth building, or is it enough to have found this one by
    hand? other:
-4. **Scope** — should the alert work be its own DESIGN, or is it small
-   enough to go straight to an IMPL once the open questions above are
-   answered? other:
+8. **Doc scope** — the consolidation is now clearly a DESIGN, not an
+   IMPL: (a) one DESIGN covering queue contract + rate-limit
+   consolidation; (b) that DESIGN plus a separate small IMPL for the
+   alert-pack work, which is independent; (c) fold the alert work into
+   the same DESIGN. other:
 
 ## References
 

--- a/docs/investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md
+++ b/docs/investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md
@@ -26,6 +26,8 @@ created: 2026-07-25
   - [D. helm template | yq | promtool works today](#d-helm-template--yq--promtool-works-today)
   - [E. Six alerts pair a window shorter than their for](#e-six-alerts-pair-a-window-shorter-than-their-for)
   - [F. The chart and contrib alert packs are near-duplicates with no drift gate](#f-the-chart-and-contrib-alert-packs-are-near-duplicates-with-no-drift-gate)
+  - [G. Rate-limit protection is three layers, and the other two work](#g-rate-limit-protection-is-three-layers-and-the-other-two-work)
+  - [H. HasFreshSnapshot is a phantom method](#h-hasfreshsnapshot-is-a-phantom-method)
 - [Conclusion](#conclusion)
 - [Recommendation](#recommendation)
 - [Open Questions](#open-questions)
@@ -47,14 +49,21 @@ Two questions, joined because the first is a worked example of the second:
 
 1. The tracker is inert: `RefreshFromAPI` has no production caller, so
    every `SpendableForEnqueue` returns `ErrNoSnapshot`, both gates fall
-   open, and the four budget gauges are never published.
+   open, and the four budget gauges are never published. Corollary
+   assumed at the outset: that this leaves rate-limit pressure
+   under-observed.
 2. Adding promtool coverage for the chart's `PrometheusRule` would close
    the alert gap.
 
-Hypothesis 1 is confirmed below. **Hypothesis 2 is refuted** — promtool
-passes the exact defect INV-0011 A7 fixed. That refutation is the most
-useful thing in this document; it means "add promtool to CI" is not the
-remediation, only a floor.
+Hypothesis 1's mechanism is confirmed below, but **its corollary is
+refuted** (finding G): two other rate-limit layers work, and the operator
+can already see API pressure without the tracker. **Hypothesis 2 is
+refuted outright** — promtool passes the exact defect INV-0011 A7 fixed.
+
+Those two refutations are the most useful things in this document. The
+first means the tracker's disposition turns on queue health and
+forward-looking capacity, not on protection. The second means "add
+promtool to CI" is a floor, not the remediation.
 
 ## Context
 
@@ -125,12 +134,13 @@ the write paths:
 
 So the entire IMPL-0015 Phase 1 budget feature — 9 metrics, 1 alert, 4 env
 vars, 2 chart values, and the values.schema.json ranges validating them —
-is dead weight at runtime. Nothing is *broken* by this (falling open is the
-documented fail-safe, and the live `RateLimitRemaining` reserve gate in
-`StaleSweeper` is a separate, working defence), but operators are tuning
-`DISCOVERY_RESERVE_FRACTION` and `DISCOVERY_ESTIMATED_COST_PER_REPO`
-against a component that never reads them, and an empty budget dashboard
-reads as "healthy" rather than "not wired".
+is dead weight at runtime. Nothing is *broken* by this — falling open is
+the documented fail-safe, and two other rate-limit layers work (finding G,
+which revises this paragraph's first draft, where I had counted one) — but
+operators are tuning `DISCOVERY_RESERVE_FRACTION` and
+`DISCOVERY_ESTIMATED_COST_PER_REPO` against a component that never reads
+them, and an empty budget dashboard reads as "healthy" rather than "not
+wired".
 
 ### B. Both consumers defer the refresh to each other
 
@@ -280,14 +290,84 @@ fix to a shared alert can silently apply to one copy. Whether these should
 be one source with the other generated is a design question, not a defect
 — recorded here so the eventual alert work considers it.
 
+### G. Rate-limit protection is three layers, and the other two work
+
+Finding A called the `StaleSweeper` reserve gate "a separate, working
+defence." That understated it — there are **two** working layers, and the
+one that most directly answers "are we hammering the API?" is the one this
+investigation nearly missed:
+
+| # | Layer | Where | Behaviour under pressure | Metrics | Status |
+|---|---|---|---|---|---|
+| 1 | Transport limiter | `internal/github/ratelimit.go`, wrapping **every** client (app + per-installation, `client.go:59` and `:1019`) | pre-emptively *sleeps* `untilReset / remaining` per request; retries primary (403 + `Remaining: 0`) and secondary (`Retry-After`) limits | `github_rate_remaining`, `github_rate_limit_waits_total{reason}`, `github_rate_limit_wait_seconds` | **works** |
+| 2 | Sweep reserve gate | `StaleSweeper.allowedByRateLimit`, IMPL-0011 P5 | *skips* the repo when `remaining < reserve × limit` | `rate_limit_remaining`, `rate_limit_reserve_blocked_total` | **works** |
+| 3 | BudgetTracker | IMPL-0015 P1 | would *decline the enqueue* before work is created | the 9 `api_budget_*` / `enqueue_gated_by_budget_total` metrics | **inert** (finding A) |
+
+Two consequences that change the disposition question:
+
+- **The "smashing into API limits" signal already exists.**
+  `github_rate_limit_waits_total` literally counts throttle events by
+  reason, and `RepoGuardianRateLimitLow` / `RepoGuardianRateLimitThrottling`
+  / `RepoGuardianRateLimitNearExhaustion` all fire off working metrics.
+  Losing layer 3 does not blind the operator to rate-limit pressure.
+- **The `Discoverer` is not ungated.** It has no layer-2 equivalent
+  (`DiscovererOptions` carries `Budget` but no `RateLimit`), but layer 1
+  wraps its `ListInstallationRepos` calls like everything else. Under
+  pressure discovery goes *slow*, not unbounded.
+
+What layer 3 uniquely adds is therefore **not** protection or basic
+visibility, but two narrower things:
+
+1. *Forward-looking capacity* — `api_budget_spendable` answers "how many
+   repos can I still afford this hour", which neither reactive layer
+   does, and `estimatedCostPerRepo` is the knob for calibrating it
+   against observed consumption.
+2. *Avoiding layer 1's degenerate mode* — layer 1 spreads a depleted
+   budget by sleeping `untilReset / remaining` **per request**. With a
+   full queue that parks worker goroutines in long sleeps while holding
+   queue leases, which is a throughput collapse plus reaper churn, not a
+   graceful slowdown. Layer 3 prevents the enqueue instead, so the work
+   is never created. This is the strongest argument for wiring it, and
+   it is about *queue health*, not about the rate limit itself.
+
+### H. `HasFreshSnapshot` is a phantom method
+
+`RefreshFromAPI`'s doc comment instructs callers to avoid redundant
+refreshes by calling a method that does not exist:
+
+```go
+// Always replaces the existing snapshot; callers that want to avoid
+// redundant refreshes should call HasFreshSnapshot first.
+```
+
+`Tracker` has exactly four methods — `RefreshFromAPI`,
+`SpendableForEnqueue`, `Decrement`, `publishGauges`. Minor on its own, but
+it matters for the wiring option: the guard the design assumed would keep
+a per-tick refresh cheap has to be written, not just called.
+
 ## Conclusion
 
 **Answer to Q1: confirmed — the BudgetTracker is inert.** No production
 code path writes a snapshot, so all nine budget metrics stay unpublished,
 both gates permanently fall open, and `RepoGuardianBudgetGated` cannot
-fire. The failure is fail-safe (nothing over-enqueues; the independent
-live rate-limit reserve gate still works), so this is wasted capability
-and misleading observability rather than an outage.
+fire.
+
+The severity is lower than it first reads, though, and finding G is why:
+rate-limit protection is **three** layers deep, not two, and the other two
+work. The transport limiter (`internal/github/ratelimit.go`) wraps every
+API call with pre-emptive throttling and 403 retry; the `StaleSweeper`
+reserve gate skips repos below the reserve floor. Between them the
+operator can already answer "are we hammering the API?" —
+`github_rate_limit_waits_total` counts throttle events directly, and three
+alerts fire off working metrics. So this is wasted capability plus a
+misleading empty dashboard, not an unprotected system.
+
+What is genuinely lost is narrower and worth naming precisely: the
+forward-looking `api_budget_spendable` view, the ability to calibrate
+`estimatedCostPerRepo` against real consumption, and — the one that would
+actually bite at fleet scale — protection against layer 1's degenerate
+mode, where a depleted budget parks worker goroutines in per-request
+sleeps while they hold queue leases.
 
 **Answer to Q2: the original framing was wrong.** Chart alerts genuinely
 have no promtool coverage, but promtool does not catch the class of defect
@@ -301,27 +381,43 @@ Split into two efforts; they share only the `RepoGuardianBudgetGated`
 alert and can proceed independently.
 
 **1. Decide the BudgetTracker's fate (needs a decision, not just code).**
-Three options, in ascending cost:
 
-- *Delete it.* The live `RateLimitRemaining` reserve gate in `StaleSweeper`
-  already provides rate-limit protection. Removes 9 metrics, 1 alert, 4 env
-  vars, 2 chart values, and their schema ranges. Cheapest, and honest about
-  what ships.
+Finding G reframes this. The question is *not* "do we need rate-limit
+protection" — two working layers already provide it, and the operator can
+already see API pressure via `github_rate_limit_waits_total` and
+`rate_limit_reserve_blocked_total`. The question is whether the two things
+only layer 3 offers are worth the wiring: forward-looking spendable
+capacity, and keeping depleted-budget work *out of the queue* rather than
+letting layer 1 park workers in multi-minute sleeps while holding leases.
+
 - *Wire it.* Add a leader-scoped refresh — the natural home is the
   `stale-sweep` handler refreshing per installation before its enqueue
   loop, which is what both consumer comments already assume exists.
-  Preserves the design intent of IMPL-0015 Phase 1; needs care that a
-  refresh per sweep does not itself become the rate-limit cost it is
-  meant to protect.
-- *Leave it, documented.* Cheapest in effort, worst in honesty — an
-  operator tuning `DISCOVERY_RESERVE_FRACTION` deserves to know it is read
-  by nothing.
+  Requires writing the `HasFreshSnapshot` guard the design assumed
+  (finding H) so a per-tick refresh does not itself become the cost it is
+  meant to protect: at the planned 20+ orgs that is 20 extra calls per
+  tick against the very budget in question.
+- *Delete it.* Layers 1 and 2 cover protection; the unique value is
+  narrow. Removes 9 metrics, 1 alert, 4 env vars, 2 chart values, and
+  their schema ranges. Honest about what ships, at the cost of a
+  user-facing removal of published chart values.
+- *Leave it, documented.* Worst option — an operator tuning
+  `DISCOVERY_RESERVE_FRACTION` deserves to know nothing reads it.
 
-Recommend **wire it**, on the grounds that the reserve fraction and
-cost-per-repo knobs are already published in the chart's values schema and
-documented in `scaling.md`; deleting them is a user-facing removal, and
-the wiring is a single refresh call in a handler that already iterates
-installations. If that proves awkward, delete rather than leave.
+Recommend **wire it**, but on the queue-health argument (G.2), not the
+"otherwise unprotected" one — that argument does not survive finding G.
+If the wiring turns out to need more than a refresh call plus the
+`HasFreshSnapshot` guard, delete rather than leave: a half-wired budget
+gate is worse than an honest absence, because its metrics look like
+coverage.
+
+A cheaper middle option worth considering explicitly: **wire the refresh
+for the metrics and leave both gates falling open.** That buys the
+observability the feature was designed to provide (G.1) with none of the
+behavioural risk of a gate that has never run in production against a
+real fleet — and the gates can be enabled later once
+`estimatedCostPerRepo` has been calibrated against observed consumption,
+which is exactly what the design says the knob is for.
 
 **2. Make the alert pack trustworthy, cheapest class first.**
 
@@ -343,10 +439,23 @@ installations. If that proves awkward, delete rather than leave.
 
 ## Open Questions
 
-1. **BudgetTracker disposition** — (a) wire it via a leader-scoped refresh
-   in the `stale-sweep` handler; (b) delete the feature and its
-   user-facing knobs; (c) leave it and document that it is inert.
-   other:
+1. **BudgetTracker disposition** — (a) wire the refresh **and** both
+   gates, via a leader-scoped refresh in the `stale-sweep` handler;
+   (b) wire the refresh for metrics only, leaving both gates falling open
+   until `estimatedCostPerRepo` is calibrated against observed
+   consumption; (c) delete the feature and its user-facing knobs;
+   (d) leave it and document that it is inert. other:
+1a. **If wiring — who owns the refresh?** (a) `stale-sweep` refreshes and
+   `Discoverer` reuses the shared snapshot (matches what the
+   `Discoverer` comment already claims); (b) each refreshes
+   independently, doubling the calls but removing the ordering
+   dependency between two separately-scheduled handlers. other:
+1b. **If wiring — refresh cadence.** `HasFreshSnapshot` does not exist
+   (finding H) and must be written. What counts as fresh: (a) one
+   refresh per installation per tick; (b) TTL-based, decoupled from tick
+   cadence; (c) refresh only when `SpendableForEnqueue` reports
+   `ErrNoSnapshot`, which is what the current `resetAt`-elapsed branch
+   already implies. other:
 2. **Alert-pack source of truth** — (a) leave the chart and `contrib/`
    packs as independent copies and add a CI drift check; (b) generate
    `contrib/` from the chart template; (c) leave as-is, accept drift.

--- a/docs/investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md
+++ b/docs/investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md
@@ -40,7 +40,6 @@ created: 2026-07-25
   - [K. The nack contract was never defined, and the worker predates the queue](#k-the-nack-contract-was-never-defined-and-the-worker-predates-the-queue)
 - [Conclusion](#conclusion)
 - [Recommendation](#recommendation)
-- [Open Questions](#open-questions)
 - [References](#references)
 <!--toc:end-->
 
@@ -585,45 +584,6 @@ consolidation work.
   cheap approximation: assert every metric named in an alert expression
   has at least one non-test writer in the Go source. Whether that is worth
   building is an open question.
-
-## Open Questions
-
-1. **Scope of the consolidation** — (a) one effort covering the delayed
-   requeue, the `queue.Job`/`Queue` contract, and the disposition of all
-   three layers; (b) split the immediate sleep-cap hotfix from the
-   redesign; (c) hotfix only, defer the redesign until a real fleet
-   produces backpressure data. other:
-2. **Layer 2's fate** — the `StaleSweeper` reserve gate becomes largely
-   redundant under delayed requeue: (a) remove it once the requeue path
-   ships; (b) keep it as cheap enqueue-side admission control; (c) decide
-   after observing `jobs_delayed_total` in production. other:
-3. **Attempt cap and terminal disposition** — the contract needs one
-   (finding J: none today): (a) cap attempts and drop with a counter;
-   (b) cap and move to a `queue:dead` ZSET for inspection; (c) cap and
-   write terminal failure to `repo_state` so the existing store is the
-   dead-letter record. other:
-4. **`AvailableAt` ownership** — (a) worker computes the delay and the
-   queue honours it; (b) queue owns backoff policy and the worker only
-   signals "throttled"; (c) transport returns a typed error carrying
-   GitHub's own `resetAt`, which the worker passes through unmodified.
-   other:
-5. **BudgetTracker removal timing** — (a) delete in the same effort as
-   the requeue work, so no window exists where neither mechanism runs;
-   (b) delete immediately as dead code, since it has never run; (c) keep
-   the `internal/budget` package but strip its gates, reusing the
-   snapshot cache for the delayed-requeue delay calculation. other:
-6. **Alert-pack source of truth** — (a) leave the chart and `contrib/`
-   packs as independent copies and add a CI drift check; (b) generate
-   `contrib/` from the chart template; (c) leave as-is, accept drift.
-   other:
-7. **Class-3 detection** — is a "every alerted metric has a production
-   writer" check worth building, or is it enough to have found this one by
-   hand? other:
-8. **Doc scope** — the consolidation is now clearly a DESIGN, not an
-   IMPL: (a) one DESIGN covering queue contract + rate-limit
-   consolidation; (b) that DESIGN plus a separate small IMPL for the
-   alert-pack work, which is independent; (c) fold the alert work into
-   the same DESIGN. other:
 
 ## References
 

--- a/docs/investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md
+++ b/docs/investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md
@@ -1,0 +1,372 @@
+---
+id: INV-0012
+title: "Inert BudgetTracker and untrustworthy alert pack"
+status: Open
+author: Donald Gifford
+created: 2026-07-25
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# INV 0012: Inert BudgetTracker and untrustworthy alert pack
+
+**Status:** Open
+**Author:** Donald Gifford
+**Date:** 2026-07-25
+
+<!--toc:start-->
+- [Question](#question)
+- [Hypothesis](#hypothesis)
+- [Context](#context)
+- [Approach](#approach)
+- [Environment](#environment)
+- [Findings](#findings)
+  - [A. The BudgetTracker never gets a snapshot in production](#a-the-budgettracker-never-gets-a-snapshot-in-production)
+  - [B. Both consumers defer the refresh to each other](#b-both-consumers-defer-the-refresh-to-each-other)
+  - [C. Chart alerts get no promtool check — but promtool would not have caught A7](#c-chart-alerts-get-no-promtool-check--but-promtool-would-not-have-caught-a7)
+  - [D. helm template | yq | promtool works today](#d-helm-template--yq--promtool-works-today)
+  - [E. Six alerts pair a window shorter than their for](#e-six-alerts-pair-a-window-shorter-than-their-for)
+  - [F. The chart and contrib alert packs are near-duplicates with no drift gate](#f-the-chart-and-contrib-alert-packs-are-near-duplicates-with-no-drift-gate)
+- [Conclusion](#conclusion)
+- [Recommendation](#recommendation)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Question
+
+Two questions, joined because the first is a worked example of the second:
+
+1. Is the IMPL-0015 Phase 1 BudgetTracker doing anything in production, and
+   if not, what should happen to it?
+2. What would it take for the alert pack to be **trustworthy** — meaning a
+   green CI run implies every shipped alert is syntactically valid, can
+   fire under realistic conditions, and is fed by a metric something
+   actually writes?
+
+## Hypothesis
+
+1. The tracker is inert: `RefreshFromAPI` has no production caller, so
+   every `SpendableForEnqueue` returns `ErrNoSnapshot`, both gates fall
+   open, and the four budget gauges are never published.
+2. Adding promtool coverage for the chart's `PrometheusRule` would close
+   the alert gap.
+
+Hypothesis 1 is confirmed below. **Hypothesis 2 is refuted** — promtool
+passes the exact defect INV-0011 A7 fixed. That refutation is the most
+useful thing in this document; it means "add promtool to CI" is not the
+remediation, only a floor.
+
+## Context
+
+Both items were found while implementing
+[IMPL-0021](../impl/0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md)
+and deliberately left unfixed there — each is a behavioral change needing
+its own decision, and IMPL-0021 was already a 17-commit `patch`.
+
+INV-0011 finding A7 was "`RepoGuardianPropertySchemaMissing` pairs
+`rate(...[15m]) > 0` with `for: 30m`, so it can never fire." IMPL-0021
+Phase 4 fixed that one alert. The question this investigation exists to
+answer is whether A7 was a one-off or the visible instance of a class, and
+what CI would have to do to catch the class.
+
+**Triggered by:** IMPL-0021 (PR #169), INV-0011 A7, IMPL-0015 Phase 1
+
+## Approach
+
+1. Grep every caller of `budget.Tracker.RefreshFromAPI` across production
+   and test code; trace what each budget metric's write path depends on.
+2. Read both budget gates (`StaleSweeper`, `Discoverer`) and record what
+   each assumes about who refreshes.
+3. Check the CI gate for `make lint-alerts` against the files that
+   actually contain alerts.
+4. Feed promtool a rule with the exact A7 shape and see whether it
+   complains.
+5. Try to render and validate the chart's `PrometheusRule` end to end, to
+   establish whether a CI job is even mechanically possible.
+6. Script a window-vs-`for` comparison across both alert files to size the
+   class.
+
+## Environment
+
+| Component | Version / Value |
+|-----------|----------------|
+| repo-guardian | `main` @ `f4390bf` (post IMPL-0021) |
+| chart / appVersion | 1.0.0-rc.9 / 1.10.1 |
+| promtool | mise-managed (`prometheus` latest) |
+| helm / yq | 4.2.2 / 4.48.1 |
+| `RECONCILE_FRESHNESS` | 24h (default) |
+
+## Findings
+
+### A. The BudgetTracker never gets a snapshot in production
+
+`RefreshFromAPI` is the only method that writes a snapshot, and every one
+of its 13 call sites is a test:
+
+```console
+$ grep -rn "RefreshFromAPI" --include='*.go' . | grep -v _test.go
+internal/budget/budget.go:106:// RefreshFromAPI fetches the current rate-limit budget for
+internal/budget/budget.go:110:func (t *Tracker) RefreshFromAPI(...) error {
+```
+
+`main.go` constructs the tracker (`bringUp`, ~line 164) and threads it into
+`StaleSweeperOptions.Budget` and `DiscovererOptions.Budget`, but nothing
+ever calls `RefreshFromAPI` on it. Consequences, all verified by reading
+the write paths:
+
+| Symptom | Mechanism |
+|---|---|
+| Both budget gates always fall open | `SpendableForEnqueue` hits `!ok` on the empty `snapshots` map → `ErrNoSnapshot` → both callers `return true` |
+| `api_budget_{remaining,spendable,reserve_fraction,utilisation}` never published | all four are written only by `publishGauges` (called from `RefreshFromAPI`) or by `SpendableForEnqueue`'s success path, which is unreachable |
+| `api_budget_refresh_total` never increments | incremented inside `RefreshFromAPI` |
+| `enqueue_gated_by_budget_total` never increments | both increments sit behind a `spendable <= 0` branch that requires a snapshot |
+| `RepoGuardianBudgetGated` can never fire | its input metric is the counter above |
+| `Decrement` is a silent no-op | early-returns on `!ok` before touching the gauge |
+
+So the entire IMPL-0015 Phase 1 budget feature — 9 metrics, 1 alert, 4 env
+vars, 2 chart values, and the values.schema.json ranges validating them —
+is dead weight at runtime. Nothing is *broken* by this (falling open is the
+documented fail-safe, and the live `RateLimitRemaining` reserve gate in
+`StaleSweeper` is a separate, working defence), but operators are tuning
+`DISCOVERY_RESERVE_FRACTION` and `DISCOVERY_ESTIMATED_COST_PER_REPO`
+against a component that never reads them, and an empty budget dashboard
+reads as "healthy" rather than "not wired".
+
+### B. Both consumers defer the refresh to each other
+
+The two gates each document their fall-open path by pointing at the other
+one as the thing that populates the cache:
+
+```go
+// internal/checker/sweep.go
+return true // fall open — caller drives refresh elsewhere
+```
+
+```go
+// internal/scheduler/discoverer.go
+if errors.Is(err, budget.ErrNoSnapshot) {
+    // No snapshot — fall open; the StaleSweeper's leader-driven
+    // refresh path will populate it.
+    return true
+}
+```
+
+There is no StaleSweeper leader-driven refresh path. This is the mechanism
+by which the gap survived review: each side's comment is locally plausible
+and cites a neighbour, and no test covers "who calls RefreshFromAPI",
+because every test calls it directly in setup. Worth noting for its own
+sake — the same shape (two components each deferring to the other, tests
+that stub the seam) will hide the next one too.
+
+### C. Chart alerts get no promtool check — but promtool would not have caught A7
+
+The CI job and the make target are both scoped to `contrib/`:
+
+```yaml
+# .github/workflows/ci.yml
+lint-alerts:
+  if: needs.changes.outputs.alerts == 'true' || needs.changes.outputs.workflows == 'true'
+#   filter → alerts: ['contrib/prometheus/**']
+```
+
+```make
+lint-alerts:
+	@promtool check rules contrib/prometheus/alerts.yaml
+```
+
+The chart's 9 alerts in `charts/repo-guardian/templates/prometheusrule.yaml`
+are never checked — that part of the original framing holds. helm-unittest
+asserts rendered strings, not PromQL validity.
+
+**But promtool would not have caught A7.** Fed a rule with the exact
+defective shape:
+
+```console
+$ cat /tmp/badrule.yaml
+groups:
+  - name: probe
+    rules:
+      - alert: WindowShorterThanFor
+        expr: increase(some_counter_total[15m]) > 0
+        for: 30m
+$ promtool check rules /tmp/badrule.yaml
+Checking /tmp/badrule.yaml
+  SUCCESS: 1 rules found
+```
+
+`promtool check rules` is a **syntax** checker: PromQL parses, durations
+are well-formed, labels are valid. Fireability is semantic and out of its
+scope. So the honest decomposition is three distinct defect classes, only
+the first of which promtool addresses:
+
+| Class | Example | Caught by |
+|---|---|---|
+| Syntax — malformed PromQL, bad duration, typo'd function | — | `promtool check rules` |
+| Semantic fireability — window vs `for`, window vs the metric's sampling cadence | A7 | `promtool test rules` with synthetic series, or a custom lint |
+| Dead input — the metric has no production writer | `RepoGuardianBudgetGated` (finding A) | neither; needs a metric-writer audit |
+
+A7 was class 2. `RepoGuardianBudgetGated` is class 3. Adding promtool to
+CI closes class 1 only — worth doing, but it must not be mistaken for
+closing the gap that motivated this investigation.
+
+### D. `helm template | yq | promtool` works today
+
+Mechanically possible with tools already in `mise.toml`, verified end to
+end:
+
+```console
+$ helm template rg charts/repo-guardian \
+    --set config.appId=1 --set secrets.webhookSecret=x --set secrets.privateKey=y \
+    --set store.dsn=postgres://x --set queue.valkey.dsn=redis://x \
+    --set prometheusRule.enabled=true \
+  | yq 'select(.kind == "PrometheusRule") | .spec' > /tmp/rr.yaml
+$ promtool check rules /tmp/rr.yaml
+Checking /tmp/rr.yaml
+  SUCCESS: 9 rules found
+```
+
+Two notes for whoever implements it: `prometheusRule.enabled` defaults to
+`false`, so the job must set it explicitly or it silently checks nothing
+(the same "0 rules found — SUCCESS" trap this probe hit on the first
+attempt); and the `.spec` extraction is required because promtool wants a
+bare rules file, not the CRD wrapper.
+
+### E. Six alerts pair a window shorter than their `for`
+
+Scripted comparison across both files:
+
+```text
+contrib/prometheus/alerts.yaml: 4
+    RepoGuardianWebhookRejectionsHigh   window [15m], for 30m
+    RepoGuardianRuleNeverApplies        window [1h],  for 6h
+    RepoGuardianStoreQueryErrors        window [5m],  for 10m
+    RepoGuardianBudgetGated             window [15m], for 30m
+charts/.../prometheusrule.yaml: 2
+    RepoGuardianStoreQueryErrors        window [5m],  for 10m
+    RepoGuardianBudgetGated             window [15m], for 30m
+```
+
+**This is a smell, not six bugs, and the distinction matters.** For a
+metric that increments continuously while the problem persists,
+`rate(...[5m]) > 0 for 10m` fires correctly — the expression stays true
+across the pending period. A7 was fatal because its metric samples roughly
+*once per 24h* (one observation per repo per reconcile, and
+`RECONCILE_FRESHNESS` defaults to 24h), so the 15m window was empty almost
+always and the condition could not stay true for 30m.
+
+Each of the six needs judging against its own metric's cadence, not a
+blanket rewrite. `RepoGuardianRuleNeverApplies` (1h window, 6h `for`) and
+`RepoGuardianStoreQueryErrors` (5m/10m) look like the highest-risk of the
+remainder; `RepoGuardianBudgetGated` is moot until finding A is resolved.
+
+### F. The chart and contrib alert packs are near-duplicates with no drift gate
+
+8 of the chart's 9 alerts also exist in `contrib/prometheus/alerts.yaml`
+(`RepoGuardianPropertySchemaMissing` is chart-only). The chart version is
+the contrib expression with the threshold and `for` templated:
+
+```yaml
+# contrib
+expr: max(repo_guardian_queue_depth{queue="jobs"}) > 1000
+for: 10m
+# chart
+expr: max(repo_guardian_queue_depth{queue="jobs"}) > {{ default 1000 (get $alert "threshold") }}
+for: {{ default "10m" (get $alert "for") | quote }}
+```
+
+Nothing enforces the correspondence. IMPL-0021's A7 fix landed in the
+chart only, which was correct there (chart-only alert) but means the next
+fix to a shared alert can silently apply to one copy. Whether these should
+be one source with the other generated is a design question, not a defect
+— recorded here so the eventual alert work considers it.
+
+## Conclusion
+
+**Answer to Q1: confirmed — the BudgetTracker is inert.** No production
+code path writes a snapshot, so all nine budget metrics stay unpublished,
+both gates permanently fall open, and `RepoGuardianBudgetGated` cannot
+fire. The failure is fail-safe (nothing over-enqueues; the independent
+live rate-limit reserve gate still works), so this is wasted capability
+and misleading observability rather than an outage.
+
+**Answer to Q2: the original framing was wrong.** Chart alerts genuinely
+have no promtool coverage, but promtool does not catch the class of defect
+that motivated the question — it passes A7's exact shape. Trustworthiness
+needs three separate mechanisms, one per class in finding C, and only the
+cheapest is a promtool job.
+
+## Recommendation
+
+Split into two efforts; they share only the `RepoGuardianBudgetGated`
+alert and can proceed independently.
+
+**1. Decide the BudgetTracker's fate (needs a decision, not just code).**
+Three options, in ascending cost:
+
+- *Delete it.* The live `RateLimitRemaining` reserve gate in `StaleSweeper`
+  already provides rate-limit protection. Removes 9 metrics, 1 alert, 4 env
+  vars, 2 chart values, and their schema ranges. Cheapest, and honest about
+  what ships.
+- *Wire it.* Add a leader-scoped refresh — the natural home is the
+  `stale-sweep` handler refreshing per installation before its enqueue
+  loop, which is what both consumer comments already assume exists.
+  Preserves the design intent of IMPL-0015 Phase 1; needs care that a
+  refresh per sweep does not itself become the rate-limit cost it is
+  meant to protect.
+- *Leave it, documented.* Cheapest in effort, worst in honesty — an
+  operator tuning `DISCOVERY_RESERVE_FRACTION` deserves to know it is read
+  by nothing.
+
+Recommend **wire it**, on the grounds that the reserve fraction and
+cost-per-repo knobs are already published in the chart's values schema and
+documented in `scaling.md`; deleting them is a user-facing removal, and
+the wiring is a single refresh call in a handler that already iterates
+installations. If that proves awkward, delete rather than leave.
+
+**2. Make the alert pack trustworthy, cheapest class first.**
+
+- Extend the `alerts` paths-filter to `charts/repo-guardian/templates/prometheusrule.yaml`
+  and add the render-extract-check pipeline from finding D to
+  `make lint-alerts`. Closes class 1. Low cost, do it regardless of what
+  else is decided.
+- Audit the six alerts in finding E against each metric's real emission
+  cadence. Fix the ones that cannot fire; leave the ones that can, with a
+  comment recording why.
+- Consider `promtool test rules` unit tests with synthetic series for the
+  handful of alerts whose fireability actually matters. This is the only
+  mechanism that closes class 2 mechanically, and it is real work — scope
+  it deliberately rather than as a side quest.
+- Class 3 (dead input metrics) has no tooling answer proposed here. A
+  cheap approximation: assert every metric named in an alert expression
+  has at least one non-test writer in the Go source. Whether that is worth
+  building is an open question.
+
+## Open Questions
+
+1. **BudgetTracker disposition** — (a) wire it via a leader-scoped refresh
+   in the `stale-sweep` handler; (b) delete the feature and its
+   user-facing knobs; (c) leave it and document that it is inert.
+   other:
+2. **Alert-pack source of truth** — (a) leave the chart and `contrib/`
+   packs as independent copies and add a CI drift check; (b) generate
+   `contrib/` from the chart template; (c) leave as-is, accept drift.
+   other:
+3. **Class-3 detection** — is a "every alerted metric has a production
+   writer" check worth building, or is it enough to have found this one by
+   hand? other:
+4. **Scope** — should the alert work be its own DESIGN, or is it small
+   enough to go straight to an IMPL once the open questions above are
+   answered? other:
+
+## References
+
+- [IMPL-0021](../impl/0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md)
+  — where both items were found and deliberately deferred (Phase 4, Phase 5)
+- [INV-0011](0011-tech-debt-cleanup-inventory-post-impl-0019.md) — finding
+  A7, the single alert this generalizes
+- [IMPL-0015](../impl/0015-stale-sweep-cutover-and-repository-discovery.md) —
+  Phase 1, which introduced the BudgetTracker
+- [DESIGN-0017](../design/0017-stale-sweep-cutover-and-repository-discovery.md)
+  — the design the tracker implements
+- `docs/operations/scaling.md` § Discoverer + BudgetTracker — the operator
+  documentation currently describing an inert component

--- a/docs/investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md
+++ b/docs/investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md
@@ -1,0 +1,417 @@
+---
+id: INV-0013
+title: "State-vs-event metrics, dashboard suite, and system observability"
+status: Open
+author: Donald Gifford
+created: 2026-08-01
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# INV 0013: State-vs-event metrics, dashboard suite, and system observability
+
+**Status:** Open
+**Author:** Donald Gifford
+**Date:** 2026-08-01
+
+<!--toc:start-->
+- [Question](#question)
+- [Hypothesis](#hypothesis)
+- [Context](#context)
+- [Approach](#approach)
+- [Environment](#environment)
+- [Findings](#findings)
+  - [A. Metric inventory — one-by-one classification](#a-metric-inventory--one-by-one-classification)
+  - [B. Eight metrics are posture masquerading as events](#b-eight-metrics-are-posture-masquerading-as-events)
+  - [C. Postgres cannot serve posture today — the write-back is status-only](#c-postgres-cannot-serve-posture-today--the-write-back-is-status-only)
+  - [D. The 1+N query fear is solvable three ways — and one is already built](#d-the-1n-query-fear-is-solvable-three-ways--and-one-is-already-built)
+  - [E. Dashboard suite architecture](#e-dashboard-suite-architecture)
+  - [F. System / USE / RED coverage gaps](#f-system--use--red-coverage-gaps)
+  - [G. OTEL is the cross-hop answer, but RED does not have to wait for it](#g-otel-is-the-cross-hop-answer-but-red-does-not-have-to-wait-for-it)
+- [Conclusion](#conclusion)
+- [Recommendation](#recommendation)
+- [References](#references)
+<!--toc:end-->
+
+## Question
+
+Three questions, one per problem observed while refreshing `contrib/`:
+
+1. Which of repo-guardian's 52 metrics represent **current posture**
+   (how many repos are missing CODEOWNERS *right now*) rather than
+   **events** (a check observed a missing file), and therefore read
+   wrong after a pod restart zeroes the counter?
+2. Can the Postgres store serve posture directly — exposed as gauges —
+   without every replica hammering the same query on every scrape, and
+   does that require a Valkey query cache?
+3. What dashboard architecture follows: KPI, per-org detailed, system
+   health, and Loki — and where are the USE/RED gaps (go runtime, DB
+   pool, Valkey, GitHub client, inbound HTTP), including whether RED
+   requires adopting OTEL?
+
+## Hypothesis
+
+- A handful of `*_total` counters are being read as posture and cannot
+  provide it even in principle — a repo fixed yesterday still counts in
+  last week's increments, and a restart zeroes the "current" reading.
+- The store cannot answer posture queries today because the worker
+  write-back persists only `{status, error, policy_version}` — no
+  per-rule outcomes — so a DB-backed gauge needs a schema extension,
+  not just an exporter.
+- The 1+N scrape-fan-out fear is real for a naive custom Collector but
+  dissolves with any of: leader-scoped export (already built), a
+  ticker-driven gauge (query cadence decoupled from scrape cadence), or
+  a Valkey-cached query layer.
+- RED for the service's own hops can be done metrics-only; only
+  cross-hop tracing (ALB → gateway → service → PG/Valkey/GitHub)
+  requires OTEL.
+
+## Context
+
+**Triggered by:** the contrib/ refresh on this branch (commit
+`e6f141a`), the enterprise migration operational work (INV-0012 branch,
+PR #171), and the operator observation that "missing catalog-info /
+CODEOWNERS counts clear on restart."
+
+Adjacent to [INV-0012](0012-inert-budgettracker-and-untrustworthy-alert-pack.md)
+but distinct: INV-0012 established that the BudgetTracker metrics are
+dead and the alert packs were unvalidated; this investigation is about
+the *semantics* of the live metrics, the dashboard suite that should
+consume them, and the system-level observability that doesn't exist yet.
+
+## Approach
+
+1. Classify all 52 metrics in `internal/metrics/metrics.go` by
+   constructor type and by semantic class (event, posture, snapshot
+   gauge, live gauge, latency, dead).
+2. Read the store schema (`internal/store/postgres/migrations/`) and
+   the worker write-back (`internal/worker/worker.go.writeBack`) to
+   establish what posture data the DB actually holds.
+3. Grep the instrumentation surfaces: metrics registry wiring
+   (`main.go`), GitHub client, webhook handler, pgxpool, go-redis.
+4. Verify the structured-log surface for the Loki dashboard (handler
+   format, locked log contracts).
+5. Enumerate dashboard mechanics (Grafana repeated rows, template
+   variables, Loki ruler) against what the metric label sets support.
+
+## Environment
+
+| Component | Version / Value |
+|-----------|----------------|
+| repo-guardian | appVersion 1.10.1, chart 1.0.0-rc.9 |
+| Metrics registry | `promauto` on default registry, `promhttp.Handler()` (main.go:413) |
+| Valkey client | `github.com/redis/go-redis/v9` v9.19.0 |
+| Store | pgx/v5 + pgxpool, `repo_state` table (migration 0001) |
+| Logging | `slog.NewJSONHandler` → stdout (main.go:520) |
+| promtool | 3.12.0 (mise) |
+
+## Findings
+
+### A. Metric inventory — one-by-one classification
+
+52 metrics: 40 CounterVec/Counter, 6 Gauge/GaugeVec (live), 6
+Histogram. Classified by what the number *means*, not what type it is:
+
+**Event counters — correct as-is.** Occurrences of an action; `rate()`
+and `increase()` are the only honest reads; restart-zeroing is handled
+by PromQL counter-reset detection and is a non-issue for these.
+
+| Metric | Notes |
+|--------|-------|
+| `repos_checked_total{trigger,org}` | work throughput |
+| `prs_created_total{org}`, `prs_updated_total{org}`, `prs_closed_total{org,reason}` | PR lifecycle events |
+| `pr_orphan_left_total{org}` | cleanup failure events (retried next sweep) |
+| `settings_remediated_total`, `branch_protection_remediated_total` | remediation actions |
+| `settings_checked_total`, `branch_protection_checked_total` | evaluation throughput |
+| `rule_gate_closed_total{rule_name,org,reason}` | gate evaluations (diagnostic) |
+| `ignored_total{scope,org}`, `out_of_scope_total{level,org}` | skip events (diagnostic) |
+| `webhook_received_total{event_type}`, `webhook_rejected_total{reason}` | ingress events |
+| `errors_total{operation,org}` | error events |
+| `github_rate_limit_waits_total{reason}` | throttle events |
+| `custom_property_cleared_total{org}` | clear actions |
+| `queue_enqueued_total`, `queue_claimed_total`, `queue_acked_total{outcome}`, `queue_reaped_total` | queue lifecycle |
+| `rate_limit_reserve_blocked_total{installation_id}` | gate events |
+| `repo_discovered_total`, `discovery_api_calls_total` | discovery events |
+| `store_writeback_total{installation_id,outcome}` | write-back events |
+
+**Live gauges — correct as-is.** Sampled truth at scrape time:
+`queue_depth{queue}`, `rate_limit_remaining{installation_id}`,
+`github_rate_remaining`, `scheduler_is_leader{name}`.
+
+**Snapshot gauge — the existing correct pattern for posture.**
+`open_prs_by_rule{org,rule,age_bucket}`: reset at sweep start by
+`metrics.ResetOpenPRsByRule` and repopulated as the sweep joins the
+open-PR set against actionable rules. It answers "how many PRs are
+open right now, by age" — surviving restarts *logically* (the next
+sweep rebuilds it) with one blind window between restart and first
+sweep. This is the in-tree precedent Finding B's metrics should follow
+or improve on.
+
+**Latency histograms — correct, three have no dashboard/alert
+consumer.** `check_duration_seconds`, `github_rate_limit_wait_seconds`,
+`store_query_seconds{op,outcome}` are consumed;
+`scheduler_sweep_batch_size`, `store_writeback_duration_seconds`,
+`discovery_duration_seconds` are exposed and documented but appear on
+no dashboard panel or alert (write-back latency has a documented p99
+target of 50ms and nothing watching it).
+
+**Dead — INV-0012.** All six `api_budget_*` plus
+`enqueue_gated_by_budget_total`: no producer calls `RefreshFromAPI` in
+prod. Excluded from all dashboard planning here; DESIGN-0021 replaces
+them.
+
+**Legacy unlabeled.** `properties_checked_total`,
+`properties_prs_created_total`, `properties_set_total`,
+`properties_already_correct_total` — plain Counters with no `org`
+label, predating the per-org labeling convention (IMPL-0009 §metrics).
+`properties_already_correct_total` is also posture-shaped (Finding B).
+Candidates for deprecation or relabeling when Finding B's design lands.
+
+### B. Eight metrics are posture masquerading as events
+
+The operator complaint — "counts of missing catalog-info or CODEOWNERS
+clear on restart" — is not a restart bug. It is a semantic mismatch:
+
+| Metric | What it actually counts | What operators read it as |
+|--------|------------------------|---------------------------|
+| `files_missing_total{rule_name,org}` | check-events that observed a missing file | repos currently missing the file |
+| `files_forbidden_present_total{rule_name,org}` | check-events that observed a forbidden file | repos currently carrying it |
+| `settings_mismatched_total{rule_name,org}` | evaluations that found drift | repos currently drifted |
+| `custom_property_missing_schema_total{org,property}` | skipped sync attempts | properties currently undefined |
+| `catalog_parse_failed_total{org}` | skipped reconciles | repos with currently-broken catalog files |
+| `pr_open_with_empty_actionable_total{org}` | drift observations | PRs currently drifted |
+| `properties_already_correct_total` | no-op syncs | fleet compliance level |
+| `open_prs_by_rule` | *(already a snapshot gauge — the model)* | — |
+
+The failure mode is worse than restart-zeroing: **a counter cannot
+represent posture even between restarts.** A repo that gained
+CODEOWNERS yesterday still contributes to `increase(...[7d])` today; a
+repo checked twice counts twice; a repo the sweep hasn't reached counts
+zero. Any KPI panel titled "repos missing CODEOWNERS" built on these
+counters is wrong on all three axes, and the restart just makes it
+obviously wrong instead of subtly wrong.
+
+The counters are still valuable *as events* (detection rate, activity,
+alerting on `increase()`); the fix is not to remove them but to add a
+posture representation alongside — which leads to Finding C.
+
+### C. Postgres cannot serve posture today — the write-back is status-only
+
+The full extent of persisted state (migration 0001):
+
+```sql
+CREATE TABLE repo_state (
+    installation_id   BIGINT  NOT NULL,
+    owner             TEXT    NOT NULL,
+    repo              TEXT    NOT NULL,
+    last_checked_at   TIMESTAMP WITH TIME ZONE,
+    last_check_status TEXT    NOT NULL DEFAULT 'pending',
+    last_error        TEXT,
+    policy_version    TEXT    NOT NULL DEFAULT '',
+    PRIMARY KEY (installation_id, owner, repo)
+);
+```
+
+`worker.writeBack` persists `{status, truncated error, policy_version,
+timestamp}` — the engine's per-rule findings (`findActionableRules`'s
+actionable set) are computed, used to open/refresh the PR, and
+discarded. "SELECT count of repos missing CODEOWNERS" has no table to
+run against. So the user-suggested "provide it by a DB query exposed as
+a metric" requires a schema extension first. Two shapes worth carrying
+into a design:
+
+- **C1 — per-rule state table.** `rule_state(installation_id, owner,
+  repo, rule_name, actionable bool, check_mode, updated_at)`, upserted
+  in the same write-back path (one batched statement per job; the
+  actionable set is already in memory at that point). Posture is then
+  `SELECT rule_name, count(*) FILTER (WHERE actionable) GROUP BY 1` —
+  and it also unlocks queries metrics can't express at all ("list the
+  repos", "compliance % per org per rule", history via audit trigger).
+- **C2 — JSONB column on `repo_state`.** `actionable_rules JSONB` —
+  cheaper migration, no second table, worse queryability (needs
+  `jsonb_array_elements` for per-rule counts) and no per-rule
+  `updated_at`. Fine if posture-by-rule-per-org is the only consumer;
+  C1 if the "show me the repos" operator workflow matters (it did,
+  twice, during this week's enterprise migration debugging).
+
+Interim zero-schema option: **C3 — extend the sweep-snapshot pattern**
+(`open_prs_by_rule` style) with
+`repos_actionable{rule_name,org}` gauges repopulated per sweep from the
+engine's in-memory result. No migration, but posture lags a full sweep
+interval, goes blind between restart and first sweep, and only exists
+on the leader replica. Honest enough for a KPI dashboard's "as of last
+sweep" panel; not honest enough for point-in-time compliance reporting.
+
+### D. The 1+N query fear is solvable three ways — and one is already built
+
+The stated concern: with N replicas scraped every 30s, a naive
+DB-backed gauge runs the same posture query N times per 30s. Three
+resolutions, cheapest first:
+
+- **D1 — leader-scoped exporter (already built).** The Valkey
+  scheduler's SETNX leader election (`repo-guardian:lock:<name>`)
+  already designates exactly one replica for sweeps. A posture exporter
+  registered as a leader-gated `Schedule` handler (query every 60s,
+  `Set()` the gauges) runs the query on **one** replica at **one**
+  cadence, independent of scrape rate and replica count. Non-leader
+  replicas simply don't serve the series; dashboards aggregate with
+  `max by (...)`, exactly as `scheduler_is_leader` panels already do.
+  No cache layer, no new infra.
+- **D2 — ticker-driven gauge instead of custom Collector.** Even
+  without leader-gating, the 1+N problem is an artifact of implementing
+  posture as a `prometheus.Collector` that queries *at scrape time*. A
+  plain ticker that queries every 60s and `Set()`s decouples query
+  cadence from scrape cadence: N replicas = N queries/minute total, not
+  N per scrape. Acceptable for small N; D1 makes it 1.
+- **D3 — Valkey as a query cache.** `GET posture:<hash>` → on miss,
+  `SET ... EX 60` + query. Solves the same problem as D1 with more
+  moving parts (serialization, TTL vs sweep-freshness coherence,
+  stampede control — go-redis v9 is in-tree, and `singleflight` is
+  already a house pattern from the schema-preflight cache). Worth it
+  only if something *other than metrics export* needs the same cached
+  query results (e.g., a future status API endpoint or the KPI
+  dashboard querying Postgres directly via Grafana's PG datasource).
+  As a pure metrics answer, D1 strictly dominates.
+
+Verdict to carry into the design: **D1 for export; D3 only if a second
+consumer for posture queries appears.** The query itself (C1 shape,
+count-group-by over ≤ `20 orgs × 5k repos × ~6 rules` rows) is
+index-friendly and sub-second; the fan-out was the only real concern.
+
+### E. Dashboard suite architecture
+
+Split the current single 61-panel dashboard into four, in `contrib/grafana/`:
+
+- **E1 — KPI / status.** Single-screen posture: compliance % per rule
+  (needs C), open-PR ages (`open_prs_by_rule` — exists), convergence
+  rate (`prs_closed_total{reason="satisfied"}`), error budget
+  (`errors_total` / `repos_checked_total`), rate-limit headroom
+  (`rate_limit_remaining` min by installation), queue depth, leader
+  status. Everything except the compliance % is buildable today; the
+  compliance panels should ship in "as of last sweep" form (C3) or wait
+  for C1 — *not* be faked with `increase(files_missing_total)`.
+- **E2 — detailed, per-org repeated rows.** Grafana multi-value
+  variable `org` from `label_values(repo_guardian_repos_checked_total,
+  org)`; a top "fleet" section of aggregate panels
+  (`sum without (org)`), then one **repeated row** per selected `$org`
+  (row → Repeat for → `org`) containing the per-org slices: checks by
+  trigger, missing/forbidden by rule, PR lifecycle, gate closures,
+  property sync, errors by operation. Every engine-side metric already
+  carries `org`, so this needs zero binary changes. Two scoping gaps to
+  note on the dashboard: queue/store/scheduler metrics are
+  fleet-scoped by design (they belong in E3, not in org rows), and
+  discovery/rate-limit metrics are keyed by `installation_id` with **no
+  org↔installation join series** — a one-line info metric
+  `repo_guardian_installation_info{installation_id, org} 1` set at
+  client-construction time would let Grafana `group_left` those into
+  org rows. Cheap, high-leverage, should ride along with any Finding C
+  implementation.
+- **E3 — system / health.** Consumes what Finding F enumerates: go
+  runtime + process (already exposed), DB pool, Valkey client, GitHub
+  client RED, inbound webhook RED, queue USE (depth = saturation,
+  enqueue/ack = utilisation, reaped = errors), store latency (exists),
+  the three orphan histograms from Finding A.
+- **E4 — Loki logging dashboard.** Grounded in what the binary
+  actually emits: `slog.NewJSONHandler` to stdout, so LogQL is
+  `| json | level="ERROR"` etc. Two log lines are load-bearing
+  contracts already: `"custom properties missing from org schema"`
+  (keys `org`, `missing_properties` — locked by
+  `TestAPIMode_FiltersUndefinedMappedProperty`) and `"catalog-info
+  parse failed; skipping reconcile to avoid clearing properties"` (not
+  test-locked — should be, if a dashboard starts depending on it).
+  Panels: error-level rate by component, sweep summaries
+  (`gated_rate_limit` / `gated_budget` fields), write-back failures,
+  webhook rejections by reason, top erroring repos. **Loki-derived
+  metrics belong in the Loki ruler, not the app**: recording rules like
+  `sum by (org) (count_over_time({app="repo-guardian"} | json |
+  msg="catalog-info parse failed..." [1h]))` give log-sourced series
+  without new instrumentation — appropriate for signals that are
+  naturally log-shaped (per-repo failure identity) where a metric label
+  would explode cardinality (`repo` must never become a metric label at
+  5k repos; it is fine as a log field).
+
+### F. System / USE / RED coverage gaps
+
+What exists vs. what's missing, per dependency:
+
+| Surface | Exists today | Missing |
+|---------|--------------|---------|
+| Go runtime / process | `go_*`, `process_*` (promauto default registry — verified exposed) | any dashboard or alert consuming them (GC pause, goroutines, RSS, FD count) |
+| Postgres | `store_query_seconds{op,outcome}` (R+E of RED) | pool USE: `pgxpool.Stat()` (AcquireCount, AcquiredConns, IdleConns, EmptyAcquireCount = pool-exhaustion signal) is never collected; a ~30-line custom Collector |
+| Valkey | queue-level counters | client-level: go-redis pool stats via `redisprometheus.NewCollector` (hits/misses/timeouts/idle) — one constructor call per client |
+| GitHub API | `github_rate_remaining`, wait counters/histogram, `errors_total` | RED per request: no duration histogram, no status-code dimension, no endpoint-class dimension. A `RoundTripper` wrapper on the installation transport — `github_request_duration_seconds{method, endpoint_class, code}` with a small fixed endpoint-class set (contents, pulls, rulesets, properties, meta) to cap cardinality |
+| Inbound HTTP (webhook) | received/rejected/enqueued counters (R+E) | duration histogram (D of RED) + response-code labels; `promhttp.InstrumentHandler*` middleware is stdlib-adjacent and fits the existing mux |
+| Queue | depth gauge, lifecycle counters | nothing structural — USE is derivable; E3 just needs the panels |
+
+None of these require OTEL; all are client_golang idioms on code paths
+that already exist.
+
+### G. OTEL is the cross-hop answer, but RED does not have to wait for it
+
+The full-path ask (ALB → Cilium gateway → service → Valkey/PG/GitHub)
+is a **tracing** problem: only trace propagation stitches hops owned by
+different systems. That means OTEL SDK + `otelhttp` (inbound),
+`otelpgx`, `redisotel`, a transport wrapper for go-github, W3C
+`traceparent` propagation (ALB and Cilium both forward it), and an
+in-cluster collector (Alloy / otel-collector) — plus a tracing backend
+(Tempo, since the stack is already Grafana-flavored). That is real
+scope: a dependency footprint, a config surface, and cluster infra.
+
+The pragmatic split: **Finding F's metrics-only RED first** (no new
+infra, answers "which hop is slow/erroring" at the aggregate level),
+OTEL tracing as a separate opt-in effort when per-request "why was
+*this* webhook slow" matters. Adopting `otelhttp` middleware early on
+the webhook path is cheap and forward-compatible (it emits both traces
+and metrics), but wiring the full chain should not gate the dashboards.
+
+## Conclusion
+
+**Answer:** Confirmed on all three fronts.
+
+1. Eight metrics are posture-shaped counters (Finding B); they cannot
+   answer "how many now" regardless of restarts, and the restart just
+   surfaces it. `open_prs_by_rule` is the one metric already doing
+   posture correctly.
+2. The DB cannot serve posture today — per-rule outcomes are discarded
+   after each check (Finding C). A Valkey query cache is **not** the
+   missing piece; the missing piece is persisted per-rule state, and
+   the leader election already solves the 1+N export fan-out (Finding
+   D) without a cache.
+3. The dashboard split is four dashboards (Finding E); the system-level
+   gaps are enumerable and metrics-only (Finding F); OTEL is required
+   only for cross-hop tracing and should not gate anything else
+   (Finding G).
+
+## Recommendation
+
+Three follow-up efforts, in dependency order:
+
+1. **DESIGN: compliance-posture state and exporters.** Per-rule state
+   persistence (C1 vs C2 decision), leader-scoped posture exporter
+   (D1), the `installation_info` join metric (E2), and deprecation
+   path for the four legacy `properties_*` counters. This is the only
+   binary-changing prerequisite for the KPI dashboard's headline
+   panels.
+2. **contrib/ dashboard suite (no binary changes).** E2 detailed
+   per-org, E3 system/health (with the three pgxpool/go-redis/GitHub
+   RoundTripper collectors from Finding F as a small accompanying
+   binary change if accepted), E4 Loki — plus E1 KPI in "as of last
+   sweep" degraded mode until effort 1 lands. Test-lock the
+   catalog-parse log line before E4 depends on it.
+3. **DESIGN (later): OTEL tracing adoption.** Scope per Finding G;
+   explicitly decoupled so it cannot stall efforts 1–2.
+
+Sequencing note: DESIGN-0021 (delayed requeue) already replaces the
+dead budget metrics with measured queue-delay observability; effort 1
+should be written against the post-0021 metric surface to avoid
+designing panels for series that are about to be deleted.
+
+## References
+
+- [INV-0012](0012-inert-budgettracker-and-untrustworthy-alert-pack.md) — dead budget metrics, alert-validation gaps
+- [DESIGN-0021](../design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md) — replaces the budget mechanism; new queue-delay metrics
+- [IMPL-0009](../impl/0009-per-org-rule-scoping-and-observability.md) — per-org metric labeling convention
+- [IMPL-0013](../impl/0013-reconcile-open-prs-when-file-rules-become-satisfied.md) — `open_prs_by_rule` snapshot-gauge precedent
+- `contrib/README.md` — refreshed metric catalog (commit `e6f141a`)
+- `internal/metrics/metrics.go`, `internal/worker/worker.go`, `internal/store/postgres/migrations/0001_init.up.sql` — primary sources
+- Grafana repeated rows: <https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/create-dashboard/#configure-repeating-rows>
+- Loki ruler recording rules: <https://grafana.com/docs/loki/latest/alert/#recording-rules>

--- a/docs/investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md
+++ b/docs/investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md
@@ -195,6 +195,30 @@ The counters are still valuable *as events* (detection rate, activity,
 alerting on `increase()`); the fix is not to remove them but to add a
 posture representation alongside — which leads to Finding C.
 
+**Source assignment — the decision run over each posture metric.** The
+operational test is three questions: (1) is the number only meaningful
+"as of now"? (2) is the system of record *our check outcomes* (vs
+GitHub's state, vs the process itself)? (3) do consumers need identity
+or since-when durations? Both yes on 1+2 → Postgres-backed; system of
+record GitHub → snapshot/TTL gauge projection; otherwise pure Prom.
+
+| Posture reading | System of record | Source verdict |
+|-----------------|------------------|----------------|
+| repos missing a file (`files_missing_total`) | our check outcomes | **PG** — `rule_state` rows → `repos_actionable{rule_name,org}` gauge |
+| repos with forbidden file (`files_forbidden_present_total`) | our check outcomes | **PG** — same table, absent-mode rows |
+| repos with setting drift (`settings_mismatched_total`) | our check outcomes | **PG** — `rule_state` must include setting rules |
+| branch-protection drift | our check outcomes | **PG** — closes a hole: no `*_mismatched` metric even exists for BP today (only checked/remediated) |
+| repos with unparseable catalog (`catalog_parse_failed_total`) | our check outcomes | **PG** — parse-ok as a per-repo fact |
+| fleet compliance % (`properties_already_correct_total`) | our check outcomes | **PG** — derived; deprecate the counter |
+| open drifted PRs (`pr_open_with_empty_actionable_total` posture reading) | **GitHub** | snapshot gauge — `open_prs_by_rule` pattern is already correct; no PG mirror (the report can hit GitHub at generation time for PR links) |
+| org schema missing properties (`custom_property_missing_schema_total` posture reading) | **GitHub** | TTL gauge set at preflight-cache refresh (`property_schema_missing{org,property}` 0/1) — the cache already knows; PG adds nothing |
+
+Summarized: **Postgres backs exactly the facts the engine computes and
+currently throws away — per-rule check outcomes.** GitHub-owned
+posture gets projections (sweep snapshot or preflight-TTL gauges).
+Process behavior — every rate, latency, and saturation signal — stays
+pure Prometheus and never touches the DB.
+
 ### C. Postgres cannot serve posture today — the write-back is status-only
 
 The full extent of persisted state (migration 0001):
@@ -392,6 +416,43 @@ OTEL tracing as a separate opt-in effort when per-request "why was
 *this* webhook slow" matters. Adopting `otelhttp` middleware early on
 the webhook path is cheap and forward-compatible (it emits both traces
 and metrics), but wiring the full chain should not gate the dashboards.
+
+**What OTEL instrumentation would unmask — signals current metrics
+hide (verified against the code):**
+
+1. `check_duration_seconds` conflates engine compute, GitHub API
+   latency, and the DESIGN-0002 transport's rate-limit sleeps (up to
+   an hour *inside* `RoundTrip`). INV-0012 found the sleep by code
+   reading; a client-span would have shown it as an hour-long span on
+   day one. `otelhttp` client instrumentation on the installation
+   transport decomposes all three.
+2. `errors_total{operation}` collapses status truth: GitHub 429 vs
+   403 vs 5xx vs network error are indistinguishable, and go-github
+   retries are invisible. Client `http.client.request.duration
+   {status_code}` + span events carry both.
+3. **HMAC 401 rejections are counted nowhere.** `webhook_rejected_total`
+   increments only in the allowlist middleware (`allowlist.go`); a
+   signature-validation failure returns 401 with no metric. Server
+   middleware (`otelhttp` or `promhttp.InstrumentHandler*`) emits
+   duration + status for *every* request — 401 volume, 404 scans,
+   panic-500s — closing the gap wholesale rather than per-reason.
+4. Enqueue latency inside the webhook path: a Valkey stall makes the
+   202 slow and nothing measures it — `redisotel` (or a go-redis
+   hook) times every command including the reaper Lua and leader
+   SETNX, none of which are measured today.
+5. `store_query_seconds` starts its timer before pool acquire
+   (`observeQuery` wraps the pool call), so pool exhaustion
+   masquerades as slow queries with no discriminator. `otelpgx`
+   separates acquire from query spans; the `pgxpool.Stat()` collector
+   (Finding F) is the aggregate USE view of the same thing.
+6. End-to-end "webhook received → PR opened" latency is a pure trace
+   concept: DESIGN-0021's `queue_wait_seconds` measures one hop;
+   traces stitch webhook → enqueue → claim → check → GitHub writes.
+
+Dedup rule for the design: OTEL semconv metrics overlap hand-rolled
+ones (`db.client.operation.duration` vs `store_query_seconds`). Keep
+the domain metrics, adopt OTEL at the transport layers, and pick one
+source per dashboard panel — never both.
 
 ### H. Config-generated dashboards and alerts — established pattern, strong fit
 

--- a/docs/investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md
+++ b/docs/investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md
@@ -242,6 +242,35 @@ interval, goes blind between restart and first sweep, and only exists
 on the leader replica. Honest enough for a KPI dashboard's "as of last
 sweep" panel; not honest enough for point-in-time compliance reporting.
 
+Considered and rejected as primary: **C4 — Loki last-state
+projection.** Emit a structured per-repo per-rule outcome log line
+(does not exist today) and reconstruct current state in LogQL
+(`last_over_time`-style, `repo` as a parsed field). It works as an
+event-sourced approximation, but every posture query must scan a
+window longer than the sweep interval — which is *weekly* — across
+5k repos, with retention pinned ≥ the window forever, versus one
+indexed `count(*) GROUP BY` on a table the workers already write in
+the same code path. Loki-derived metrics stay correct for log-shaped
+event signals (Finding E4); they are a fallback for posture, not a
+design.
+
+**The downstream report requirement settles the C1-vs-C2 choice.** The
+stated goal is a compliance dashboard *and* a generated per-org report
+sent to org owners. A report needs repo *names* (identity — never
+representable in metrics, marginal in Loki) and *durations* ("missing
+since 2026-06-14" is what makes an owner act), which means per-rule
+rows with timestamps: C1, not C2's JSONB blob. Two riders fall out:
+a nightly `compliance_snapshot(org, rule_name, actionable_count, ts)`
+insert gives quarter-over-quarter history independent of Prometheus
+retention, and the report generator itself is a
+`repo-guardian report` sibling of Finding H's `monitoring generate`
+subcommand (loads the same config, queries the same tables, renders
+per-org output; Grafana's native reporting is an Enterprise-license
+feature, so the CLI shape is the OSS path). The compliance dashboard
+is then a mixed-datasource dashboard: Prom for the projected count
+gauges and trends, the Grafana Postgres datasource for the "which
+repos" table panels.
+
 ### D. The 1+N query fear is solvable three ways — and one is already built
 
 The stated concern: with N replicas scraped every 30s, a naive

--- a/docs/investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md
+++ b/docs/investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md
@@ -27,6 +27,7 @@ created: 2026-08-01
   - [E. Dashboard suite architecture](#e-dashboard-suite-architecture)
   - [F. System / USE / RED coverage gaps](#f-system--use--red-coverage-gaps)
   - [G. OTEL is the cross-hop answer, but RED does not have to wait for it](#g-otel-is-the-cross-hop-answer-but-red-does-not-have-to-wait-for-it)
+  - [H. Config-generated dashboards and alerts — established pattern, strong fit](#h-config-generated-dashboards-and-alerts--established-pattern-strong-fit)
 - [Conclusion](#conclusion)
 - [Recommendation](#recommendation)
 - [References](#references)
@@ -363,6 +364,79 @@ OTEL tracing as a separate opt-in effort when per-request "why was
 the webhook path is cheap and forward-compatible (it emits both traces
 and metrics), but wiring the full chain should not gate the dashboards.
 
+### H. Config-generated dashboards and alerts — established pattern, strong fit
+
+The follow-up question: instead of static dashboards (or purely
+label-discovered template variables), should repo-guardian *generate*
+its monitoring artifacts from `guardian.hcl` — per-org rows for exactly
+the configured orgs, panels only for enabled rules, alerts only for
+mechanisms actually in use?
+
+**Prior art — this is a named, established pattern, not a novelty:**
+
+- **Monitoring mixins** (kubernetes-mixin, node-mixin, kube-prometheus)
+  — the granddaddy: jsonnet packages that take a config object and
+  emit dashboards JSON + PrometheusRule YAML via `mixtool`. "Read
+  config, generate dashboards + alerts" has been the prometheus-
+  ecosystem convention for years.
+- **Sloth / Pyrra** — generate PrometheusRule CRs from an SLO spec:
+  the exact "validate a config and spit out a prom alerts CR" shape.
+- **Elastic beats** `setup --dashboards` — the shipping binary knows
+  its own enabled modules and pushes matching dashboards; precedent
+  for the CLI-subcommand shape.
+- **Grafana Foundation SDK** (`grafana/grafana-foundation-sdk`) — the
+  current official, strongly-typed Go builder library: chained
+  builders → `Build()` → standard dashboard JSON, or wrapped in
+  `apiVersion/kind/metadata` for Grafana's Kubernetes-compatible API /
+  grafana-operator `GrafanaDashboard` CRs. Grafana ≥ 10. (The older
+  community lineage — grabana, DARK — is superseded by this.)
+
+**Why the fit is unusually strong here.** The E2 template-variable
+approach (`label_values(...)`) can only show orgs that have *emitted
+data*. An org that is configured in `scope.orgs` but silent is
+invisible — and "configured but silent" is precisely the failure mode
+of this week's enterprise migration (dead installation IDs, orgs
+producing nothing). Config-generated dashboards invert the direction:
+a row exists for every org that *should* report, so absence renders as
+a no-data panel — a signal instead of a blind spot. The same inversion
+applies to rules and alerts: no `custom_properties` reconciler
+configured → no property-sync panels and no `PropertySchemaMissing`
+alert; no absent-mode rules → no forbidden-files panels; no empty
+graphs, no dead alerts. The generator also subsumes config
+*validation*: it must `policy.Load()` the same HCL the server loads,
+so `repo-guardian monitoring generate` in CI is a free config check
+(the strict-templates precedent, extended).
+
+**Where generation runs — three shapes:**
+
+- **H1 — CLI subcommand (recommended).** `repo-guardian monitoring
+  generate --config guardian.hcl --out ./monitoring/ --format
+  json|k8s` emitting dashboard JSON (or GrafanaDashboard CRs) + a
+  PrometheusRule CR. Artifacts are committed to the GitOps repo and
+  consumed by kustomize/ArgoCD like any manifest; a CI check re-runs
+  the generator and fails on diff (the `helm-docs`/`docz update` drift
+  convention this repo already uses). The binary already links the
+  policy loader; the foundation SDK is a codegen'd type dependency —
+  if its weight on the server binary matters, the subcommand can live
+  in a separate `cmd/` binary sharing `internal/policy`.
+- **H2 — kustomize KRM/exec plugin** wrapping H1 — generation at
+  render time, no committed artifacts. Works, but exec plugins need
+  `--enable-alpha-plugins` everywhere including ArgoCD's repo-server,
+  which is operationally clunky; only worth it if config churn makes
+  committed artifacts annoying.
+- **H3 — operator/sidecar** applying grafana-operator CRs at runtime
+  from the live ConfigMap. Most automatic, most infra, hardest to
+  review; not justified at current config-change frequency.
+
+**Trade-offs to carry into the design:** SDK output is coupled to
+Grafana schema versions (pin and test-render); generated and static
+artifacts must not fork silently — the static `contrib/` suite remains
+the zero-config fallback tier, the generated suite is the config-aware
+tier, and both should share panel definitions (generate the static one
+from an empty/default config so there is exactly one source of truth);
+`repo` must still never become a metric label — generation does not
+change cardinality rules, it only scopes which series get panels.
+
 ## Conclusion
 
 **Answer:** Confirmed on all three fronts.
@@ -380,6 +454,11 @@ and metrics), but wiring the full chain should not gate the dashboards.
    gaps are enumerable and metrics-only (Finding F); OTEL is required
    only for cross-hop tracing and should not gate anything else
    (Finding G).
+4. Generating dashboards and alert CRs from `guardian.hcl` is an
+   established ecosystem pattern (mixins, Sloth/Pyrra, beats setup)
+   with an unusually strong fit here: it makes configured-but-silent
+   orgs visible — the exact blind spot of this week's enterprise
+   migration — and doubles as CI config validation (Finding H).
 
 ## Recommendation
 
@@ -391,12 +470,16 @@ Three follow-up efforts, in dependency order:
    path for the four legacy `properties_*` counters. This is the only
    binary-changing prerequisite for the KPI dashboard's headline
    panels.
-2. **contrib/ dashboard suite (no binary changes).** E2 detailed
-   per-org, E3 system/health (with the three pgxpool/go-redis/GitHub
-   RoundTripper collectors from Finding F as a small accompanying
-   binary change if accepted), E4 Loki — plus E1 KPI in "as of last
-   sweep" degraded mode until effort 1 lands. Test-lock the
-   catalog-parse log line before E4 depends on it.
+2. **Dashboard suite DESIGN.** E2 detailed per-org, E3 system/health
+   (with the three pgxpool/go-redis/GitHub RoundTripper collectors
+   from Finding F as a small accompanying binary change if accepted),
+   E4 Loki — plus E1 KPI in "as of last sweep" degraded mode until
+   effort 1 lands. Test-lock the catalog-parse log line before E4
+   depends on it. The design's central decision is Finding H: static
+   contrib dashboards vs a `repo-guardian monitoring generate` CLI
+   subcommand (H1, foundation SDK) emitting the config-aware suite —
+   recommended shape is H1 with the static contrib tier generated
+   from a default config so there is one source of truth.
 3. **DESIGN (later): OTEL tracing adoption.** Scope per Finding G;
    explicitly decoupled so it cannot stall efforts 1–2.
 
@@ -415,3 +498,7 @@ designing panels for series that are about to be deleted.
 - `internal/metrics/metrics.go`, `internal/worker/worker.go`, `internal/store/postgres/migrations/0001_init.up.sql` — primary sources
 - Grafana repeated rows: <https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/create-dashboard/#configure-repeating-rows>
 - Loki ruler recording rules: <https://grafana.com/docs/loki/latest/alert/#recording-rules>
+- Grafana Foundation SDK: <https://github.com/grafana/grafana-foundation-sdk> — official Go builders → dashboard JSON / k8s-resource output
+- Foundation SDK CI/CD provisioning: <https://grafana.com/docs/grafana/latest/as-code/observability-as-code/foundation-sdk/dashboard-automation/>
+- Monitoring mixins (config → dashboards + alerts precedent): <https://github.com/kubernetes-monitoring/kubernetes-mixin>
+- Sloth (SLO spec → PrometheusRule generation precedent): <https://github.com/slok/sloth>

--- a/docs/investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md
+++ b/docs/investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md
@@ -28,6 +28,7 @@ created: 2026-08-01
   - [F. System / USE / RED coverage gaps](#f-system--use--red-coverage-gaps)
   - [G. OTEL is the cross-hop answer, but RED does not have to wait for it](#g-otel-is-the-cross-hop-answer-but-red-does-not-have-to-wait-for-it)
   - [H. Config-generated dashboards and alerts — established pattern, strong fit](#h-config-generated-dashboards-and-alerts--established-pattern-strong-fit)
+  - [I. Signal taxonomy — business / service / infra](#i-signal-taxonomy--business--service--infra)
 - [Conclusion](#conclusion)
 - [Recommendation](#recommendation)
 - [References](#references)
@@ -454,6 +455,96 @@ ones (`db.client.operation.duration` vs `store_query_seconds`). Keep
 the domain metrics, adopt OTEL at the transport layers, and pick one
 source per dashboard panel — never both.
 
+**What OTEL actually lets us remove.** Less than intuition suggests,
+because nearly every hand-rolled metric is *domain*-level (org, rule,
+trigger, reason labels OTEL cannot know). The honest ledger:
+
+- *Removable existing metrics (2):* `github_rate_limit_waits_total`
+  and `github_rate_limit_wait_seconds` — but their real executioner is
+  DESIGN-0021, which stops the transport from sleeping at all; OTEL
+  client histograms then carry the residual signal (slow GitHub calls
+  by status). Nothing else existing goes away: `store_query_seconds`
+  keeps its domain `op` labels (semconv sees SQL verbs, not
+  `stale_repos`), `check_duration_seconds` is job-level not
+  transport-level, `webhook_*` reasons are security semantics.
+- *Planned work cancelled (3–4 items from Finding F):* the
+  hand-rolled GitHub RoundTripper RED histogram → `otelhttp` client
+  transport; the webhook duration middleware → `otelhttp` server; the
+  `redisprometheus` collector → `redisotel` metrics; possibly the
+  `pgxpool.Stat()` collector if `otelpgx`'s pool-stats option covers
+  it (verify at design time — one or the other, not both).
+- *Removed by other efforts, not OTEL:* the 7 dead budget series
+  (DESIGN-0021 Phase 6) and the 4 legacy `properties_*` counters
+  (posture design). Postgres loses nothing to OTEL — posture facts
+  are business state, not telemetry.
+
+**"OTEL now" without the infra bill:** the OTel Go SDK can export its
+metrics through the *existing* Prometheus endpoint (the
+`go.opentelemetry.io/otel/exporters/prometheus` bridge registers into
+the same registry `promhttp` serves). So the instrumentation set —
+`otelhttp` both directions, `redisotel`, `otelpgx` — can ship
+metrics-first with zero new cluster infrastructure; the collector +
+Tempo backend becomes a later, purely additive step that turns the
+already-emitted spans on.
+
+### I. Signal taxonomy — business / service / infra
+
+Classification of every signal (live, planned, retiring) by tier, so
+each dashboard has one obvious source list: **E1 KPI = business**,
+**E2 detailed = business + service sliced by org**, **E3 = service +
+infra**, **E4 Loki = evidence across all tiers**.
+
+**Business — fleet compliance and value delivered (org-facing):**
+
+| Signal | Source | Covers |
+|--------|--------|--------|
+| `repos_actionable{rule_name,org}` *(planned)* | PG → leader gauge | posture: repos failing each rule, per org |
+| compliance % per org/rule *(planned)* | PG → leader gauge + PG datasource | the KPI headline |
+| `compliance_snapshot` history *(planned)* | PG table | quarter-over-quarter reporting |
+| "which repos" tables + per-org report | PG datasource / `report` CLI | identity + missing-since |
+| `open_prs_by_rule{org,rule,age_bucket}` | binary (sweep snapshot) | open remediation PRs by age |
+| `files_missing_total`, `files_forbidden_present_total` | binary counter | detection activity per rule/org |
+| `settings_mismatched_total` | binary counter | setting-drift detections |
+| `prs_created_total`, `prs_updated_total`, `prs_closed_total{reason}` | binary counter | remediation delivered |
+| `settings_remediated_total`, `branch_protection_remediated_total` | binary counter | remediation delivered |
+| `custom_property_cleared_total` | binary counter | property sync actions |
+| `custom_property_missing_schema_total` | binary counter (+ planned TTL gauge) | org schema governance gap |
+| `catalog_parse_failed_total` | binary counter (+ Loki for repo identity) | broken catalog files, per org |
+| `properties_*` (4 legacy) | binary counter | *deprecate with posture design* |
+
+**Service — repo-guardian's own operation:**
+
+| Signal | Source | Covers |
+|--------|--------|--------|
+| `repos_checked_total{trigger,org}` | binary counter | throughput by trigger |
+| `check_duration_seconds` | binary histogram | job latency (decomposed by OTEL spans later) |
+| `errors_total{operation,org}` | binary counter | operation failures |
+| `queue_depth`, `queue_{enqueued,claimed,acked,reaped}_total` | binary | queue USE |
+| `queue_wait_seconds`, `queue_delayed_*`, `attempts_exhausted` *(DESIGN-0021)* | binary | queue latency + deferral behavior |
+| `scheduler_is_leader`, `scheduler_sweep_batch_size` | binary | leader + sweep sizing |
+| `store_writeback_total`, `store_writeback_duration_seconds` | binary | state write-back health |
+| `repo_discovered_total`, `discovery_duration_seconds`, `discovery_api_calls_total` | binary | discovery behavior |
+| `rate_limit_reserve_blocked_total` | binary counter | self-throttling decisions |
+| `ignored_total`, `out_of_scope_total`, `rule_gate_closed_total` | binary counter | policy-engine gating |
+| `pr_open_with_empty_actionable_total`, `pr_orphan_left_total` | binary counter | convergence-path faults |
+| `webhook_received_total{event_type}`, `webhook_rejected_total{reason}` | binary counter | ingress domain semantics |
+| `http.server.request.duration{route,status}` *(planned OTEL)* | OTEL → prom bridge | inbound RED incl. the uncounted 401s |
+
+**Infra — dependencies and runtime:**
+
+| Signal | Source | Covers |
+|--------|--------|--------|
+| `store_query_seconds{op,outcome}` | binary histogram | Postgres latency/errors (R+E) |
+| pgx pool stats *(planned — `pgxpool.Stat()` or otelpgx, pick one)* | collector / OTEL | Postgres pool USE |
+| `db.client.operation.duration` + acquire spans *(planned OTEL)* | OTEL | query-vs-acquire decomposition |
+| Valkey command latency + pool *(planned — `redisotel`)* | OTEL | queue/scheduler dependency health |
+| `http.client.request.duration{host,status}` *(planned OTEL)* | OTEL | GitHub API RED, status truth, retry visibility |
+| `rate_limit_remaining{installation_id}`, `github_rate_remaining` | binary gauge | GitHub quota headroom |
+| `github_rate_limit_waits_total`, `github_rate_limit_wait_seconds` | binary | *retiring with DESIGN-0021* |
+| `api_budget_*` (7 series) | binary | *dead — removed by DESIGN-0021 Phase 6* |
+| `go_*`, `process_*` | default registry | runtime USE (GC, goroutines, RSS, FDs) |
+| k8s/node/ALB/gateway signals | cluster stacks | outside the binary; join via traces (Finding G) |
+
 ### H. Config-generated dashboards and alerts — established pattern, strong fit
 
 The follow-up question: instead of static dashboards (or purely
@@ -570,8 +661,15 @@ Three follow-up efforts, in dependency order:
    subcommand (H1, foundation SDK) emitting the config-aware suite —
    recommended shape is H1 with the static contrib tier generated
    from a default config so there is one source of truth.
-3. **DESIGN (later): OTEL tracing adoption.** Scope per Finding G;
-   explicitly decoupled so it cannot stall efforts 1–2.
+3. **OTEL adoption, split in two.** Metrics-first now: `otelhttp`
+   (both directions), `redisotel`, `otelpgx` exporting through the
+   existing Prometheus endpoint via the OTel prometheus bridge — zero
+   new infra, closes the Finding G unmask list, and cancels 3–4 items
+   of Finding F's planned hand-rolled work. Tracing infra (collector +
+   Tempo) as a later, purely additive DESIGN; explicitly decoupled so
+   it cannot stall efforts 1–2. Dashboard source lists follow the
+   Finding I taxonomy (E1=business, E2=business+service by org,
+   E3=service+infra).
 
 Sequencing note: DESIGN-0021 (delayed requeue) already replaces the
 dead budget metrics with measured queue-delay observability; effort 1

--- a/docs/investigation/README.md
+++ b/docs/investigation/README.md
@@ -24,6 +24,7 @@ Design docs, plans, and implementation docs can reference investigations by ID
 | INV-0009 | Read-only status API and web UI options | Open | 2026-07-19 | Donald Gifford | [0009-read-only-status-api-and-web-ui-options.md](0009-read-only-status-api-and-web-ui-options.md) |
 | INV-0010 | Silently ignored operator config: auto_close_pr HCL attribute and cross-mode existingSecret | Resolved | 2026-07-20 | Donald Gifford | [0010-silently-ignored-operator-config-autoclosepr-hcl-attribute-and.md](0010-silently-ignored-operator-config-autoclosepr-hcl-attribute-and.md) |
 | INV-0011 | Tech debt cleanup inventory post IMPL-0019 | Open | 2026-07-23 | Donald Gifford | [0011-tech-debt-cleanup-inventory-post-impl-0019.md](0011-tech-debt-cleanup-inventory-post-impl-0019.md) |
+| INV-0012 | Inert BudgetTracker and untrustworthy alert pack | Open | 2026-07-25 | Donald Gifford | [0012-inert-budgettracker-and-untrustworthy-alert-pack.md](0012-inert-budgettracker-and-untrustworthy-alert-pack.md) |
 <!-- END DOCZ AUTO-GENERATED -->
 <!-- BEGIN DOCZ AUTO-GENERATED -->
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/investigation/README.md
+++ b/docs/investigation/README.md
@@ -25,6 +25,7 @@ Design docs, plans, and implementation docs can reference investigations by ID
 | INV-0010 | Silently ignored operator config: auto_close_pr HCL attribute and cross-mode existingSecret | Resolved | 2026-07-20 | Donald Gifford | [0010-silently-ignored-operator-config-autoclosepr-hcl-attribute-and.md](0010-silently-ignored-operator-config-autoclosepr-hcl-attribute-and.md) |
 | INV-0011 | Tech debt cleanup inventory post IMPL-0019 | Open | 2026-07-23 | Donald Gifford | [0011-tech-debt-cleanup-inventory-post-impl-0019.md](0011-tech-debt-cleanup-inventory-post-impl-0019.md) |
 | INV-0012 | Inert BudgetTracker and untrustworthy alert pack | Open | 2026-07-25 | Donald Gifford | [0012-inert-budgettracker-and-untrustworthy-alert-pack.md](0012-inert-budgettracker-and-untrustworthy-alert-pack.md) |
+| INV-0013 | State-vs-event metrics, dashboard suite, and system observability | Open | 2026-08-01 | Donald Gifford | [0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md](0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md) |
 <!-- END DOCZ AUTO-GENERATED -->
 <!-- BEGIN DOCZ AUTO-GENERATED -->
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/operations/aws.md
+++ b/docs/operations/aws.md
@@ -17,6 +17,12 @@ For prior reading: `docs/operations/scaling.md` covers the sizing
 math for multi-org GHEC fleets — this doc covers how to land that
 sizing on AWS infrastructure specifically.
 
+If you provision with `libtftest-tf-modules/modules/rds/*`, the
+variable-level companion to this guide is
+[External Postgres on RDS — Terraform variable reference](rds-terraform-variables.md):
+exact settings for `instance` / `cluster` / `serverless`, each with and
+without `proxy`.
+
 ## Postgres on AWS
 
 ### Option matrix
@@ -30,6 +36,16 @@ sizing on AWS infrastructure specifically.
 All three speak vanilla Postgres protocol, so the binary's
 `internal/store/postgres/` works unchanged. The decision is
 operational, not architectural.
+
+**Version and parameter parity with the chart.** The chart's two
+managed shapes both pin Postgres 18 (`baked.image: postgres:18.4`,
+`cnpg.imageName: ...postgresql:18.4`) — pin the RDS `engine_version`
+to the same major so dev/test on the chart-managed shapes exercises
+the major prod runs on. Neither chart mode sets any custom Postgres
+parameters, so the default-valued parameter groups the Terraform
+modules create are already correct; there is nothing to mirror. Both
+points in detail:
+[Parameter groups and engine version](rds-terraform-variables.md#parameter-groups-and-engine-version).
 
 ### Connection pooling: use RDS Proxy
 
@@ -77,7 +93,13 @@ spec:
     name: repo-guardian-store-dsn
     template:
       data:
-        STORE_DSN: "postgres://{{ .username }}:{{ .password }}@{{ .endpoint }}:5432/{{ .dbname }}?sslmode=require"
+        # urlquery percent-encodes reserved characters; the replace
+        # re-maps space from "+" (query-string form) to %20 (userinfo
+        # form). Without this, a password containing @ : / % or space
+        # produces a DSN that fails to parse or authenticates with the
+        # wrong password. ESO templates are Go text/template + Sprig,
+        # so both functions are available.
+        STORE_DSN: "postgres://{{ .username }}:{{ .password | urlquery | replace \"+\" \"%20\" }}@{{ .endpoint }}:5432/{{ .dbname }}?sslmode=require"
   data:
     - secretKey: username
       remoteRef:
@@ -132,9 +154,15 @@ direct admin connections.
 - **Secrets Manager rotation gap.** If AWS rotates the DB password
   via Secrets Manager → ESO re-syncs the k8s Secret → but the
   binary's open pgxpool connections still use the OLD password
-  until they hit a transient failure and reconnect. RDS Proxy
-  eliminates this because the Proxy holds the DB creds; clients
-  talk to the Proxy with their own (static) creds.
+  until they hit a transient failure and reconnect, and the
+  Deployment needs a restart to pick up the new env value at all.
+  **RDS Proxy does not eliminate this.** Clients authenticate to the
+  Proxy with the same credentials the Proxy holds in Secrets Manager
+  — there is no separate static client credential — so a rotation
+  invalidates the password the pods are using. The escape hatches
+  are automating the restart, or setting
+  `manage_master_user_password = false` and rotating on your own
+  schedule.
 
 ## ElastiCache for Valkey
 

--- a/docs/operations/ent-setup.md
+++ b/docs/operations/ent-setup.md
@@ -1,0 +1,417 @@
+# repo-guardian GitHub App — Enterprise Setup Guide
+
+How to register, install, and run repo-guardian as an **enterprise-owned
+GitHub App** across N organizations in a GitHub Enterprise Cloud
+account. One registration, one private key, N installations — the
+[same-key-for-all-orgs stance](../investigation/0006-per-org-github-app-credentials.md)
+(per-org credentials were investigated and deferred in INV-0006).
+
+Companion docs: [Getting started](../usage/getting-started.md) covers a
+single-org install; [Scaling repo-guardian](scaling.md) covers the
+sizing math for multi-org fleets; [Running repo-guardian on AWS](aws.md)
+covers the infrastructure underneath.
+
+## The model in one diagram
+
+Registration and installation are separate things. The **enterprise
+account owns the app registration** (name, private key, permission
+manifest, webhook config) — ownership grants no access.
+**Installations** are the per-org grants: each one gives the app its
+requested permissions on that org only, with its own installation ID
+and its own independent rate-limit budget.
+
+```mermaid
+flowchart TB
+    subgraph ent["Enterprise account"]
+        direction TB
+        reg1["App registration: installer-app
+        Enterprise perms: Organization installations (r/w)
+        (client ID + private key)"]
+        reg2["App registration: repo-guardian
+        Repo perms: Contents, PRs, Metadata (+ feature-gated)
+        Webhook: ACTIVE → the service's /webhook endpoint
+        (client ID + private key)"]
+        entinstall["Installation on the
+        enterprise account itself"]
+    end
+
+    reg1 -. "installed once on" .-> entinstall
+
+    subgraph orgs["Organizations in the enterprise"]
+        o1["org1
+        installation #111"]
+        o2["org2
+        installation #222"]
+        oN["orgN
+        installation #NNN"]
+    end
+
+    entinstall -- "POST /enterprises/E/apps/organizations/{org}/installations
+    (one call per org)" --> o1
+    entinstall --> o2
+    entinstall --> oN
+
+    svc["repo-guardian service (EKS/Talos)
+    holds the repo-guardian private key
+    Postgres store + Valkey queue"]
+    o1 -- "webhooks: push, repository,
+    installation, installation_repositories" --> svc
+    svc -- "per-installation token:
+    check repos, open PRs" --> o1
+    svc <--> o2
+    svc <--> oN
+```
+
+Key properties of this shape:
+
+- **One registration, N installations.** The service holds a single App
+  ID + private key; `ghinstallation` mints short-lived per-installation
+  tokens on demand, and installation clients are cached per
+  installation ID.
+- **The service's configuration is oblivious to all of this.** There is
+  no enterprise token, endpoint, or mode anywhere in the binary or
+  chart — the deployment uses the same three credentials as a
+  single-org install (`config.appId`, `secrets.privateKey`,
+  `secrets.webhookSecret`), just pointing at the enterprise-owned
+  registration. Enterprise ownership matters at exactly two moments:
+  registration time (Step 1) and install time (Step 3), and the service
+  participates in neither. Runtime auth is always per-installation.
+- **Per-installation rate budgets.** Each org's installation gets its
+  own budget — 5,000 req/hr baseline, scaling with repo and user count
+  up to 12,500, and a flat 15,000 req/hr for installations on GitHub
+  Enterprise Cloud orgs. One busy org cannot spend another org's
+  budget. `docs/operations/scaling.md` has the math.
+- Enterprise permissions (the ability to install apps into orgs) live
+  on a separate **installer app** with a separate key. A leaked
+  repo-guardian key can touch what repo-guardian's manifest grants —
+  it can never install anything anywhere.
+- Enterprise-owned apps can only be installed on the enterprise or orgs
+  within it — structurally incapable of being installed outside, so
+  there is no "accidentally public" failure mode.
+- Permission changes made by an enterprise owner on the registration
+  are **auto-accepted by every org installation** — no per-org approval
+  chase when a new feature needs a new permission.
+
+## Step 1 — Register the repo-guardian app
+
+1. Go to `https://github.com/enterprises/<ENTERPRISE>/settings/apps` →
+   **New GitHub App**.
+2. Settings:
+   - **Name:** `repo-guardian` (or your app naming convention).
+   - **Homepage URL:** this repo's URL (required field).
+   - **Webhook:** **Active**, unlike a pull-based CLI — repo-guardian is
+     webhook-driven. **Webhook URL:** the service's public endpoint
+     (ingress, LoadBalancer, or Tailscale Funnel — see the ordering
+     note below). **Webhook secret:** generate a strong random value;
+     it becomes `GITHUB_WEBHOOK_SECRET` / chart `secrets.webhookSecret`.
+     Payloads are HMAC-validated, and the webhook route additionally
+     sits behind the GitHub IP allowlist middleware (`SECURITY.md`).
+   - **Expire user authorization tokens:** deselect (repo-guardian
+     never signs in users).
+   - **Permissions:** see the table below.
+   - **Subscribe to events:** `Push`, `Repository`, `Installation
+     repositories` (installation target events are delivered to App
+     webhooks automatically).
+   - **Enterprise permissions:** none.
+3. Create the app. Record the **App ID** (→ `config.appId`) and
+   **Client ID** (used by the Step 3 install loop).
+4. **Generate a private key**. The `.pem` becomes
+   `secrets.privateKey` (or an operator-managed Secret — ESO/1Password
+   patterns in `docs/operations/aws.md`). The key never lives in a
+   repo or a laptop; store it in your secrets backend.
+
+### Permission manifest
+
+Core — always required:
+
+| Permission | Access | Used for |
+|---|---|---|
+| Repository → **Contents** | Read & write | File checks, reconcile-branch commits, forbidden-file deletion (`absent` rules) |
+| Repository → **Pull requests** | Read & write | Create/update/close PRs, sticky reconcile-log comments, PR labels |
+| Repository → **Metadata** | Read | Mandatory baseline; repo listing |
+
+Feature-gated — grant only if your `guardian.hcl` uses the feature
+(auto-accepted enterprise-wide when you add them later):
+
+| Permission | Access | Needed by |
+|---|---|---|
+| Repository → **Administration** | Read & write | `rule "setting"` remediation (repo properties) and `rule "branch_protection"` / `branch_protection` reconciler (rulesets API) |
+| Repository → **Issues** | Read & write | `label_sync` reconciler (label create/update/rename/delete) |
+| Repository → **Workflows** | Read & write | Any rule or reconciler that writes `.github/workflows/*` (`renovate_workflow`, `custom_properties` in `github-action` mode) — Contents write alone is rejected by GitHub for workflow files |
+| Repository → **Custom properties** | Read & write | `custom_properties` reconciler in `api` mode (`PATCH /repos/{o}/{r}/properties/values`) |
+| Organization → **Custom properties** | Read | The org-schema preflight (IMPL-0017). Optional — without it the preflight fails open; with it, unmapped properties are filtered and surfaced via `custom_property_missing_schema_total`. See [annotation-properties migration](annotation-properties-migration.md) §4 |
+
+> **Ordering note (webhook URL chicken-and-egg).** The registration
+> form requires a webhook URL when the webhook is active, but you need
+> the App ID + key from registration to deploy the service that serves
+> that URL. Resolution: register with the *planned* URL, deploy the
+> chart with the recorded credentials, then confirm delivery under the
+> app's **Advanced → Recent Deliveries** tab. Deliveries that fired
+> before the service was up can be redelivered from the same tab — or
+> simply ignored, since the Discoverer converges on anything missed.
+>
+> The registration alone now exists but can do nothing anywhere. Access
+> only materializes in Step 3.
+
+## Step 2 — Installer app (reuse if it exists)
+
+The installer app is what turns "install into N orgs" from a clickfest
+into a loop. **Check whether one already exists** at
+`https://github.com/enterprises/<ENTERPRISE>/settings/apps`. If yes,
+skip to Step 3.
+
+> **Do you actually need a second app?** Strictly, no — two
+> alternatives exist, and the split is a deliberate choice, not an API
+> requirement:
+>
+> - **Zero extra apps:** install repo-guardian into each org by hand
+>   (org settings → the app's Install page). Fine at a handful of orgs;
+>   a clickfest at 20+, and every new org is a manual step someone
+>   forgets.
+> - **One combined app:** the install endpoint's caller just needs
+>   *some* app installed on the enterprise account with **Enterprise
+>   organization installations: write** — GitHub documents no
+>   prohibition on an app installing itself, so repo-guardian's own
+>   registration could carry the enterprise permission and run the
+>   Step 3 loop with its own key.
+>
+> Don't do the combined shape. That enterprise permission installs
+> "**any valid GitHub App**" (GitHub's wording — not limited to
+> enterprise-owned apps) into any org: a leaked key holding it lets an
+> attacker install an app *they* control across the whole enterprise
+> and mint tokens everywhere. repo-guardian's key is **hot** — mounted
+> in a pod, touched on every reconcile. The installer key is **cold** —
+> used for minutes at onboarding, then back in the vault, and reused
+> for every future enterprise app (one more `client_id` through the
+> same loop, no new install-capable key). Keep the escalation primitive
+> out of the runtime credential. (The combined shape also gives the app
+> an installation on the enterprise account itself, which the
+> `Discoverer` would enumerate and fail-safe skip with log noise every
+> `DISCOVERY_INTERVAL`.)
+
+If not:
+
+1. Same **New GitHub App** flow. Name it `<enterprise>-installer` per
+   convention.
+2. Webhook inactive, no repository permissions, no organization
+   permissions.
+3. **Enterprise permissions:** **Enterprise organization installations
+   → Read and write**. This is the one permission that authorizes
+   installing apps into member orgs.
+4. Create, record Client ID, generate and store the private key.
+5. In the app's sidebar → **Install App** → install it **on the
+   enterprise account itself**. Note the installation ID from the
+   resulting URL
+   (`/enterprises/<ENTERPRISE>/settings/installations/<ID>`).
+
+## Step 3 — Install repo-guardian into every org
+
+Authenticate the installer app, then loop the install endpoint over the
+org list:
+
+```bash
+# 1. JWT for the installer app (client ID + its private key)
+INSTALLER_JWT=$(gen-jwt.sh "$INSTALLER_CLIENT_ID" installer.private-key.pem)
+
+# 2. Exchange JWT for an enterprise-scoped installation token
+INSTALLER_TOKEN=$(gh api --method POST \
+  "/app/installations/${INSTALLER_INSTALL_ID}/access_tokens" \
+  --header "Authorization: Bearer ${INSTALLER_JWT}" --jq .token)
+
+# 3. Install repo-guardian into each org — all repositories
+for ORG in $(cat orgs.txt); do
+  gh api --method POST \
+    "/enterprises/${ENTERPRISE}/apps/organizations/${ORG}/installations" \
+    --header "Authorization: Bearer ${INSTALLER_TOKEN}" \
+    --header "X-GitHub-Api-Version: 2022-11-28" \
+    --field "client_id=${RG_CLIENT_ID}" \
+    --field "repository_selection=all"
+done
+```
+
+Notes:
+
+- The endpoint takes the **client ID of the app being installed** — the
+  installer token authorizes the act, the client ID says which app.
+- **`repository_selection=all` matters for repo-guardian** (unlike a
+  members-only app): it is an org-compliance tool, and `all` means new
+  repos in the org are covered automatically. Per-repo exclusions
+  belong in `guardian.hcl` `ignore {}` blocks, not in the installation's
+  repo selection — ignores are visible, versioned policy; a `selected`
+  installation is invisible drift.
+- The call is effectively idempotent — an org that already has the
+  installation returns an "already installed" error, which the loop
+  treats as success.
+- Each successful install fires an `installation.created` webhook at
+  the already-running service, which seeds `repo_state` rows for the
+  org's repos with jittered `LastCheckedAt` — so a 200-org rollout
+  spreads its cold-start sweep over the freshness window instead of
+  thundering.
+
+## Step 4 — Verify
+
+Spot-check the UI at
+`https://github.com/organizations/<ORG>/settings/installations` —
+repo-guardian should be listed. Programmatically, with the
+**repo-guardian** app's own credentials:
+
+```bash
+RG_JWT=$(gen-jwt.sh "$RG_CLIENT_ID" repo-guardian.private-key.pem)
+gh api "/orgs/${ORG}/installation" \
+  --header "Authorization: Bearer ${RG_JWT}" --jq .id
+```
+
+Then verify the service side — installation is only half the story:
+
+```bash
+# Webhook deliveries landing (should show installation.created batches)
+kubectl logs -n repo-guardian deploy/repo-guardian | grep installation
+
+# Store rows seeded per org
+psql "$STORE_DSN" -c \
+  "SELECT owner, count(*), min(last_checked_at) FROM repo_state GROUP BY owner;"
+
+# After the first sweep: per-org activity on the metrics endpoint
+curl -s localhost:9090/metrics | grep 'repos_checked_total{'
+```
+
+Every org from `orgs.txt` should appear as an `owner` in `repo_state`
+(webhook-seeded) even before the first sweep touches it. The periodic
+`Discoverer` (`DISCOVERY_INTERVAL`, default 1h) enumerates all
+installations and backfills anything a webhook missed, so a gap here
+self-heals — but a *persistently* missing org means its installation
+doesn't exist, and the Step 3 loop needs re-running.
+
+**Do the first fleet-wide sweep in `DRY_RUN=true`.** At N orgs the
+first reconcile is the largest PR burst the fleet will ever see. Dry
+run logs every action it would take; review, then flip it off.
+
+## Step 5 — How repo-guardian authenticates at runtime
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant GH as GitHub
+    participant WH as webhook handler
+    participant Q as Valkey queue
+    participant W as worker
+    participant API as GitHub API (org1)
+
+    GH->>WH: push / repository / installation events
+    Note over WH: IP allowlist → HMAC validation → 202 Accepted
+    WH->>Q: Enqueue(job{installation_id, owner, repo})
+    Q->>W: Subscribe delivers job
+    Note over W: holds App ID + private key
+    W->>API: JWT → POST /app/installations/111/access_tokens
+    API-->>W: installation token (≈1 h, scoped: org1, manifest perms)
+    W->>API: check files / settings / rulesets
+    W->>API: create or converge the reconcile PR
+    Note over W,API: installation client + token cached per installation —<br/>N orgs share one key, never one budget
+```
+
+Implementation notes:
+
+- The `go-github` + `ghinstallation` transport handles the JWT/token
+  dance; the binary never persists tokens.
+- Installation clients are cached per installation ID
+  (`getInstallClient`), so token minting and rate-limit accounting are
+  per-org across the whole worker pool.
+- Scheduled work follows the same path minus the webhook: the
+  `StaleSweeper` enqueues repos whose `last_checked_at` exceeds
+  `RECONCILE_FRESHNESS` (batch-bounded by `STALE_SWEEP_BATCH_SIZE`),
+  and the `Discoverer` keeps the installation → repo inventory current.
+
+## Ongoing operations
+
+**New orgs.** Joining the enterprise does not install anything.
+Onboarding = run the Step 3 loop for the org (or re-run the full list;
+already-installed orgs no-op). From there discovery is automatic — the
+`installation.created` webhook seeds the org's repos and the next sweep
+covers them. **One caveat:** if your `guardian.hcl` declares a
+top-level `scope { orgs = [...] }` (strict mode, DESIGN-0010), the new
+org is discovered but every rule skips it — visible as
+`out_of_scope_total{level="policy"}` — until you add it to the scope
+list and roll the config. In legacy mode (no top-level scope) rules
+apply to the new org with no config change.
+
+**Key rotation.** GitHub App registrations support two private keys
+simultaneously: generate the new key, update the secret backing
+`secrets.privateKey`, roll the Deployment, confirm clean reconciles,
+then delete the old key from the registration. Same procedure for the
+installer app on its own cadence.
+
+**Permission changes.** Edit the manifest on the enterprise-owned
+registration; orgs in the enterprise auto-accept. This is how the
+feature-gated permissions get added when you enable a feature later —
+e.g. granting org-level **Custom properties: read** to activate the
+schema preflight took effect fleet-wide with no per-org action
+(the IMPL-0017 rollout).
+
+**Webhook health.** The app's **Advanced → Recent Deliveries** tab is
+the ground truth for delivery failures (the service returns
+`202 Accepted` on ingest). Failed deliveries can be redelivered from
+there; anything missed also converges via the Discoverer within
+`DISCOVERY_INTERVAL`.
+
+**Migrating from a non-enterprise registration.** An enterprise-owned
+app is a **new registration** — new App ID, new private key, and new
+installation IDs; there is no transfer path from a personal- or
+org-owned registration. The cutover is: register per Step 1, swap the
+chart's `config.appId` + `secrets.privateKey` + `secrets.webhookSecret`,
+run the Step 3 loop, then uninstall the old app. The old `repo_state`
+rows are orphaned but harmless (the primary key includes
+`installation_id`; new installations re-seed fresh rows), and existing
+reconcile PRs converge unchanged — the engine finds them by the
+deterministic `repo-guardian/add-missing-files` branch name, not by
+stored state. A credential swap plus a re-seed, not a data migration.
+
+**Drain the Valkey queue during the cutover.** Unlike `repo_state`
+rows, queued jobs are *not* harmless across the swap: each job carries
+the old app's installation ID baked into its JSON, and a persistent
+Valkey (EBS-backed, AOF/RDB enabled) keeps them across redeploys. The
+new deployment's workers will dequeue them, fail to mint an
+installation token for the dead ID, and — because a failed job is left
+in-flight for the reaper to requeue after `JOB_ACK_TIMEOUT` (default
+5m) — **retry them forever**. There is no attempt cap or dead-letter
+queue today (DESIGN-0021 adds one). The symptom is a steady drip of
+"installation not found" errors every ~5 minutes per stale job. The
+fix, during cutover with the deployment scaled to zero:
+
+```text
+valkey-cli DEL repo-guardian:queue:jobs repo-guardian:queue:in-flight
+```
+
+(or `FLUSHDB` if the instance is dedicated to repo-guardian — every
+key it holds is transient work state; the durable state lives in
+Postgres). Nothing is lost: discovery and the stale-sweeper re-enqueue
+anything due on the next tick. If the errors continue *after* the
+flush, the old app registration still exists with an active webhook
+pointed at the same URL — if its webhook secret matches, its
+deliveries pass HMAC validation and keep minting jobs with dead
+installation IDs. Suspend or delete the old app (or deactivate its
+webhook) as part of the cutover, not as an afterthought.
+
+**Uninstall / decommission.** Uninstalling from an org (org settings →
+installations) immediately revokes that installation's tokens; the
+org's `repo_state` rows go stale and its open reconcile PRs remain as
+ordinary PRs. Deleting the registration revokes everything everywhere.
+
+## References
+
+- [Getting started](../usage/getting-started.md) — single-org setup,
+  chart deployment, policy basics
+- [Scaling repo-guardian](scaling.md) — multi-org sizing, sweep and
+  discovery tuning, per-installation budget math
+- [Running repo-guardian on AWS](aws.md) — EKS, RDS, ElastiCache,
+  External Secrets
+- [INV-0006](../investigation/0006-per-org-github-app-credentials.md)
+  — why one App/key for all orgs (per-org credentials deferred)
+- `SECURITY.md` — webhook IP allowlist + HMAC two-layer defence
+- GitHub Docs — Automating app installations in your enterprise's
+  organizations (installer-app pattern, install endpoint)
+- GitHub Docs — Creating GitHub Apps for your enterprise
+  (enterprise-owned registration, auto-accepted permission changes)
+- GitHub REST — Apps: create an installation access token; Enterprise
+  admin: organization installations
+- GitHub Changelog — Enterprise-level access for GitHub Apps and
+  installation automation APIs (2025-07-01)

--- a/docs/operations/ent-setup.md
+++ b/docs/operations/ent-setup.md
@@ -358,15 +358,36 @@ app is a **new registration** — new App ID, new private key, and new
 installation IDs; there is no transfer path from a personal- or
 org-owned registration. The cutover is: register per Step 1, swap the
 chart's `config.appId` + `secrets.privateKey` + `secrets.webhookSecret`,
-run the Step 3 loop, then uninstall the old app. The old `repo_state`
-rows are orphaned but harmless (the primary key includes
-`installation_id`; new installations re-seed fresh rows), and existing
-reconcile PRs converge unchanged — the engine finds them by the
-deterministic `repo-guardian/add-missing-files` branch name, not by
-stored state. A credential swap plus a re-seed, not a data migration.
+run the Step 3 loop, then uninstall the old app. Existing reconcile
+PRs converge unchanged — the engine finds them by the deterministic
+`repo-guardian/add-missing-files` branch name, not by stored state. A
+credential swap plus a re-seed, not a data migration — with two
+cleanup steps that are easy to skip and expensive to debug:
 
-**Drain the Valkey queue during the cutover.** Unlike `repo_state`
-rows, queued jobs are *not* harmless across the swap: each job carries
+**Delete the old installation's `repo_state` rows.** They are *not*
+harmless: the stale-sweeper selects rows by `(last_checked_at,
+policy_version)` with no notion of whether the installation still
+exists, so every old-installation row is re-enqueued (drifted rows in
+a burst on the first sweep, then once per freshness window each), and
+every minted job fails with "installation not found" against the
+deleted app. The primary key is `(installation_id, owner, repo)`, so
+the same repos coexist under the new installation's rows — deleting
+the old ones loses nothing:
+
+```sql
+-- see which installation IDs the store knows about
+SELECT installation_id, count(*) FROM repo_state GROUP BY 1 ORDER BY 2 DESC;
+-- drop the dead one(s)
+DELETE FROM repo_state WHERE installation_id = <old_installation_id>;
+```
+
+Note the rows can appear even in a *fresh* database: a first deploy
+that briefly ran with the old app's credentials (discovery seeds its
+installations), or old-app webhook deliveries landing before the app
+was deleted, is enough to plant them.
+
+**Drain the Valkey queue during the cutover.** Like the store rows,
+queued jobs are *not* harmless across the swap: each job carries
 the old app's installation ID baked into its JSON, and a persistent
 Valkey (EBS-backed, AOF/RDB enabled) keeps them across redeploys. The
 new deployment's workers will dequeue them, fail to mint an

--- a/docs/operations/rds-terraform-variables.md
+++ b/docs/operations/rds-terraform-variables.md
@@ -1,0 +1,489 @@
+# External Postgres on RDS — Terraform variable reference
+
+Concrete variable settings for running repo-guardian against
+`libtftest-tf-modules/modules/rds/*`, for each of the six shapes:
+`instance` / `cluster` / `serverless`, each with or without `proxy`.
+
+[Running repo-guardian on AWS](aws.md) covers the *choice* between those
+shapes and the surrounding wiring (External Secrets Operator, chart
+values, ElastiCache). This doc is the variable-level companion: what to
+set, what the module defaults get wrong for this specific consumer, and
+what breaks if you leave it alone.
+
+<!--toc:start-->
+- [What repo-guardian requires of any Postgres](#what-repo-guardian-requires-of-any-postgres)
+- [Shape matrix](#shape-matrix)
+- [Variables common to all three DB modules](#variables-common-to-all-three-db-modules)
+  - [Parameter groups and engine version](#parameter-groups-and-engine-version)
+- [`modules/rds/instance`](#modulesrdsinstance)
+- [`modules/rds/cluster`](#modulesrdscluster)
+- [`modules/rds/serverless`](#modulesrdsserverless)
+- [`modules/rds/proxy`](#modulesrdsproxy)
+- [Building the DSN](#building-the-dsn)
+- [Chart values](#chart-values)
+- [Verification checklist](#verification-checklist)
+- [Known limitations](#known-limitations)
+<!--toc:end-->
+
+## What repo-guardian requires of any Postgres
+
+Five requirements drive every setting below. They come from the code,
+not from preference.
+
+1. **A database must already exist.** Every pod calls
+   `pgstore.Migrate(cfg.StoreDSN)` at startup
+   (`cmd/repo-guardian/main.go:391`) and fails fast if it can't apply
+   `0001_init.up.sql`. The module's `database_name` defaults to `null`,
+   which creates **no** database — so this must be set explicitly or the
+   binary crash-loops on first boot.
+2. **DDL privileges on that database.** Migrations run in-process, in
+   every replica, on every start. There is no separate migration Job and
+   no separate migration DSN.
+3. **A static username/password DSN.** `postgres.New` does
+   `pgxpool.ParseConfig(dsn)` and nothing else — no `BeforeConnect` hook,
+   no credential refresh. This is what makes IAM auth unusable (below).
+4. **Writer access.** `StaleRepos` is read-heavy but everything shares
+   one DSN slot; reader endpoints have no wiring today
+   (DESIGN-0016 is Draft).
+5. **Plain Postgres, default parameters.** The schema is two indexes and
+   a table with no version-specific syntax, so any supported engine
+   version works — but run the **same major the chart runs** (18; both
+   `store.postgres.baked.image: postgres:18.4` and
+   `store.postgres.cnpg.imageName: ...postgresql:18.4`) so dev/test on
+   the chart-managed shapes exercises the major prod runs on. Neither
+   chart mode sets a single custom Postgres parameter, so RDS
+   default-valued parameter groups are correct — see
+   [Parameter groups](#parameter-groups-and-engine-version).
+
+## Shape matrix
+
+| Shape | Module(s) | Endpoint the DSN points at | Use when |
+|---|---|---|---|
+| Instance, no proxy | `instance` | `endpoint` | Simplest. Dev, or single-replica prod. |
+| Instance + proxy | `instance` + `proxy` | `proxy_endpoint` | **Recommended default.** Survives failover, absorbs replica restarts. |
+| Cluster, no proxy | `cluster` | `cluster_endpoint` | HA without the proxy hop. |
+| Cluster + proxy | `cluster` + `proxy` | `proxy_endpoint` | HA + connection stability. Best availability. |
+| Serverless, no proxy | `serverless` | `cluster_endpoint` | Not recommended — scaling events cause connection storms. |
+| Serverless + proxy | `serverless` + `proxy` | `proxy_endpoint` | **Recommended for spiky/idle workloads.** Proxy is close to mandatory here. |
+
+repo-guardian's load shape is long idle stretches punctuated by sweep
+bursts, which suits Serverless v2 — but only with the proxy in front.
+
+## Variables common to all three DB modules
+
+### Composition plumbing (required, no defaults)
+
+Identical across `instance`, `cluster`, and `serverless`. These locate
+the VPC remote state; Terragrunt injects them in production.
+
+| Variable | Notes |
+|---|---|
+| `region` | Deployment region. |
+| `remote_state_bucket` | Bucket holding the VPC stack state. |
+| `remote_state_bucket_region` | Region *of the bucket* — differs from `region` in multi-region setups. |
+| `vpc_name` | Composed into the state key. |
+| `account_name` | Prefix of the account-scoped state key. |
+| `account_id` | 12-digit ID owning the bucket. |
+| `deploy_role_name` | Role assumed for the cross-account state read. |
+| `identifier_prefix` | Must match `^[a-z][a-z0-9-]{0,61}[a-z0-9]$`. |
+| `engine` | Validated per module — see each section. |
+
+### Must-set for repo-guardian (module defaults are wrong for us)
+
+| Variable | Default | Set to | Why |
+|---|---|---|---|
+| `database_name` | `null` | `"repoguardian"` | **The one that bites.** Default creates no database; migrations fail on first boot. |
+| `allowed_consumer_sg_ids` | `[]` | EKS node SG, **or** the proxy SG | Default is reachable from nowhere. With a proxy this is the *proxy's* SG, not the nodes'. |
+| `master_username` | `"admin"` | `"admin"` or `"repoguardian"` | Cosmetic, but it goes in the DSN — pick before first apply, changing it later forces replacement. |
+
+### Recommended
+
+| Variable | Default | Recommendation |
+|---|---|---|
+| `engine_version` | `null` (module resolves major 18) | **Pin `"18"`** — the major the chart runs (`postgres:18.4` baked, CNPG `18.4`). Pinning matters even though the module's default is currently also 18: `default_major_map` is Renovate-bumped, so an unpinned prod DB changes major whenever the module updates. See [Parameter groups and engine version](#parameter-groups-and-engine-version). |
+| `manage_master_user_password` | `true` | Keep `true` — but read [Known limitations](#known-limitations) on rotation, which is not free for this consumer. |
+| `backup_retention_period` | `7` | `7` dev / `30` prod. |
+| `deletion_protection` | `true` | Keep `true`. |
+| `publicly_accessible` | `false` | Keep `false`. |
+| `performance_insights_enabled` | `false` | `true` in prod — the cheapest way to see whether the sweep is DB-bound. |
+| `skip_final_snapshot` | `false` | Keep `false`; supply `final_snapshot_identifier` at destroy time. |
+| `iam_database_authentication_enabled` | `false` | **Keep `false`** — unusable, see limitations. |
+
+### Parameter groups and engine version
+
+The modules create parameter groups **unconditionally** — you never
+create or attach one yourself, and there is nothing to configure inside
+them today:
+
+- `instance` creates one `aws_db_parameter_group`; `cluster` and
+  `serverless` create the Aurora pair (`aws_rds_cluster_parameter_group`
+  + `aws_db_parameter_group` for the instances).
+- All are **deliberately empty** in module v1 ("No custom `parameter`
+  blocks — per-parameter tuning is a later additive change"). They exist
+  as rename-safe attachment points (`create_before_destroy`) so future
+  tuning never forces instance replacement.
+- The family auto-resolves from `engine` + `engine_version` via a static
+  map: `postgres16/17/18` on `instance`, `aurora-postgresql14`–`18` on
+  the Aurora shapes. `parameter_family` is an override for the rare case
+  the map lags a new major — with `engine_version = "18"` it resolves to
+  `postgres18` / `aurora-postgresql18` and you should leave it null.
+
+**repo-guardian needs nothing custom in them.** This is verifiable on
+both sides: the chart's baked mode runs stock `postgres:18.4` with no
+`args` and no config file, the CNPG `Cluster` CR sets no
+`postgresql.parameters` block, and the store itself needs no
+non-default server behaviour (one table, two indexes, parameterized
+queries via pgx, and session advisory locks for migrations — all
+default-on). So the empty default-valued groups the module creates are
+not a gap to fill; they are the same "stock Postgres" contract the
+chart-managed shapes already run.
+
+Three parameter-adjacent facts still worth knowing:
+
+- **`rds.force_ssl = 1` is the default on RDS for PostgreSQL 15+** —
+  plaintext connections are rejected server-side. This is why
+  `sslmode=require` in the DSN is mandatory on the `instance` shape, not
+  just recommended. Aurora PostgreSQL does *not* force TLS by default;
+  there the proxy's `require_tls = true` is what enforces it.
+- **`max_connections` is a family default derived from instance
+  memory** (`{DBInstanceClassMemory/9531392}` for Postgres — ≈112 on a
+  `db.t4g.micro`). It bounds the [connection math](#chart-values);
+  size `replicas × maxConns` against it, don't raise it in a parameter
+  group.
+- **If tuning is ever genuinely needed** (e.g.
+  `log_min_duration_statement` while chasing a slow sweep), the module
+  cannot express it today — no variable accepts parameter blocks. That's
+  a module feature request, not a values tweak; and if a parameter turns
+  out to matter for repo-guardian itself, mirror it into the chart's
+  baked/CNPG shapes so all four deployment shapes keep running the same
+  effective config.
+
+## `modules/rds/instance`
+
+Non-Aurora, single instance.
+
+### Required beyond the common set
+
+| Variable | Constraint | Suggested |
+|---|---|---|
+| `engine` | `postgres` or `mysql` | `"postgres"` |
+| `instance_class` | — | `db.t4g.micro` dev / `db.t4g.medium` prod |
+| `allocated_storage` | `>= 20` | `20` — the schema is one small table; storage is not the constraint |
+
+### Instance-only optionals
+
+| Variable | Default | Notes |
+|---|---|---|
+| `multi_az` | `false` | `true` for prod HA. The only HA lever this module has. |
+| `max_allocated_storage` | `null` | Set above `allocated_storage` to enable autoscaling. Rarely needed here. |
+| `storage_type` | `gp3` | Leave. |
+| `iops` / `storage_throughput` | `null` | Leave. `iops` becomes required if you switch to `io2`. |
+| `ca_cert_identifier` | `null` | Set only if pinning a specific RDS CA. |
+
+```hcl
+module "repo_guardian_db" {
+  source = ".../modules/rds/instance"
+
+  region                     = "us-east-1"
+  remote_state_bucket        = var.remote_state_bucket
+  remote_state_bucket_region = "us-east-1"
+  vpc_name                   = "platform"
+  account_name               = var.account_name
+  account_id                 = var.account_id
+  deploy_role_name           = var.deploy_role_name
+
+  identifier_prefix = "repo-guardian"
+  engine            = "postgres"
+  engine_version    = "18" # match the chart's baked/CNPG major (postgres:18.4)
+  instance_class    = "db.t4g.medium"
+  allocated_storage = 20
+  # parameter_family omitted — auto-resolves to "postgres18"; the module
+  # creates the (empty, default-valued) parameter group itself.
+
+  database_name           = "repoguardian"
+  master_username         = "repoguardian"
+  allowed_consumer_sg_ids = [module.eks.node_security_group_id]  # or [module.proxy.proxy_security_group_id]
+
+  multi_az                     = true
+  backup_retention_period      = 30
+  performance_insights_enabled = true
+
+  tags = local.tags
+}
+```
+
+## `modules/rds/cluster`
+
+Aurora provisioned. Same surface as `instance` minus the storage knobs,
+plus cluster concerns.
+
+### Required beyond the common set
+
+| Variable | Constraint | Suggested |
+|---|---|---|
+| `engine` | `aurora-postgresql` or `aurora-mysql` | `"aurora-postgresql"` |
+| `engine_version` | optional but pin it | `"18"` — chart-major parity, resolves family `aurora-postgresql18` |
+| `instance_class` | — | `db.t4g.medium` / `db.r6g.large` |
+
+Note there is **no `allocated_storage`** — Aurora storage is elastic.
+
+### Cluster-only optionals
+
+| Variable | Default | Notes |
+|---|---|---|
+| `backtrack_window` | — | Aurora-MySQL only in practice; leave unset for Postgres. |
+| `enabled_cloudwatch_logs_exports` | — | `["postgresql"]` to ship logs. |
+| `promotion_tier` | — | Failover priority. Single-instance clusters can ignore it. |
+
+**Endpoint choice matters here.** The module emits both
+`cluster_endpoint` (writer) and `reader_endpoint`. Use
+**`cluster_endpoint`** — repo-guardian writes on every reconcile, and
+pointing it at the reader produces read-only transaction errors on the
+first write-back.
+
+## `modules/rds/serverless`
+
+Aurora Serverless v2.
+
+### Required beyond the common set
+
+| Variable | Constraint | Suggested |
+|---|---|---|
+| `engine` | `aurora-postgresql` or `aurora-mysql` | `"aurora-postgresql"` |
+| `engine_version` | optional but pin it | `"18"` — chart-major parity, resolves family `aurora-postgresql18` |
+| `min_acu` | `0.5` – `256` | `0.5` |
+| `max_acu` | `0.5` – `256`, `>= min_acu` | `4` dev / `16` prod |
+
+`min_acu = 0.5` still bills continuously (~$0.12/ACU-hour for Postgres
+in us-east-1 at time of writing), so the floor is a cost decision, not a
+performance one. repo-guardian idles between sweeps, which is precisely
+the shape that makes a low floor worth it.
+
+Same writer-endpoint rule as `cluster`: use `cluster_endpoint`.
+
+**Pair this with the proxy.** Serverless v2 scaling events drop
+connections; without a proxy, pgxpool sees them as connection errors
+mid-sweep.
+
+## `modules/rds/proxy`
+
+The proxy module reads the target's remote state rather than taking its
+attributes as inputs, so its required surface is just pointers.
+
+### Required
+
+| Variable | Notes |
+|---|---|
+| `region`, `remote_state_bucket`, `remote_state_bucket_region`, `account_name`, `account_id`, `deploy_role_name` | Same plumbing as the DB modules. |
+| `name` | `^[a-zA-Z][a-zA-Z0-9-]{0,58}[a-zA-Z0-9]$`. AWS additionally rejects `--`. |
+| `target_type` | **`rds-instance`** \| **`aurora-cluster`** \| **`serverless`** — must match the module you deployed. Selects both the remote-state key shape and whether the target is keyed by instance or cluster identifier. |
+| `target_identifier` | The DB's `identifier_prefix`. |
+
+### Optionals that matter for repo-guardian
+
+| Variable | Default | Set to | Why |
+|---|---|---|---|
+| `allowed_consumer_sg_ids` | `[]` | EKS node SG | Default is reachable from nowhere. |
+| `require_tls` | `true` | `true` | Keep. Your DSN then needs `sslmode=require` or stricter. |
+| `require_iam_auth` | `false` | **`false`** | `true` makes repo-guardian unable to connect at all. |
+| `max_connections_percent` | `100` | `50`–`75` | Leaves headroom for admin sessions. |
+| `max_idle_connections_percent` | `50` | `<= max_connections_percent` | Cross-bound is enforced by a precondition. |
+| `connection_borrow_timeout` | `120` | `120` | Fine as-is at this QPS. |
+| `idle_client_timeout` | `1800` | `1800` | Fine. Sweeps are far shorter than 30 min. |
+| `session_pinning_filters` | `[]` | `["EXCLUDE_VARIABLE_SETS"]` | Reduces pinning. See the pinning note below. |
+| `create_read_only_endpoint` | `false` | `false` | Aurora-only, and unusable until DESIGN-0016 lands. |
+| `debug_logging` | `false` | `false` | Logs SQL to CloudWatch. |
+
+### The two-apply security-group dance
+
+The proxy sits between the app and the DB, so the SG wiring is *not*
+symmetric and can't be done in one pass:
+
+1. Apply the **DB** module with `allowed_consumer_sg_ids = []` (or just
+   the nodes, temporarily).
+2. Apply the **proxy** module with
+   `allowed_consumer_sg_ids = [<EKS node SG>]`.
+3. Re-apply the **DB** module with
+   `allowed_consumer_sg_ids = [module.proxy.proxy_security_group_id]`.
+
+The module documents this: `proxy_security_group_id` is emitted as an
+output specifically "so it can be added to the DB module's
+`allowed_consumer_sg_ids` on a subsequent apply." Once the proxy is in
+front, the nodes should generally **not** retain direct DB ingress —
+that path bypasses the pool.
+
+### Pinning
+
+RDS Proxy falls back to a dedicated (pinned) connection when a session
+carries state it can't safely multiplex. Two things repo-guardian does
+are relevant:
+
+- **Migrations take a session-level advisory lock.** golang-migrate's
+  pgx/v5 driver issues `SELECT pg_advisory_lock($1)`
+  (`database/pgx/v5/pgx.go:229`). That's session state by definition, so
+  every pod's startup migration will pin its connection for the duration.
+  It's brief and correct — but it's why you may see pinning spikes on
+  rollouts specifically.
+- **pgx uses prepared statements by default.** `QueryExecModeCacheStatement`
+  is the default exec mode (`pgx@v5.9.2/conn.go:190`).
+
+Neither is a reason to avoid the proxy. But if you see
+`DatabaseConnectionsCurrentlySessionPinned` sitting high in CloudWatch,
+the lever is `default_query_exec_mode=simple_protocol` in the DSN —
+pgx parses that key directly out of the connection string, so it needs
+no code change. Trade-off: simple protocol disables the statement cache,
+which costs a round trip per query. At repo-guardian's QPS that is
+irrelevant; measure before reaching for it.
+
+## Building the DSN
+
+```text
+postgres://<master_username>:<password>@<endpoint>:5432/<database_name>?sslmode=require
+```
+
+| Shape | `<endpoint>` from |
+|---|---|
+| instance, no proxy | `module.db.endpoint` (or `address` for host-only) |
+| instance + proxy | `module.proxy.proxy_endpoint` |
+| cluster / serverless, no proxy | `module.db.cluster_endpoint` ← writer, **not** `reader_endpoint` |
+| cluster / serverless + proxy | `module.proxy.proxy_endpoint` |
+
+`endpoint` on the instance module includes the port; `address` is
+host-only. Check which you're interpolating so you don't end up with
+`host:5432:5432`.
+
+**Percent-encode the password.** RDS-managed master passwords exclude
+`/`, `@`, `"`, and space — but *not* `%`, `+`, `:`, `?` — so encoding
+is still required. There is no way to validate or transform the DSN at
+the `secretKeyRef` (env injection is a byte copy), so correctness lives
+at the producer: the [ESO example in aws.md](aws.md#credentials-via-external-secrets-operator)
+assembles the DSN with `urlquery | replace "+" "%20"`. The replace is
+load-bearing: pgx treats `+` in the password position as a **literal
+plus**, so an encoder that maps space → `+` mints a wrong password.
+
+How an unencoded password actually fails (verified against pgx v5.9.2,
+the parser the binary uses):
+
+- space, `/`, or a malformed `%`-escape → hard parse error; the pod
+  crash-loops at startup before doing any work (password redacted in
+  the error).
+- raw `@`, `+`, `:` → tolerated; pgx recovers the correct password.
+- `%` followed by two hex digits → **silently decodes to a different
+  password** and presents as `password authentication failed` at
+  startup. This is the diagnosis trap: with Secrets Manager rotation
+  in the picture it looks exactly like a rotation problem. If auth
+  fails right after a password change and the new password contains
+  `%`, check encoding before chasing rotation.
+
+Eyeballing the Secret is not a decisive check for the last case — the
+Secret holds the *encoded* form and pgx uses the *decoded* form. To see
+exactly the password the binary will present to Postgres:
+
+```bash
+kubectl get secret <name> -n <ns> -o jsonpath='{.data.STORE_DSN}' | base64 -d |
+  python3 -c 'import sys
+from urllib.parse import urlsplit, unquote
+print(repr(unquote(urlsplit(sys.stdin.read().strip()).password)))'
+```
+
+(`unquote`, not `unquote_plus` — pgx treats `+` in the password as a
+literal plus, and so does `unquote`.)
+
+If that output doesn't match the real password, the DSN in the Secret
+is mis-encoded, regardless of how correct it looks raw.
+
+**`sslmode` is not optional in practice.** pgx defaults to `prefer`,
+which silently accepts an unencrypted connection. RDS accepts TLS
+everywhere and the proxy *requires* it when `require_tls = true`, so set
+at least `sslmode=require`. For `verify-full` you must also mount the
+RDS CA bundle and add `sslrootcert=`; `require` encrypts without
+verifying the server certificate.
+
+## Chart values
+
+Identical for all six shapes — only the DSN inside the Secret changes:
+
+```yaml
+store:
+  backend: postgres
+  postgres:
+    mode: external
+    existingSecret: repo-guardian-store-dsn
+    existingSecretKey: STORE_DSN
+    maxConns: 10
+```
+
+Guards worth knowing: setting `store.postgres.existingSecret` while
+`mode != external` fails the render deliberately
+(`repo-guardian.validateBackendSecrets`), as does setting
+`store.postgres.baked.existingSecret` outside baked mode. That's
+IMPL-0018's fix for silently-ignored config.
+
+**Connection math:** `maxConns` is per replica, so the ceiling is
+`replicas × maxConns`. Three replicas at the chart default of 16 is 48
+client connections — against a `db.t4g.micro`
+(`max_connections` ≈ 112) that's already 43% of the instance before
+anything else connects. With a proxy, size
+`max_connections_percent` so `replicas × maxConns` fits inside the
+proxy's share.
+
+## Verification checklist
+
+```bash
+# 1. The database exists (the #1 first-boot failure)
+psql "$STORE_DSN" -c '\l' | grep repoguardian
+
+# 2. TLS is actually on
+psql "$STORE_DSN" -c 'SELECT ssl FROM pg_stat_ssl WHERE pid = pg_backend_pid();'
+
+# 3. Migrations applied
+psql "$STORE_DSN" -c '\dt' | grep -E 'repo_state|schema_migrations'
+
+# 4. From inside the cluster, not your laptop — SG rules differ
+kubectl run pg-probe --rm -it --restart=Never -n repo-guardian \
+  --image=postgres:18-alpine -- psql "$STORE_DSN" -c 'SELECT 1;'
+```
+
+Then confirm the pod got past migrations:
+
+```bash
+kubectl logs -n repo-guardian deploy/repo-guardian | grep -i migrat
+```
+
+## Known limitations
+
+- **IAM database authentication is unusable.** Not "discouraged" —
+  unusable. `postgres.New` builds the pool from a static DSN with no
+  `BeforeConnect` hook, and IAM tokens expire every 15 minutes, so the
+  pool would authenticate once and then fail every subsequent
+  connection. Leave `iam_database_authentication_enabled = false` on the
+  DB and `require_iam_auth = false` on the proxy. Supporting it means a
+  code change (a `BeforeConnect` that mints a token per connection).
+
+- **Password rotation is not transparent, even with a proxy.** With
+  `manage_master_user_password = true`, AWS rotates the secret. Clients
+  authenticate to RDS Proxy with the *same* credentials the proxy holds
+  in Secrets Manager — the proxy does not issue separate static
+  credentials — so a rotation invalidates the password the pods are
+  using. External Secrets Operator re-syncs the k8s Secret, but existing
+  pgxpool connections keep the old password until they're recycled, and
+  the Deployment needs a restart (or a `reloader`-style annotation) to
+  pick up the new env value at all. Options: accept a brief blip and
+  automate the restart, or set `manage_master_user_password = false` and
+  own rotation on your own schedule.
+
+- **Migrations run in every replica, through whatever the DSN points
+  at.** There is no separate migration DSN, so with a proxy the
+  advisory-lock handshake goes through the proxy too. It is safe —
+  golang-migrate's lock serialises concurrent pods — but you cannot
+  route migrations to the direct endpoint while runtime traffic uses the
+  proxy without a code or chart change. `postgres.Migrate` is exported
+  separately with a one-shot Job in mind; the chart doesn't ship one yet.
+
+- **No reader/writer split.** Aurora reader endpoints and the proxy's
+  `create_read_only_endpoint` have nowhere to plug in. Tracked in
+  [DESIGN-0016](../design/0016-separate-postgres-read-and-write-endpoints.md)
+  (Draft).
+
+- **`master_username` is baked into the DSN.** Changing it after first
+  apply forces a replacement. Decide before the first apply.

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,7 +15,7 @@ your Helm values under `policy.config`.
 | [`guardian-full.hcl`](guardian-full.hcl) | Kitchen sink — all rule types, assertions, reconcilers, ignore lists, settings, branch protection. |
 | [`guardian-multi-org.hcl`](guardian-multi-org.hcl) | Strict-mode multi-org example in a single file. Top-level `scope { }` + per-rule scopes (universal `["*"]` and per-org subsets). |
 | [`guardian-multi-org/`](guardian-multi-org/) | Same as above, split across `scope.hcl`, `shared.hcl`, `prod-only.hcl`, `staging-only.hcl`. Point `GUARDIAN_CONFIG` at the directory. |
-| [`guardian-enterprise.hcl`](guardian-enterprise.hcl) | Enterprise App topology: one App installed across every org in the enterprise, but the policy enumerates which orgs to reconcile. Per-org rule scoping for diverging policies. Repos from unconfigured enterprise orgs are silently skipped (visible via `repo_guardian_out_of_scope_total{level="policy"}`). |
+| [`guardian-enterprise.hcl`](guardian-enterprise.hcl) | Enterprise App topology: one App installed across every org in the enterprise, but the policy enumerates which orgs to reconcile. Per-org rule scoping for diverging policies, PR templates at all three scopes (with the PR-vs-file template variable sets documented — `.Org` is file-template-only), catalog-info assertions + custom-property sync, and a when-gated absent rule. Setup runbook: `docs/operations/ent-setup.md`. Repos from unconfigured enterprise orgs are silently skipped (visible via `repo_guardian_out_of_scope_total{level="policy"}`). |
 
 ### Usage
 

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -6,12 +6,90 @@ import (
 	"testing"
 
 	"github.com/donaldgifford/repo-guardian/internal/policy"
+	"github.com/donaldgifford/repo-guardian/internal/rules"
 )
 
 func examplesDir() string {
 	_, file, _, _ := runtime.Caller(0)
 
 	return filepath.Dir(file)
+}
+
+// allExampleConfigs lists every loadable example config (files and
+// directories). New examples MUST be added here so the sweeping
+// validity tests below cover them.
+func allExampleConfigs() []string {
+	return []string{
+		"guardian-minimal.hcl",
+		"guardian-renovate.hcl",
+		"guardian-full.hcl",
+		"guardian-multi-org.hcl",
+		"guardian-enterprise.hcl",
+		"guardian-multi-org", // directory-style config
+	}
+}
+
+// TestExampleHCL_AllExamples_PRTemplatesStrict runs the strict PR
+// template validator over every example. This catches variables that
+// don't exist in the PR render context (e.g. `.Org`, which is
+// file-template-only) — without this lock an example deploys clean and
+// fails at render time on the first actionable repo.
+func TestExampleHCL_AllExamples_PRTemplatesStrict(t *testing.T) {
+	for _, name := range allExampleConfigs() {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := policy.Load(filepath.Join(examplesDir(), name))
+			if err != nil {
+				t.Fatalf("Load %s: %v", name, err)
+			}
+
+			if err := policy.ValidatePRTemplates(cfg); err != nil {
+				t.Errorf("ValidatePRTemplates(%s): %v", name, err)
+			}
+		})
+	}
+}
+
+// TestExampleHCL_AllExamples_TemplateNamesResolve checks that every
+// file-rule template name referenced by an example resolves against the
+// embedded TemplateStore. Template resolution happens at check time,
+// not load time, so a typo (e.g. "renovate-config" instead of
+// "renovate") loads clean and then errors on the first actionable repo.
+// Examples that intentionally reference operator-supplied templates
+// (chart templates.files) must be allowlisted here with a comment.
+func TestExampleHCL_AllExamples_TemplateNamesResolve(t *testing.T) {
+	store := rules.NewTemplateStore()
+	if err := store.Load(""); err != nil {
+		t.Fatalf("loading embedded templates: %v", err)
+	}
+
+	// name → reason it is operator-supplied rather than embedded.
+	operatorSupplied := map[string]string{}
+
+	for _, name := range allExampleConfigs() {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := policy.Load(filepath.Join(examplesDir(), name))
+			if err != nil {
+				t.Fatalf("Load %s: %v", name, err)
+			}
+
+			for i := range cfg.FileRules {
+				r := &cfg.FileRules[i]
+
+				// Absent rules forbid templates at load; nothing to resolve.
+				if r.CheckMode() == policy.CheckAbsent {
+					continue
+				}
+
+				if _, ok := operatorSupplied[r.Template]; ok {
+					continue
+				}
+
+				if _, err := store.Get(r.Template); err != nil {
+					t.Errorf("rule %q references template %q, not in the embedded set: %v", r.Name, r.Template, err)
+				}
+			}
+		})
+	}
 }
 
 func TestExampleHCL_Minimal(t *testing.T) {
@@ -144,10 +222,11 @@ func TestExampleHCL_Enterprise(t *testing.T) {
 		t.Errorf("Scope.Orgs count = %d, want 3", len(cfg.Scope.Orgs))
 	}
 
-	// Two universal-scope baseline rules (codeowners + dependabot) and one
-	// org-specific rule pair (renovate workflow + config for myent-product).
-	if len(cfg.FileRules) != 4 {
-		t.Errorf("FileRules count = %d, want 4", len(cfg.FileRules))
+	// Three universal-scope baseline rules (codeowners + dependabot +
+	// catalog_info) and the myent-product trio (renovate workflow +
+	// config + gated no_dependabot absent rule).
+	if len(cfg.FileRules) != 6 {
+		t.Errorf("FileRules count = %d, want 6", len(cfg.FileRules))
 	}
 
 	if len(cfg.SettingRules) != 1 {
@@ -175,6 +254,25 @@ func TestExampleHCL_Enterprise(t *testing.T) {
 		if r.Scope == nil {
 			t.Errorf("BranchProtectionRule %q missing scope (strict mode)", r.Name)
 		}
+	}
+
+	// PR template grammar: defaults.pr, per-rule partial override, and
+	// per-reconciler inherits=false — the surface the enterprise example
+	// documents (PRVars vs FileVars variable sets).
+	if cfg.Defaults == nil || cfg.Defaults.PR == nil {
+		t.Fatal("expected defaults.pr block to be parsed")
+	}
+
+	if cfg.Defaults.PR.CompiledTitle == nil {
+		t.Error("defaults.pr.title not compiled")
+	}
+
+	if rulePR := cfg.RulePR("codeowners"); rulePR == nil || rulePR.Title == nil {
+		t.Error("expected RulePR(codeowners) to resolve with a title")
+	}
+
+	if recPR := cfg.ReconcilerPR("catalog_info", "custom_properties"); recPR == nil || recPR.Title == nil {
+		t.Error("expected ReconcilerPR(catalog_info, custom_properties) to resolve with a title")
 	}
 }
 

--- a/examples/guardian-enterprise.hcl
+++ b/examples/guardian-enterprise.hcl
@@ -1,11 +1,15 @@
 // guardian-enterprise.hcl — GitHub Enterprise App, installed on every org
 // in the enterprise, run against only the configured subset.
 //
+// Setup runbook for the enterprise topology (App registration, scripted
+// installs, verification): docs/operations/ent-setup.md.
+//
 // Topology:
 //   - One GitHub App at the enterprise level (single auth, GITHUB_APP_ID +
 //     private key).
 //   - The App is installed on every org in the enterprise (operator-side
-//     concern via the Enterprise admin UI).
+//     concern via the Enterprise admin UI or the install script in
+//     ent-setup.md).
 //   - repo-guardian receives webhooks + discovery rows for every install.
 //   - This policy enumerates which orgs to actually reconcile, and each
 //     configured org gets its own per-rule scope so policies can diverge.
@@ -28,6 +32,16 @@
 //   this is wasteful — track the metric and file a feature request for
 //   discovery-time scope gating if it becomes load-bearing.
 
+guardian {
+  log_level         = "info"
+  dry_run           = false
+  worker_count      = 5
+  queue_size        = 1000
+  schedule_interval = "168h"
+  skip_forks        = true
+  skip_archived     = true
+}
+
 // Top-level scope: ONLY the orgs we want repo-guardian to reconcile.
 // Add orgs here as teams onboard. Orgs the App is installed on but
 // NOT listed here will be silently skipped (visible via
@@ -37,6 +51,64 @@ scope {
     "myent-platform",   // platform / infra org — strictest baseline
     "myent-product",    // product engineering — baseline + Renovate
     "myent-sandbox",    // experimentation org — relaxed rules
+  ]
+}
+
+// =========================================================================
+// PR template defaults — and the two template variable sets.
+// =========================================================================
+// There are TWO distinct template contexts, and they do not share fields:
+//
+//   pr {} blocks (title/body) render with the PR context:
+//     .Owner .Repo .DefaultBranch .Date   — repo identity
+//     .Rule {Name Target Action}          — single-rule PRs
+//     .Rules                              — bundled multi-rule PRs (slice)
+//     .Files                              — every path in the PR
+//     .Reconciler                         — set for reconciler-opened PRs
+//
+//   File templates (the rendered CODEOWNERS / catalog-info.yaml / etc.,
+//   supplied via chart `templates.files` or the embedded defaults) render
+//   with the file context, which additionally has:
+//     .Org       — alias for .Owner (file templates ONLY)
+//     .Catalog   — parsed catalog-info fields, where applicable
+//
+// THE TRAP: `.Org` does not exist in pr {} blocks. Use `.Owner` there.
+// A pr title/body referencing `.Org` fails at render time (or at startup
+// under STRICT_TEMPLATES=true, which you should run in CI — see
+// --strict-templates in the chart values).
+//
+// Helpers available in both contexts: env, default, join, lower, upper,
+// title. NEVER reference secret env vars in PR text — rendered output is
+// visible to PR reviewers.
+defaults {
+  pr {
+    title = "[{{ env \"JIRA_PROJECT\" | default \"GUARDIAN\" }}] guardian: {{ .Owner }}/{{ .Repo }}"
+    body = <<EOT
+## Repo Guardian
+
+This PR was opened automatically by **repo-guardian** for
+`{{ .Owner }}/{{ .Repo }}` (default branch: `{{ .DefaultBranch }}`).
+
+### Files changed
+{{ range .Files }}- `{{ . }}`
+{{ end }}
+
+### What to do
+1. Review each file for your team's needs.
+2. Merge when ready — these are sensible defaults, not one-size-fits-all.
+
+---
+*Need help? Reach out in #platform-engineering.*
+EOT
+    labels = ["automated", "guardian"]
+  }
+}
+
+// Global ignore list — these repos are skipped for ALL rules, in every org.
+ignore {
+  repos = [
+    "*/.github",         // org meta-repos manage their own config
+    "*/archive-*",
   ]
 }
 
@@ -55,6 +127,13 @@ rule "file" "codeowners" {
   scope {
     orgs = ["*"]
   }
+
+  // Partial override: only `title` is set here; body and labels inherit
+  // from defaults.pr (inherits defaults to true).
+  pr {
+    search_terms = ["codeowners", "CODEOWNERS"]
+    title        = "chore({{ .Repo }}): adopt CODEOWNERS"
+  }
 }
 
 rule "file" "dependabot" {
@@ -64,6 +143,77 @@ rule "file" "dependabot" {
 
   scope {
     orgs = ["*"]
+  }
+
+  pr {
+    search_terms = ["dependabot"]
+  }
+}
+
+// Backstage catalog-info.yaml with content assertions + custom-property
+// sync. The embedded "catalog-info" template renders a skeleton with
+// TODO placeholders (metadata.name = {{ .Repo }}, source-location from
+// {{ .Owner }}/{{ .Repo }}); the assertions below keep the rule
+// actionable until a human replaces the TODOs, so the PR stays open as
+// the prompt. To customize the generated file, supply your own template
+// under chart `templates.files` — file templates may use `.Org` (alias
+// for `.Owner`) in addition to the common fields.
+rule "file" "catalog_info" {
+  check    = "contains"
+  paths    = ["catalog-info.yaml", "catalog-info.yml"]
+  target   = "catalog-info.yaml"
+  template = "catalog-info"
+
+  scope {
+    orgs = ["*"]
+  }
+
+  pr {
+    search_terms = ["catalog-info"]
+  }
+
+  // Regex assertion — file must contain an owner field at all.
+  assertion {
+    pattern = "owner:"
+    message = "catalog-info.yaml must have an owner field"
+  }
+
+  // YAML path assertion — owner must reference a team.
+  assertion {
+    yaml_path = "spec.owner"
+    contains  = "team"
+    message   = "spec.owner must reference a team (e.g., team-platform)"
+  }
+
+  // Negative assertion — no placeholder values left behind.
+  assertion {
+    not_pattern = "TODO"
+    message     = "catalog-info.yaml must not contain TODO placeholders"
+  }
+
+  // Sync ownership metadata to GitHub custom properties after checks
+  // pass. Owner/Component are always managed; annotation_properties
+  // opts additional annotations into the same sync + clear-on-removal
+  // behavior. Requires the org custom-property schema to define the
+  // target names (undefined names are skipped with a warning — see
+  // docs/operations/scaling.md § schema preflight).
+  reconcile "custom_properties" {
+    mode  = "api"
+    watch = true
+
+    annotation_properties = {
+      "jira/project-key" = "JiraProject"
+      "jira/label"       = "JiraLabel"
+    }
+
+    // Reconciler PRs merge reconciler.pr → defaults.pr only (rule.pr is
+    // deliberately skipped). inherits=false opts out of the defaults
+    // entirely.
+    pr {
+      title    = "chore({{ .Repo }}): sync custom properties from catalog-info"
+      labels   = ["automated", "catalog-sync"]
+      inherits = false
+    }
   }
 }
 
@@ -87,8 +237,8 @@ rule "branch_protection" "main_required" {
 
 // Vulnerability alerts must be on for platform repos.
 rule "setting" "vulnerability_alerts" {
-  property = "vulnerability_alerts_enabled"
-  expected = true
+  property  = "vulnerability_alerts_enabled"
+  expected  = true
   remediate = true
 
   scope {
@@ -97,10 +247,11 @@ rule "setting" "vulnerability_alerts" {
 }
 
 // =========================================================================
-// Product org — baseline + Renovate workflow.
+// Product org — baseline + Renovate, with gated Dependabot removal.
 // =========================================================================
 
 rule "file" "renovate_workflow" {
+  check    = "exact"
   paths    = [".github/workflows/renovate.yml"]
   target   = ".github/workflows/renovate.yml"
   template = "renovate-workflow"
@@ -114,20 +265,55 @@ rule "file" "renovate_workflow" {
   }
 }
 
+// NOTE: the template name is "renovate" (the embedded renovate.json
+// template), not "renovate-config". Template names resolve at check
+// time, not load time — a typo here deploys clean and then errors on
+// the first actionable repo. examples_test.go locks every referenced
+// name against the embedded set.
 rule "file" "renovate_config" {
+  check    = "contains"
   paths    = ["renovate.json", ".github/renovate.json"]
   target   = "renovate.json"
-  template = "renovate-config"
-  check    = "contains"
+  template = "renovate"
 
   scope {
     orgs = ["myent-product"]
+  }
+
+  pr {
+    search_terms = ["renovate"]
   }
 
   assertion {
     yaml_path = "extends"
     contains  = "github>myent-product/renovate-config"
     message   = "renovate.json must extend the shared org preset"
+  }
+}
+
+// Once Renovate is live and reviewed on a product repo's default branch,
+// remove the Dependabot config the universal baseline added. The
+// when-gate is fail-closed and evaluates the default branch only, so
+// Dependabot is never removed before renovate_config is actually
+// satisfied. Absent rules take no target/template/assertion blocks —
+// remediation is a file-deletion PR on the reconcile branch.
+rule "file" "no_dependabot" {
+  check = "absent"
+  paths = [".github/dependabot.yml", ".github/dependabot.yaml"]
+
+  when {
+    rule_satisfied = "renovate_config"
+  }
+
+  scope {
+    orgs = ["myent-product"]
+  }
+
+  pr {
+    // search_terms MUST NOT match the "dependabot" add rule's PR titles,
+    // or the removal PR would be mistaken for the add PR and skipped.
+    search_terms = ["remove dependabot"]
+    title        = "chore({{ .Repo }}): remove Dependabot config (repo uses Renovate)"
   }
 }
 
@@ -153,3 +339,6 @@ rule "file" "renovate_config" {
 //   - For very large directory-style configs, split into a directory of
 //     HCL files (one per org or per concern) and point GUARDIAN_CONFIG
 //     at the directory. See examples/guardian-multi-org/ for the pattern.
+//   - Run with STRICT_TEMPLATES=true (chart: templating.strict) so a bad
+//     variable in any pr {} block fails at startup instead of at render
+//     time on some repo mid-sweep.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
         - 'INV-0010: Silently ignored operator config: auto_close_pr HCL attribute and cross-mode existingSecret': investigation/0010-silently-ignored-operator-config-autoclosepr-hcl-attribute-and.md
         - 'INV-0011: Tech debt cleanup inventory post IMPL-0019': investigation/0011-tech-debt-cleanup-inventory-post-impl-0019.md
         - 'INV-0012: Inert BudgetTracker and untrustworthy alert pack': investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md
+        - 'INV-0013: State-vs-event metrics, dashboard suite, and system observability': investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md
     - Plans:
         - Overview: plan/README.md
     - RFCs:
@@ -80,13 +81,13 @@ nav:
         - Custom-property annotation migration (appVersion 1.9.1 → next minor): operations/annotation-properties-migration.md
         - Custom-property name charset correction (appVersion 1.10.1): operations/property-name-charset.md
         - ECR publish setup (maintainer-side): operations/ecr-publish-setup.md
-        - Enterprise setup — one App across N orgs: operations/ent-setup.md
         - External Postgres on RDS — Terraform variable reference: operations/rds-terraform-variables.md
         - Homelab CNPG cutover runbook: operations/cnpg-homelab-cutover.md
         - Postgres schema operations: operations/migrations.md
         - Running repo-guardian on AWS: operations/aws.md
         - Scaling repo-guardian: operations/scaling.md
         - Template migration guide (chart 0.3.x → 0.4.0): operations/template-migration.md
+        - repo-guardian GitHub App — Enterprise Setup Guide: operations/ent-setup.md
 plugins:
     - techdocs-core
 site_description: Documentation for repo-guardian

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,6 +29,7 @@ nav:
         - 'DESIGN-0019: Configurable annotation-sourced custom properties': design/0019-configurable-annotation-sourced-custom-properties.md
         - 'DESIGN-0020: Absent check mode and conditional file rules': design/0020-absent-check-mode-and-conditional-file-rules.md
         - 'DESIGN-0021: Delayed-requeue job contract and rate-limit consolidation': design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md
+        - 'DESIGN-0022: Compliance posture state, dashboard suite, and OTEL-first observability': design/0022-compliance-posture-state-dashboard-suite-and-otel-first.md
     - Implementation Plans:
         - Overview: impl/README.md
         - 'IMPL-0001: Repo Guardian Implementation Plan': impl/0001-repo-guardian-implementation-plan.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,8 @@ nav:
         - 'IMPL-0019: Absent check mode and conditional file rules': impl/0019-absent-check-mode-and-conditional-file-rules.md
         - 'IMPL-0020: Pre-IMPL-0019 high-severity fixes (INV-0011 Group A High)': impl/0020-pre-impl-0019-high-severity-fixes-inv-0011-group-a-high.md
         - 'IMPL-0021: Post-IMPL-0019 hardening and structural cleanup (INV-0011 Group A Medium + Group B)': impl/0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md
+        - 'IMPL-0022: Delayed-requeue job contract and rate-limit consolidation': impl/0022-delayed-requeue-job-contract-and-rate-limit-consolidation.md
+        - 'IMPL-0023: Compliance posture state, dashboard suite, and OTEL-first observability': impl/0023-compliance-posture-state-dashboard-suite-and-otel-first.md
     - Investigations:
         - Overview: investigation/README.md
         - 'INV-0001: Tailscale Funnel for Webhook Testing': investigation/0001-tailscale-funnel-for-webhook-testing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
         - 'INV-0009: Read-only status API and web UI options': investigation/0009-read-only-status-api-and-web-ui-options.md
         - 'INV-0010: Silently ignored operator config: auto_close_pr HCL attribute and cross-mode existingSecret': investigation/0010-silently-ignored-operator-config-autoclosepr-hcl-attribute-and.md
         - 'INV-0011: Tech debt cleanup inventory post IMPL-0019': investigation/0011-tech-debt-cleanup-inventory-post-impl-0019.md
+        - 'INV-0012: Inert BudgetTracker and untrustworthy alert pack': investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md
     - Plans:
         - Overview: plan/README.md
     - RFCs:
@@ -71,12 +72,12 @@ nav:
         - 'RFC-0001: Repo Compliance App (repo-guardian)': rfc/0001-repo-compliance-app-repo-guardian.md
         - 'RFC-0002: HCL-driven Policy Engine for repo-guardian': rfc/0002-hcl-driven-policy-engine-for-repo-guardian.md
     - Operations:
-        - Absent rules and conditional gates migration (IMPL-0019): operations/absent-rules-migration.md
+        - Absent rules and conditional gates migration (appVersion → next minor): operations/absent-rules-migration.md
         - Chart 0.5.0 migration runbook (IMPL-0011): operations/chart-0.5.0-migration.md
         - Chart 0.6.0 / appVersion 1.7.0 — PR convergence migration: operations/pr-convergence-migration.md
-        - Custom-property annotation migration (appVersion 1.9.1 → next minor): operations/annotation-properties-migration.md
         - Custom-properties security fix (IMPL-0020): operations/custom-properties-security-fix.md
-        - Custom-property name charset correction (IMPL-0021): operations/property-name-charset.md
+        - Custom-property annotation migration (appVersion 1.9.1 → next minor): operations/annotation-properties-migration.md
+        - Custom-property name charset correction (appVersion 1.10.1): operations/property-name-charset.md
         - ECR publish setup (maintainer-side): operations/ecr-publish-setup.md
         - Homelab CNPG cutover runbook: operations/cnpg-homelab-cutover.md
         - Postgres schema operations: operations/migrations.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,8 @@ nav:
         - Custom-property annotation migration (appVersion 1.9.1 → next minor): operations/annotation-properties-migration.md
         - Custom-property name charset correction (appVersion 1.10.1): operations/property-name-charset.md
         - ECR publish setup (maintainer-side): operations/ecr-publish-setup.md
+        - Enterprise setup — one App across N orgs: operations/ent-setup.md
+        - External Postgres on RDS — Terraform variable reference: operations/rds-terraform-variables.md
         - Homelab CNPG cutover runbook: operations/cnpg-homelab-cutover.md
         - Postgres schema operations: operations/migrations.md
         - Running repo-guardian on AWS: operations/aws.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
         - 'DESIGN-0018: Deprecate memory backend': design/0018-deprecate-memory-backend.md
         - 'DESIGN-0019: Configurable annotation-sourced custom properties': design/0019-configurable-annotation-sourced-custom-properties.md
         - 'DESIGN-0020: Absent check mode and conditional file rules': design/0020-absent-check-mode-and-conditional-file-rules.md
+        - 'DESIGN-0021: Delayed-requeue job contract and rate-limit consolidation': design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md
     - Implementation Plans:
         - Overview: impl/README.md
         - 'IMPL-0001: Repo Guardian Implementation Plan': impl/0001-repo-guardian-implementation-plan.md


### PR DESCRIPTION
Docs-only PR (\`dont-release\`). Full planning arc from the inert-BudgetTracker finding through decision-complete implementation plans, plus the enterprise-migration operational docs.

## Investigations
- **INV-0012** — inert BudgetTracker + untrustworthy alert pack (findings A–K, Concluded by DESIGN-0021)
- **INV-0013** — state-vs-event metrics, dashboard suite, system observability (findings A–I: posture-vs-event classification, PG-vs-Prom source assignment, 1+N resolution, four-dashboard architecture, USE/RED gaps, OTEL scoping, config-generated dashboards, signal taxonomy)

## Designs (all open questions resolved 2026-08-02)
- **DESIGN-0021** — delayed-requeue job contract + rate-limit consolidation; INV-0013 amendments folded in (wait-pair retirement, otelhttp ordering contract, OQ2 resolved on enterprise-migration evidence)
- **DESIGN-0022** — compliance posture state (rule_state table + leader-scoped exporter), OTEL metrics-first via prometheus bridge, compliance snapshots + report CLI, guardian.hcl-driven monitoring generator, E1–E4 dashboard suite

## Implementation plans (all open questions resolved)
- **IMPL-0022** — DESIGN-0021 phases 0–7; Phase 0 bundled with Phase 1, terminal disposition via repo_state, rate_limit_remaining sampling preserved when the sweep gate dies
- **IMPL-0023** — DESIGN-0022 phases 1–7; Grafana 13+ floor, concrete datasource UIDs (prometheus/loki defaults), stdlib subcommand dispatch

## Operational docs (enterprise migration)
- ent-setup.md: Valkey queue drain at cutover, old-installation repo_state row deletion
- rds-terraform-variables.md + aws.md: STORE_DSN percent-encoding verification
- examples/guardian-enterprise.hcl fully rewritten + CI validity locks (strict PR-template validation, template-name resolution) across all six examples

## Contrib refresh
- alerts.yaml: custom-property sync group, unfireable-alert fixes, BudgetGated commented out (22 rules promtool-clean)
- Grafana dashboard: IMPL-0017/0019/0020 row (5 panels), BudgetTracker row marked inert
- README: metric catalog caught up

🤖 Generated with [Claude Code](https://claude.com/claude-code)