### PR TITLE
fix: never delete a file the default branch owns (INV-0014)

### DIFF
--- a/charts/repo-guardian/README.md
+++ b/charts/repo-guardian/README.md
@@ -441,10 +441,11 @@ incoming webhook.
 | podAnnotations | object | `{}` | Pod annotations |
 | podLabels | object | `{}` | Pod labels |
 | podSecurityContext | object | `{}` | Pod security context |
-| policy | object | `{"autoClosePR":true,"config":"","existingConfigMap":""}` | HCL policy configuration |
+| policy | object | `{"autoClosePR":true,"config":"","existingConfigMap":"","orphanCleanup":true}` | HCL policy configuration |
 | policy.autoClosePR | bool | `true` | Auto-close repo-guardian PRs when every file rule is satisfied on the default branch (IMPL-0013 Phase 3). When `true` (default), the PR is closed with a sticky comment and the reconcile branch is deleted. When `false`, the PR stays open until a human closes it. |
 | policy.config | string | `""` | Inline HCL policy config (creates a ConfigMap) |
 | policy.existingConfigMap | string | `""` | Use an existing ConfigMap for policy config |
+| policy.orphanCleanup | bool | `true` | Remove files from repo-guardian's own reconcile branch once the rule that added them is satisfied on the default branch (IMPL-0013 Phase 3). When `true` (default), a PR stops proposing files that are no longer needed. When `false`, no file is ever deleted from the reconcile branch and PR bodies may list rules already satisfied on the default branch.  This is a kill switch, not a tuning knob: orphan cleanup is the only path that deletes files, and INV-0014 is a fixed defect in it that produced PRs proposing to remove files repositories legitimately owned. Leave it enabled unless you have reason not to. |
 | prometheusRule | object | `{"alerts":{},"enabled":false,"labels":{}}` | Prometheus PrometheusRule with starter alerts (IMPL-0011 P6). |
 | prometheusRule.alerts | object | `{}` | Per-alert overrides: each key under `alerts.<name>` accepts `for`, `severity`, `threshold`, and `enabled`. See the rendered PrometheusRule template for the canonical alert names. |
 | prometheusRule.enabled | bool | `false` | Create PrometheusRule with starter alerts. |

--- a/charts/repo-guardian/templates/deployment.yaml
+++ b/charts/repo-guardian/templates/deployment.yaml
@@ -94,6 +94,8 @@ spec:
               value: {{ .Values.config.skipArchived | quote }}
             - name: AUTO_CLOSE_PR
               value: {{ .Values.policy.autoClosePR | quote }}
+            - name: ORPHAN_CLEANUP
+              value: {{ .Values.policy.orphanCleanup | quote }}
             - name: TEMPLATE_DIR
               value: /etc/repo-guardian/templates
             - name: WEBHOOK_IP_ALLOWLIST

--- a/charts/repo-guardian/tests/deployment_env_test.yaml
+++ b/charts/repo-guardian/tests/deployment_env_test.yaml
@@ -75,6 +75,28 @@ tests:
             configMap:
               name: my-shared-templates
 
+  - it: emits ORPHAN_CLEANUP=true by default (INV-0014)
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ORPHAN_CLEANUP
+            value: "true"
+
+  # The false case is asserted explicitly: a bool rendered through sprig
+  # `default` collapses false to the default, and this kill switch is
+  # worthless if setting it to false silently renders "true".
+  - it: respects policy.orphanCleanup=false override (INV-0014 kill switch)
+    set:
+      policy:
+        orphanCleanup: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ORPHAN_CLEANUP
+            value: "false"
+
   - it: emits AUTO_CLOSE_PR=true by default (IMPL-0013 Phase 5)
     asserts:
       - contains:

--- a/charts/repo-guardian/values.yaml
+++ b/charts/repo-guardian/values.yaml
@@ -422,6 +422,18 @@ policy:
   # the reconcile branch is deleted. When `false`, the PR stays
   # open until a human closes it.
   autoClosePR: true
+  # -- Remove files from repo-guardian's own reconcile branch once the
+  # rule that added them is satisfied on the default branch (IMPL-0013
+  # Phase 3). When `true` (default), a PR stops proposing files that are
+  # no longer needed. When `false`, no file is ever deleted from the
+  # reconcile branch and PR bodies may list rules already satisfied on
+  # the default branch.
+  #
+  # This is a kill switch, not a tuning knob: orphan cleanup is the only
+  # path that deletes files, and INV-0014 is a fixed defect in it that
+  # produced PRs proposing to remove files repositories legitimately
+  # owned. Leave it enabled unless you have reason not to.
+  orphanCleanup: true
 
 # -- Additional environment variables
 extraEnv: []

--- a/docs/investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md
+++ b/docs/investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md
@@ -28,6 +28,7 @@ created: 2026-08-03
   - [E. Latent since IMPL-0013 Phase 3](#e-latent-since-impl-0013-phase-3)
 - [Conclusion](#conclusion)
 - [Recommendation](#recommendation)
+- [Blast radius](#blast-radius)
 - [Open questions for the operator](#open-questions-for-the-operator)
 - [References](#references)
 <!--toc:end-->
@@ -316,17 +317,43 @@ Whatever fix is chosen, three things are required alongside it:
    that carry an orphan-deletion commit, so remediation is not limited
    to whatever the operator happened to notice.
 
+## Blast radius
+
+Operator reports the affected PRs were **closed, not merged**. If that
+holds fleet-wide this is containment, not recovery: the deletion never
+reached a default branch, and closing the PR is sufficient. It is worth
+verifying rather than trusting recall, because the failure mode is
+silent — a merged orphan-deletion looks like an ordinary chore commit in
+the repo's history.
+
+`scripts/inv-0014-scan.sh ORG [ORG...]` measures it. Strictly read-only:
+no merges, no closes, no branch deletions. For every PR in the org whose
+head is `repo-guardian/add-missing-files` it reports the PR state, every
+path removed by a `chore: remove ...` commit, and — the question that
+actually matters — whether that path exists on the default branch
+**today**:
+
+| PR state | Path on default | Meaning |
+|---|---|---|
+| merged | absent | confirmed data loss; restore from history |
+| open | present | containment; close before anyone merges |
+| closed | present | no action — the expected state per the report |
+| any | probe failed | indeterminate, never assumed safe |
+
+Both fragile parts were verified before use: the commit-message regex
+against the exact format `cleanupOrphans` emits (and against add-mode,
+restore-mode and merge commits, which must not match), and the
+200/404 status extraction against a public repository.
+
 ## Open questions for the operator
 
-1. Do the affected repositories keep CODEOWNERS at `.github/CODEOWNERS`
-   rather than at the repository root? Finding C predicts only the
-   former are affected — a cheap confirmation of the whole diagnosis.
-2. Which appVersion was running before the upgrade, and which is running
-   now? If the prior version was < 1.7.0, that fully explains "first run
-   fine, second run bad" without any second mechanism.
-3. Were any of these delete-commit PRs merged? That determines whether
-   this is a "stop the bleeding" situation or a "restore deleted files"
-   one.
+1. ~~Do the affected repositories keep CODEOWNERS at
+   `.github/CODEOWNERS`?~~ Confirmed — matches Finding C's prediction.
+2. ~~Which appVersion was running?~~ v1.10.1, which contains the
+   defect. No version change is needed to explain the timeline.
+3. ~~Were any of these delete-commit PRs merged?~~ Operator reports
+   closed, not merged — containment rather than recovery. To be
+   confirmed fleet-wide with `scripts/inv-0014-scan.sh`.
 4. Are the affected repos ones where some *other* rule (dependabot,
    renovate) is still actionable? The model says they must be; a
    counter-example would mean there is a second path to investigate.

--- a/docs/investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md
+++ b/docs/investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md
@@ -15,6 +15,7 @@ created: 2026-08-03
 
 <!--toc:start-->
 - [Question](#question)
+- [What it looks like in practice](#what-it-looks-like-in-practice)
 - [Hypothesis](#hypothesis)
 - [Context](#context)
 - [Approach](#approach)
@@ -27,11 +28,18 @@ created: 2026-08-03
   - [E'. The fix already exists in this file, one function down](#e-the-fix-already-exists-in-this-file-one-function-down)
   - [E. Latent since IMPL-0013 Phase 3](#e-latent-since-impl-0013-phase-3)
 - [Conclusion](#conclusion)
+- [Blast radius](#blast-radius)
 - [Recommendation](#recommendation)
   - [R1. Fix the test fake first, and let it reproduce the bug](#r1-fix-the-test-fake-first-and-let-it-reproduce-the-bug)
   - [R2. Fix discoverOrphans](#r2-fix-discoverorphans)
   - [R3. Operational, ahead of the code](#r3-operational-ahead-of-the-code)
   - [Scope still to decide](#scope-still-to-decide)
+- [Testing strategy: breaking the circularity](#testing-strategy-breaking-the-circularity)
+  - [The circularity](#the-circularity)
+  - [The fix: one contract suite, two implementations](#the-fix-one-contract-suite-two-implementations)
+  - [Make the fake's blind spots loud, not plausible](#make-the-fakes-blind-spots-loud-not-plausible)
+  - [The existing CLAUDE.md rule is too narrow](#the-existing-claudemd-rule-is-too-narrow)
+  - [Tiered plan](#tiered-plan)
 - [Open questions for the operator](#open-questions-for-the-operator)
 - [References](#references)
 <!--toc:end-->
@@ -47,6 +55,49 @@ therefore satisfied and should be a no-op.
 
 Why does a *satisfied* rule produce a *deletion*, and what is the blast
 radius?
+
+## What it looks like in practice
+
+Take a repository that already has `.github/CODEOWNERS` and is missing
+`.github/dependabot.yml`.
+
+**First sweep**
+
+1. CODEOWNERS is present → the rule is satisfied, nothing to do.
+2. dependabot.yml is missing → actionable.
+3. repo-guardian creates `repo-guardian/add-missing-files` **from main**.
+   A new branch is a copy of main, so the branch now contains
+   `.github/CODEOWNERS` — not because repo-guardian added it, but
+   because main has it.
+4. It writes `dependabot.yml` to the branch and opens the PR.
+
+Correct so far.
+
+**Second sweep** — the PR is open, so orphan cleanup runs. For every
+rule that is *not* actionable it asks one question:
+
+> Is this rule's file sitting on the PR branch even though the rule is
+> satisfied? Then I must have added it in an earlier sweep and it is no
+> longer needed — delete it.
+
+It asks whether `.github/CODEOWNERS` is on the branch. It is. So it
+deletes it, and the PR now reads *"add dependabot.yml, delete
+CODEOWNERS."*
+
+The file is on the branch because **the branch is a copy of main**, not
+because repo-guardian put it there — and nothing in the code can tell
+those two apart. repo-guardian never recorded "I added this file," so
+"it is on the branch" is the only evidence available, and that evidence
+does not mean what the code takes it to mean.
+
+**The case the feature still needs to handle.** A repository with no
+CODEOWNERS anywhere: repo-guardian writes `.github/CODEOWNERS` to the
+branch and opens a PR; a human then commits `CODEOWNERS` at the repo
+root straight to main. Now the rule is satisfied by the root file,
+`.github/CODEOWNERS` is on the branch, and it is **not** on main — so
+repo-guardian is the only party that could have put it there. Deleting
+it is correct, and the PR stops proposing a duplicate. Any fix has to
+keep this working.
 
 ## Hypothesis
 
@@ -295,6 +346,34 @@ Finding C's prediction — that only `.github/CODEOWNERS` repos are
 affected — was confirmed by the operator against the real fleet, which
 moves this from a plausible reading of the code to a diagnosis.
 
+## Blast radius
+
+Operator reports the affected PRs were **closed, not merged**. If that
+holds fleet-wide this is containment, not recovery: the deletion never
+reached a default branch, and closing the PR is sufficient. It is worth
+verifying rather than trusting recall, because the failure mode is
+silent — a merged orphan-deletion looks like an ordinary chore commit in
+the repo's history.
+
+`scripts/inv-0014-scan.sh ORG [ORG...]` measures it. Strictly read-only:
+no merges, no closes, no branch deletions. For every PR in the org whose
+head is `repo-guardian/add-missing-files` it reports the PR state, every
+path removed by a `chore: remove ...` commit, and — the question that
+actually matters — whether that path exists on the default branch
+**today**:
+
+| PR state | Path on default | Meaning |
+|---|---|---|
+| merged | absent | confirmed data loss; restore from history |
+| open | present | containment; close before anyone merges |
+| closed | present | no action — the expected state per the report |
+| any | probe failed | indeterminate, never assumed safe |
+
+Both fragile parts were verified before use: the commit-message regex
+against the exact format `cleanupOrphans` emits (and against add-mode,
+restore-mode and merge commits, which must not match), and the
+200/404 status extraction against a public repository.
+
 ## Recommendation
 
 Two changes, in this order. The ordering is not cosmetic: done this way
@@ -476,6 +555,121 @@ call on.**
   branch-vs-default semantics? Current reading is checker-only, but that
   should be checked rather than assumed.
 - Whether Option 4's flag ships in the same patch or not at all.
+
+## Testing strategy: breaking the circularity
+
+R1 fixes the fake's model of branch inheritance. That corrects *this*
+wrong belief and leaves the mechanism that produced it fully intact. The
+mechanism is worth naming, because it will produce the next one.
+
+### The circularity
+
+The fake is a hand-written encoding of our mental model of GitHub. Our
+model said *"a branch contains what we put on it."* GitHub says *"a
+branch contains what main had, plus what we put on it."* Every test then
+validated the engine against the model — so the tests agreed with the
+code because both were built from the same wrong belief. **Nothing
+inside that loop is capable of disagreeing.**
+
+Note the shape: the tests were not sloppy and the assertions were not
+weak. A correct assertion evaluated against a fictional world is still
+fiction. No amount of additional testing *of that kind* would have found
+this.
+
+### The fix: one contract suite, two implementations
+
+State the GitHub behaviours we depend on **once**, as tests, and run
+them against both the fake and real GitHub. If the fake drifts from
+reality the shared test fails, so the fake cannot quietly encode a
+fantasy — it is held to the same contract as the real thing.
+
+```go
+// Same bodies, two drivers.
+func contractBranchInheritsDefaultContents(t *testing.T, c ghclient.Client)
+func contractDeleteOnBranchLeavesDefaultUntouched(t *testing.T, c ghclient.Client)
+func contractUpdateBranchMergesDefaultIn(t *testing.T, c ghclient.Client)
+func contractFileAddedToBranchIsNotOnDefault(t *testing.T, c ghclient.Client)
+```
+
+- **Against the fake** — runs in `make test`, milliseconds, every PR.
+- **Against real GitHub** — `//go:build ghcontract`, a scratch org and a
+  throwaway repo, run nightly or pre-release.
+
+The real-GitHub driver is the only true oracle anywhere in this
+codebase; every other test asks us what we believe. It is also small,
+because it does not test the engine — it tests *our assumptions about
+the API*. "Does creating a branch from main make main's files readable
+on that branch?" is a single test, and it would have caught INV-0014
+before IMPL-0013 shipped.
+
+There is direct precedent: Postgres and Valkey both have real-backend
+integration suites under a build tag, with contract assertions living in
+each backend's own test file (CLAUDE.md § single-backend contract test
+convention). GitHub is currently the only major dependency with **no
+real-thing test at all** — the `httptest.Server` suite in
+`internal/github/client_test.go` tests our request/response plumbing
+against handlers we also wrote, which is the same circularity one layer
+down.
+
+### Make the fake's blind spots loud, not plausible
+
+`GetContentsOnBranch` returned `false` for a state it could not
+represent: a confident, plausible, wrong answer. The repo has already
+learned this lesson once — the generated mocks panic on un-overridden
+methods, explicitly because "a silent zero value is how the IMPL-0013 P4
+vacuous-assertion bug happened" (CLAUDE.md). The same reasoning applies
+here and was never carried across.
+
+Concretely: if a test never declares the repository's default-branch
+contents, the fake should not assume "empty." It should fail and force
+the test to say what the repo contains. A fake that cannot represent a
+state must refuse to answer questions about it.
+
+### The existing CLAUDE.md rule is too narrow
+
+The rule written after the last occurrence of this failure shape:
+
+> when a production code path is shaped like "list existing → decide to
+> skip-or-act → mutate," the mock's list method MUST return prior
+> writes **from the same mock instance**.
+
+That covers state **the test** created. INV-0014 is state **the world**
+created — a file that existed before repo-guardian ever ran. Identical
+failure shape, entirely outside the rule's scope, which is why
+following the rule did not prevent it.
+
+Proposed extension, to land with the fix:
+
+> ...and MUST also return state the mock never wrote but the real system
+> would have — repository state that pre-existed the test. Where a fake
+> cannot represent such state, it MUST fail loudly rather than return a
+> plausible default.
+
+### Tiered plan
+
+**Now, shipping with the fix**
+
+1. Fake inheritance + tombstones (R1).
+2. The four contract tests above, running against the fake.
+3. A safety-net assertion in the checker test harness: no test may
+   finish having deleted a path that exists on the default branch. This
+   catches the whole class rather than this one instance, and it is
+   stated in domain terms, so it keeps working as the fake improves.
+4. The CLAUDE.md rule extension above.
+
+**Next, on its own PR**
+
+5. The same contract tests against a scratch org under `//go:build
+   ghcontract`. Needs a throwaway repo and a token; roughly a couple of
+   hours. This is the step that actually breaks the circle — without it
+   items 1-3 are still our model checking our model.
+
+**Later, only if it earns it**
+
+6. Replace the interface-level fake with an HTTP-level fake GitHub that
+   stores refs and trees, so branch semantics become structurally
+   impossible to get wrong rather than correct-by-maintenance. Real
+   work; explicitly not under this bug's time pressure.
 
 ## Open questions for the operator
 

--- a/docs/investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md
+++ b/docs/investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md
@@ -28,7 +28,10 @@ created: 2026-08-03
   - [E. Latent since IMPL-0013 Phase 3](#e-latent-since-impl-0013-phase-3)
 - [Conclusion](#conclusion)
 - [Recommendation](#recommendation)
-- [Blast radius](#blast-radius)
+  - [R1. Fix the test fake first, and let it reproduce the bug](#r1-fix-the-test-fake-first-and-let-it-reproduce-the-bug)
+  - [R2. Fix discoverOrphans](#r2-fix-discoverorphans)
+  - [R3. Operational, ahead of the code](#r3-operational-ahead-of-the-code)
+  - [Scope still to decide](#scope-still-to-decide)
 - [Open questions for the operator](#open-questions-for-the-operator)
 - [References](#references)
 <!--toc:end-->
@@ -294,56 +297,185 @@ moves this from a plausible reading of the code to a diagnosis.
 
 ## Recommendation
 
-Not yet decided — this section is the next working session. The leading
-candidate is to make the orphan predicate compare against the default
-branch rather than the reconcile branch alone: a path that exists on the
-default branch is by definition not an orphan, because deleting it
-proposes removing a file the repository legitimately owns. That is a
-small, local change to `discoverOrphans` with an obvious fail-safe
-direction (when in doubt, do not delete), and it composes correctly with
-`updateReconcileBranch` rather than fighting it.
+Two changes, in this order. The ordering is not cosmetic: done this way
+the first change *proves* the bug and the second fixes it, so the
+regression test is non-vacuous by construction rather than by
+assertion.
 
-Whatever fix is chosen, three things are required alongside it:
+### R1. Fix the test fake first, and let it reproduce the bug
 
-1. **Operator guidance now, before the fix ships.** Any open
-   repo-guardian PR containing a `chore: remove ...` commit must not be
-   merged. This needs to go out ahead of the code change.
-2. **A test fake that can represent inherited content.** Until
-   `branchContents` (or its replacement) models default-branch
-   inheritance, no regression test for this can be non-vacuous — it
-   would pass before the fix. Per standing practice the regression test
-   must be verified by neutralising the fix and watching it fail.
-3. **A blast-radius query.** Identify already-open PRs across the fleet
-   that carry an orphan-deletion commit, so remediation is not limited
-   to whatever the operator happened to notice.
+Finding D established that the failing state — a file on the reconcile
+branch that repo-guardian did not write — is inexpressible in the
+current fake. Until that changes, **any regression test written for
+this bug would pass before the fix**, which is the definition of a
+vacuous test.
 
-## Blast radius
+Three ways to address it:
 
-Operator reports the affected PRs were **closed, not merged**. If that
-holds fleet-wide this is containment, not recovery: the deletion never
-reached a default branch, and closing the PR is sufficient. It is worth
-verifying rather than trusting recall, because the failure mode is
-silent — a merged orphan-deletion looks like an ordinary chore commit in
-the repo's history.
+**Option A — seed `branchContents` directly in the new test.** One line
+of test setup, no fake change.
 
-`scripts/inv-0014-scan.sh ORG [ORG...]` measures it. Strictly read-only:
-no merges, no closes, no branch deletions. For every PR in the org whose
-head is `repo-guardian/add-missing-files` it reports the PR state, every
-path removed by a `chore: remove ...` commit, and — the question that
-actually matters — whether that path exists on the default branch
-**today**:
+*Rejected.* It makes exactly one test correct and leaves the trap armed
+for everyone else. Nobody wrote that line for the existing convergence
+tests precisely because nobody knew the invariant existed; a fix that
+depends on future authors knowing it does not hold.
 
-| PR state | Path on default | Meaning |
-|---|---|---|
-| merged | absent | confirmed data loss; restore from history |
-| open | present | containment; close before anyone merges |
-| closed | present | no action — the expected state per the report |
-| any | probe failed | indeterminate, never assumed safe |
+**Option B — teach `GetContentsOnBranch` that branches inherit from the
+default branch.** *Recommended.*
 
-Both fragile parts were verified before use: the commit-message regex
-against the exact format `cleanupOrphans` emits (and against add-mode,
-restore-mode and merge commits, which must not match), and the
-200/404 status extraction against a public repository.
+```go
+func (m *mockClient) GetContentsOnBranch(_ context.Context, owner, repo, path, branch string) (string, bool, error) {
+	if m.getContentsOnBranchErr != nil {
+		return "", false, m.getContentsOnBranchErr
+	}
+
+	key := owner + "/" + repo + "/" + branch + "/" + path
+
+	// A tombstone means the path was deleted on this branch and must NOT
+	// be inherited back from the default branch.
+	if m.branchDeleted[key] {
+		return "", false, nil
+	}
+
+	if sha, ok := m.branchContents[key]; ok {
+		return sha, true, nil
+	}
+
+	// The reconcile branch is cut from the default branch, so anything on
+	// default is visible on it unless the branch overrode or deleted it.
+	// Modelling this is what makes INV-0014's failing state expressible.
+	if m.contents[owner+"/"+repo+"/"+path] {
+		return "sha-inherited-" + path, true, nil
+	}
+
+	return "", false, nil
+}
+```
+
+The tombstone map is load-bearing, not incidental. `DeleteFile`
+currently does a bare `delete(m.branchContents, key)`
+(`engine_test.go:338`); with an inheritance fallback and no tombstone, a
+file deleted from the branch would immediately reappear from the default
+branch, breaking the `restoreInverseOrphans` tests — which depend on
+exactly the state "deleted on branch, present on default". So
+`DeleteFile` must set the tombstone and `CreateOrUpdateFile` must clear
+it.
+
+One more required edit: `GetContentsOnBranch` currently early-returns
+`false` when `branchContents == nil` (`engine_test.go:320`). That guard
+has to go, or every test that leaves the map nil silently skips
+inheritance.
+
+**Expect existing tests to fail, and read that as the reproduction.**
+Most convergence tests never populate `branchContents`, so today they
+run in a world where the reconcile branch is empty except for what
+repo-guardian wrote. Giving the fake inheritance puts them in the real
+world, and any that assert an orphan deletion against a file the repo
+owns will go red. That red is INV-0014 reproducing under test. Triage
+each failure as either "this is the bug" or "this fixture now needs
+adjusting"; do not blanket-adjust fixtures to restore green.
+
+**Option C — replace the string maps with a small git-shaped model**
+(default tree + per-branch overlay of adds/deletes).
+
+Defensible, and strictly more faithful. Rejected *for this fix* because
+CLAUDE.md records six behaviours across three fake sites that depend on
+current semantics (IMPL-0021 task 7.1), and rebuilding them under
+time pressure on a data-destructive bug trades a small risk for a large
+one. Worth revisiting later on its own schedule.
+
+### R2. Fix `discoverOrphans`
+
+**Option 1 — probe the default branch before the reconcile branch.**
+*Recommended.* Mirrors `restoreInverseOrphans` (Finding E'), which
+already does this correctly twelve lines away.
+
+```go
+// A path that exists on the default branch is never an orphan: deleting
+// it from the reconcile branch makes the PR propose removing a file the
+// repository legitimately owns (INV-0014).
+onDefault, err := client.GetContents(ctx, owner, repo, r.Target)
+if err != nil {
+	log.Warn("orphan discovery: default-branch probe failed, treating as still-actionable",
+		"rule", r.Name, "path", r.Target, "err", err)
+
+	continue
+}
+
+if onDefault {
+	continue
+}
+
+// ... existing GetContentsOnBranch probe unchanged
+```
+
+The rule is unconditional and easy to state: **if the default branch has
+the path, never delete it.** There is no case where deleting a
+default-branch file from the reconcile branch is the right action —
+doing so always produces a PR that proposes removing a real file.
+
+It still catches the genuine orphan. Rule satisfied by a root-level
+`CODEOWNERS` on main, `.github/CODEOWNERS` written to the branch by an
+earlier sweep, `.github/CODEOWNERS` absent from main: not on default →
+still an orphan → deleted. That is the convergence case IMPL-0013 Phase
+3 was built for, and it is preserved.
+
+Ordering matters for cost: probing default *first* means the common case
+(rule satisfied because the file is on main) costs one API call instead
+of two. Genuine orphans cost two. The probe only runs for
+non-actionable rules on repos that already have an open PR, so fleet-wide
+impact is small.
+
+Fail-safe direction is the same as everywhere else in this file: a probe
+error means "do not delete."
+
+**Option 2 — compare blob SHAs between branch and default.** *Rejected,
+and worth recording because it is the tempting "more precise" answer.*
+
+The idea is that a differing SHA proves repo-guardian authored the branch
+copy. It does — and it still must not delete. If main holds a human-
+authored `.github/CODEOWNERS` and the branch holds repo-guardian's
+version, deleting from the branch proposes removing main's file. SHA
+comparison is more precise about provenance and wrong about the action.
+Presence on the default branch, not authorship, is the correct predicate.
+
+**Option 3 — record provenance properly** (track which files
+repo-guardian wrote to the branch, in the store or via a commit-message
+convention).
+
+The "real" fix for the root cause named in Finding A. Rejected as the
+immediate remedy: it needs persistent state or branch-history parsing,
+and Option 1 makes the destructive outcome unreachable without it. Worth
+a follow-up if orphan cleanup ever needs to distinguish cases Option 1
+deliberately collapses.
+
+**Option 4 — gate orphan cleanup behind a config flag, defaulting off.**
+
+Worth naming because the risk/benefit is genuinely lopsided: the feature
+prevents a stale PR body, and the failure mode is deleting a real file.
+Rejected as the primary fix because Option 1 is small enough that
+disabling a working convergence feature is not warranted — but if we
+want defence in depth on a fleet already burned once, a flag composes
+with Option 1 rather than replacing it. **This one I would like your
+call on.**
+
+### R3. Operational, ahead of the code
+
+1. Close any open repo-guardian PR carrying a `chore: remove ...`
+   commit. Confirmed closed already per the operator, pending the scan.
+2. Ship as a patch release once R1+R2 land. Every repo in a fleet meets
+   the precondition on its second sweep, so this is not a "wait for the
+   next feature release" fix.
+3. Correct the misattributed `PR #71` comment at the
+   `updateReconcileBranch` call site while in the file (Finding B).
+
+### Scope still to decide
+
+- Do the `scheduler` and `reconciler` fakes need the same inheritance
+  fix, or is `internal/checker` the only package whose tests exercise
+  branch-vs-default semantics? Current reading is checker-only, but that
+  should be checked rather than assumed.
+- Whether Option 4's flag ships in the same patch or not at all.
 
 ## Open questions for the operator
 

--- a/docs/investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md
+++ b/docs/investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md
@@ -1,0 +1,298 @@
+---
+id: INV-0014
+title: "Orphan cleanup deletes files the default branch legitimately owns"
+status: In Progress
+author: Donald Gifford
+created: 2026-08-03
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# INV 0014: Orphan cleanup deletes files the default branch legitimately owns
+
+**Status:** In Progress
+**Author:** Donald Gifford
+**Date:** 2026-08-03
+
+<!--toc:start-->
+- [Question](#question)
+- [Hypothesis](#hypothesis)
+- [Context](#context)
+- [Approach](#approach)
+- [Environment](#environment)
+- [Findings](#findings)
+  - [A. discoverOrphans has no provenance signal](#a-discoverorphans-has-no-provenance-signal)
+  - [B. UpdatePRBranch guarantees the false positive](#b-updateprbranch-guarantees-the-false-positive)
+  - [C. The blast radius is Target-shaped, not Paths-shaped](#c-the-blast-radius-is-target-shaped-not-paths-shaped)
+  - [D. Why the test suite cannot express this](#d-why-the-test-suite-cannot-express-this)
+  - [E. Latent since IMPL-0013 Phase 3](#e-latent-since-impl-0013-phase-3)
+- [Conclusion](#conclusion)
+- [Recommendation](#recommendation)
+- [Open questions for the operator](#open-questions-for-the-operator)
+- [References](#references)
+<!--toc:end-->
+
+## Question
+
+On a second sweep against a repository that already has a
+`repo-guardian/add-missing-files` PR open, repo-guardian commits a
+deletion of `.github/CODEOWNERS` with the message
+`chore: remove .github/CODEOWNERS (rule "codeowners" satisfied on default branch)`
+— even though the file exists on the default branch and the rule is
+therefore satisfied and should be a no-op.
+
+Why does a *satisfied* rule produce a *deletion*, and what is the blast
+radius?
+
+## Hypothesis
+
+`discoverOrphans` cannot distinguish a file repo-guardian itself wrote
+to the reconcile branch in an earlier sweep (a true orphan) from a file
+that is visible on that branch only because the branch was cut from —
+and is continuously merged with — the default branch. Any rule that
+(a) is not actionable and (b) has its `Target` path present on the
+default branch is therefore misclassified as an orphan and deleted.
+
+## Context
+
+Reported from production. Timeline as described by the operator: an
+initial run behaved correctly, an upgrade was applied, and the following
+weekend's run began emitting delete commits against repositories whose
+`CODEOWNERS` file already existed.
+
+This is a **data-destructive** defect, not a cosmetic one: the deletion
+lands on the reconcile branch of an *open* PR. Merging that PR removes
+`.github/CODEOWNERS` from the default branch. Because CODEOWNERS drives
+review routing and is frequently a branch-protection input, the
+downstream effect of a merge is silent loss of required-reviewer
+enforcement.
+
+**Triggered by:** production report, 2026-08-03. Related to IMPL-0013
+Phase 3 (orphan cleanup) and INV-0011 B4 / PR #71 (reconcile-branch
+freshening).
+
+## Approach
+
+1. Trace the commit message back to its producer to identify the code
+   path with certainty rather than by inference.
+2. Read `discoverOrphans` and determine what evidence it uses to decide
+   a file is an orphan.
+3. Establish whether the preceding branch-freshening step makes the
+   misclassification possible, likely, or certain.
+4. Determine which rules and which repository layouts are affected, and
+   which are not.
+5. Explain why the existing convergence test suite passes.
+6. Identify the release in which the defect became reachable.
+
+## Environment
+
+| Component | Version / Value |
+|-----------|-----------------|
+| Branch analysed | `main` @ `b1bd32e` |
+| Defect introduced | `ee80603` (IMPL-0013, PR #82) |
+| First affected release | appVersion 1.7.0 / chart 0.6.0 |
+| Affected rule (built-in defaults) | `codeowners`, `Target = .github/CODEOWNERS` |
+| Code paths | `internal/checker/drift.go`, `internal/checker/engine_pr.go` |
+
+## Findings
+
+### A. `discoverOrphans` has no provenance signal
+
+`internal/checker/drift.go:101` is the whole decision:
+
+```go
+sha, exists, err := client.GetContentsOnBranch(ctx, owner, repo, r.Target, BranchName)
+...
+if !exists {
+    continue
+}
+
+orphans = append(orphans, orphanFile{RuleName: r.Name, Path: r.Target, SHA: sha})
+```
+
+The predicate is *"the rule is not actionable **and** its target path
+exists on the reconcile branch."* That is presumed to mean "we wrote
+this file in an earlier sweep and it is no longer needed." It does not.
+The reconcile branch is cut from the default branch, so **every** file
+the default branch has is present on the reconcile branch. The
+predicate matches:
+
+1. a file repo-guardian committed in an earlier sweep — a true orphan;
+2. a file that exists on the default branch and always did — a false
+   positive, and the reported bug.
+
+The two are indistinguishable from the branch alone. Provenance is
+never recorded anywhere, and the branch contents cannot supply it.
+
+The corresponding cleanup at `drift.go:139` is the commit the operator
+observed:
+
+```go
+msg := fmt.Sprintf("chore: remove %s (rule %q satisfied on default branch)", o.Path, o.RuleName)
+```
+
+The message is accurate about *why* the rule stopped being actionable
+and wrong about what should follow from it. "Satisfied on the default
+branch" is precisely the state in which the file must be left alone.
+
+### B. `UpdatePRBranch` guarantees the false positive
+
+`engine_pr.go:161-163` runs immediately before orphan discovery:
+
+```go
+if existingPR != nil {
+    updateReconcileBranch(ctx, log, client, owner, repo, existingPR.Number)
+}
+```
+
+This merges the default branch into the reconcile branch — the INV-0011
+B4 fix (PR #71), added so the file sync always operates on current
+content and cannot silently revert a manual edit on merge.
+
+That fix is correct in isolation, and it converts this defect from
+*possible* to *certain*. Any file on the default branch is merged onto
+the reconcile branch a few lines before `discoverOrphans` asks whether
+that path exists on the reconcile branch. The answer is now
+unconditionally yes. Two individually-sound behaviours compose into a
+deletion.
+
+### C. The blast radius is `Target`-shaped, not `Paths`-shaped
+
+The satisfaction check and the orphan check use different fields.
+`policy.BuiltinDefaults()` (`internal/policy/defaults.go:118-129`):
+
+```go
+Paths:  []string{pathCodeownersRoot, pathCodeownersGitHub, "docs/CODEOWNERS"},
+Target: pathCodeownersGitHub,   // ".github/CODEOWNERS"
+```
+
+`evaluateRule` satisfies the rule if **any** of the three paths exist.
+`discoverOrphans` only ever looks at `Target`. So:
+
+| Repository layout | Rule state | Orphan check | Outcome |
+|---|---|---|---|
+| `.github/CODEOWNERS` present | satisfied | `Target` found | **file deleted** |
+| root `CODEOWNERS` only | satisfied | `Target` absent | safe |
+| `docs/CODEOWNERS` only | satisfied | `Target` absent | safe |
+| no CODEOWNERS | actionable | rule in actionable set, skipped | safe |
+
+This yields a sharp, falsifiable prediction: **only repositories whose
+CODEOWNERS lives at `.github/CODEOWNERS` are affected.** Repositories
+with a root-level `CODEOWNERS` see nothing. That prediction is the
+cheapest way to confirm this diagnosis against the real fleet.
+
+The same reasoning applies to every non-actionable file rule with a
+`Target` that the default branch happens to contain — `codeowners` is
+not special, it is merely the one whose `Target` most often already
+exists. `dependabot`, `renovate_config` and any operator-defined rule
+are subject to the identical failure.
+
+Two further preconditions, both matching the report:
+
+- An open repo-guardian PR must already exist — orphan discovery is
+  only reachable from the `existingPR != nil` branch. This is why the
+  first run was clean and the second was not; it is a second-sweep-only
+  defect by construction.
+- At least one *other* rule must still be actionable. With an empty
+  actionable set the code takes the `autoClosePR` path instead and no
+  deletion occurs.
+
+### D. Why the test suite cannot express this
+
+`internal/checker/engine_test.go:315` backs `GetContentsOnBranch` with
+a `branchContents` map, and the only writer to that map is the fake's
+own `CreateOrUpdateFile` (`engine_test.go:167-172`). The fake models
+"repo-guardian wrote this file to this branch" and nothing else. The
+fake's `UpdatePRBranch` (`engine_test.go:364`) appends to a call-log and
+does not touch `branchContents` at all.
+
+So the fake has no representation of the failing state — *a file present
+on the reconcile branch that repo-guardian did not put there*. The
+convergence tests are not weak here; they are describing a world in
+which the bug cannot occur. Every assertion in
+`convergence_test.go` about orphan cleanup passes because in the fake's
+model the only files on the branch **are** orphans.
+
+This is a textbook instance of the mock-fidelity rule already in
+CLAUDE.md ("when a production path is shaped like list → decide → mutate,
+the mock's list method must return what production's list would
+return"). The existing rule is stated in terms of *the mock's own prior
+writes*; this case shows it needs to extend to **state the mock never
+wrote** — inherited default-branch content.
+
+### E. Latent since IMPL-0013 Phase 3
+
+`internal/checker/drift.go` was added whole in `ee80603` (IMPL-0013,
+PR #82), shipped as appVersion 1.7.0 / chart 0.6.0. The defect has been
+present since that release. It requires a second sweep against a repo
+with an open PR and a `Target`-path file on the default branch, which is
+why it can sit unnoticed across many deployments and then appear all at
+once when a fleet reaches its second sweep — matching "ran it again over
+the weekend."
+
+## Conclusion
+
+**Answer:** Hypothesis confirmed.
+
+`discoverOrphans` treats "path exists on the reconcile branch" as proof
+that repo-guardian authored it. Because the reconcile branch inherits
+the default branch — and is force-freshened from it by
+`updateReconcileBranch` immediately beforehand — a satisfied rule whose
+`Target` exists on the default branch is misclassified as an orphan and
+deleted, producing an open PR that proposes removing a legitimate file.
+
+The bug is real, destructive, and reachable in the default
+configuration. It is not caused by the recent upgrade in the sense of
+being newly introduced by it — it has been latent since 1.7.0 — but an
+upgrade that restarted sweeps, or a fleet reaching its second sweep,
+would surface it exactly as reported.
+
+## Recommendation
+
+Not yet decided — this section is the next working session. The leading
+candidate is to make the orphan predicate compare against the default
+branch rather than the reconcile branch alone: a path that exists on the
+default branch is by definition not an orphan, because deleting it
+proposes removing a file the repository legitimately owns. That is a
+small, local change to `discoverOrphans` with an obvious fail-safe
+direction (when in doubt, do not delete), and it composes correctly with
+`updateReconcileBranch` rather than fighting it.
+
+Whatever fix is chosen, three things are required alongside it:
+
+1. **Operator guidance now, before the fix ships.** Any open
+   repo-guardian PR containing a `chore: remove ...` commit must not be
+   merged. This needs to go out ahead of the code change.
+2. **A test fake that can represent inherited content.** Until
+   `branchContents` (or its replacement) models default-branch
+   inheritance, no regression test for this can be non-vacuous — it
+   would pass before the fix. Per standing practice the regression test
+   must be verified by neutralising the fix and watching it fail.
+3. **A blast-radius query.** Identify already-open PRs across the fleet
+   that carry an orphan-deletion commit, so remediation is not limited
+   to whatever the operator happened to notice.
+
+## Open questions for the operator
+
+1. Do the affected repositories keep CODEOWNERS at `.github/CODEOWNERS`
+   rather than at the repository root? Finding C predicts only the
+   former are affected — a cheap confirmation of the whole diagnosis.
+2. Which appVersion was running before the upgrade, and which is running
+   now? If the prior version was < 1.7.0, that fully explains "first run
+   fine, second run bad" without any second mechanism.
+3. Were any of these delete-commit PRs merged? That determines whether
+   this is a "stop the bleeding" situation or a "restore deleted files"
+   one.
+4. Are the affected repos ones where some *other* rule (dependabot,
+   renovate) is still actionable? The model says they must be; a
+   counter-example would mean there is a second path to investigate.
+
+## References
+
+- IMPL-0013 — orphan cleanup and PR convergence (PR #82, `ee80603`)
+- INV-0011 B4 / PR #71 — reconcile-branch freshening via
+  `UpdatePRBranch`
+- INV-0005 — the PR-drift surface that motivated IMPL-0013 Phase 3
+- `internal/checker/drift.go` — `discoverOrphans`, `cleanupOrphans`
+- `internal/checker/engine_pr.go` — `createOrUpdatePRFromPolicy`,
+  `updateReconcileBranch`
+- CLAUDE.md § "Mock-fidelity rule for list-then-act idempotency tests"

--- a/docs/investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md
+++ b/docs/investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md
@@ -530,13 +530,25 @@ deliberately collapses.
 
 **Option 4 — gate orphan cleanup behind a config flag, defaulting off.**
 
-Worth naming because the risk/benefit is genuinely lopsided: the feature
-prevents a stale PR body, and the failure mode is deleting a real file.
-Rejected as the primary fix because Option 1 is small enough that
-disabling a working convergence feature is not warranted — but if we
-want defence in depth on a fleet already burned once, a flag composes
-with Option 1 rather than replacing it. **This one I would like your
-call on.**
+**Accepted (operator decision, 2026-08-03) — ships alongside Option 1,
+not instead of it.**
+
+The risk/benefit is lopsided: the feature prevents a stale PR body, and
+its failure mode deletes a real file. Option 1 makes the destructive
+path unreachable, so the flag is defence in depth on a fleet that has
+already been burned once — an operator who does not trust the fix can
+turn the whole behaviour off without downgrading.
+
+Shape follows the existing `auto_close_pr` precedent exactly, which is
+the closest analogue (a `guardian {}` bool gating a PR-mutating
+behaviour, default-on, env override): an `orphan_cleanup` attribute on
+the `guardian {}` block plus an `ORPHAN_CLEANUP` env override. Per
+INV-0010, adding a `GuardianConfig` field needs **three** edits in
+lockstep — `guardianBodySchema`, a `setGuardianAttr` case, and a
+`mergeGuardianConfig` carry — and missing the merge is exactly how
+`auto_close_pr` silently did nothing. Default is **on**, because with
+Option 1 in place the behaviour is correct and turning it off by default
+would regress the INV-0005 convergence fix for every operator.
 
 ### R3. Operational, ahead of the code
 
@@ -657,12 +669,17 @@ Proposed extension, to land with the fix:
    stated in domain terms, so it keeps working as the fake improves.
 4. The CLAUDE.md rule extension above.
 
-**Next, on its own PR**
+**Next, deferred out of the patch (operator decision, 2026-08-03)**
 
 5. The same contract tests against a scratch org under `//go:build
-   ghcontract`. Needs a throwaway repo and a token; roughly a couple of
-   hours. This is the step that actually breaks the circle — without it
-   items 1-3 are still our model checking our model.
+   ghcontract`. **Deferred**: the operator will verify this fix manually
+   against real repositories so the patch can ship promptly, rather than
+   holding a data-destructive fix behind new test infrastructure.
+
+   This remains the step that actually breaks the circle. Items 1-4 are
+   still our model checking our model, and manual verification confirms
+   *this* fix without leaving anything behind that would catch the next
+   one. Track it as follow-up work, not as closed.
 
 **Later, only if it earns it**
 

--- a/docs/investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md
+++ b/docs/investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md
@@ -21,9 +21,10 @@ created: 2026-08-03
 - [Environment](#environment)
 - [Findings](#findings)
   - [A. discoverOrphans has no provenance signal](#a-discoverorphans-has-no-provenance-signal)
-  - [B. UpdatePRBranch guarantees the false positive](#b-updateprbranch-guarantees-the-false-positive)
+  - [B. The branch inherits the file; UpdatePRBranch only widens the window](#b-the-branch-inherits-the-file-updateprbranch-only-widens-the-window)
   - [C. The blast radius is Target-shaped, not Paths-shaped](#c-the-blast-radius-is-target-shaped-not-paths-shaped)
   - [D. Why the test suite cannot express this](#d-why-the-test-suite-cannot-express-this)
+  - [E'. The fix already exists in this file, one function down](#e-the-fix-already-exists-in-this-file-one-function-down)
   - [E. Latent since IMPL-0013 Phase 3](#e-latent-since-impl-0013-phase-3)
 - [Conclusion](#conclusion)
 - [Recommendation](#recommendation)
@@ -55,9 +56,11 @@ default branch is therefore misclassified as an orphan and deleted.
 ## Context
 
 Reported from production. Timeline as described by the operator: an
-initial run behaved correctly, an upgrade was applied, and the following
+initial run behaved correctly, updates were applied, and the following
 weekend's run began emitting delete commits against repositories whose
-`CODEOWNERS` file already existed.
+`CODEOWNERS` file already existed. The operator reports running v1.10.1
+and confirms the affected repositories keep CODEOWNERS at
+`.github/CODEOWNERS`.
 
 This is a **data-destructive** defect, not a cosmetic one: the deletion
 lands on the reconcile branch of an *open* PR. Merging that PR removes
@@ -67,8 +70,9 @@ downstream effect of a merge is silent loss of required-reviewer
 enforcement.
 
 **Triggered by:** production report, 2026-08-03. Related to IMPL-0013
-Phase 3 (orphan cleanup) and INV-0011 B4 / PR #71 (reconcile-branch
-freshening).
+Phase 3 (orphan cleanup, PR #82) and IMPL-0021 (reconcile-branch
+freshening, PR #169) — see Finding B on the misattributed PR number in
+the source comment.
 
 ## Approach
 
@@ -91,6 +95,9 @@ freshening).
 | Defect introduced | `ee80603` (IMPL-0013, PR #82) |
 | First affected release | appVersion 1.7.0 / chart 0.6.0 |
 | Affected rule (built-in defaults) | `codeowners`, `Target = .github/CODEOWNERS` |
+| Operator-reported running version | v1.10.1 |
+| `updateReconcileBranch` introduced | `49a6424` / PR #169 / v1.10.1 |
+| Repo layout confirmed by operator | `.github/CODEOWNERS` (matches Finding C) |
 | Code paths | `internal/checker/drift.go`, `internal/checker/engine_pr.go` |
 
 ## Findings
@@ -134,9 +141,17 @@ The message is accurate about *why* the rule stopped being actionable
 and wrong about what should follow from it. "Satisfied on the default
 branch" is precisely the state in which the file must be left alone.
 
-### B. `UpdatePRBranch` guarantees the false positive
+### B. The branch inherits the file; `UpdatePRBranch` only widens the window
 
-`engine_pr.go:161-163` runs immediately before orphan discovery:
+The reconcile branch is created from the default branch HEAD —
+`engine_pr.go:143` passes `baseSHA` to `CreateBranch`, which is a plain
+`Git.CreateRef`. So from the instant it exists, the branch contains
+every file the default branch had, `.github/CODEOWNERS` included. No
+merge step is required for the false positive: **it is already certain
+for any repo that had the file at branch-creation time**, and has been
+since IMPL-0013 shipped.
+
+`engine_pr.go:161-163` then runs immediately before orphan discovery:
 
 ```go
 if existingPR != nil {
@@ -144,16 +159,18 @@ if existingPR != nil {
 }
 ```
 
-This merges the default branch into the reconcile branch — the INV-0011
-B4 fix (PR #71), added so the file sync always operates on current
-content and cannot silently revert a manual edit on merge.
+This merges the default branch into the reconcile branch so the file
+sync always operates on current content and cannot silently revert a
+manual edit on merge. It is correct in isolation, and it *widens* the
+trigger rather than creating it: it additionally captures repos where
+the file appeared on the default branch **after** the reconcile branch
+was cut. Without it those repos would escape; with it they do not.
 
-That fix is correct in isolation, and it converts this defect from
-*possible* to *certain*. Any file on the default branch is merged onto
-the reconcile branch a few lines before `discoverOrphans` asks whether
-that path exists on the reconcile branch. The answer is now
-unconditionally yes. Two individually-sound behaviours compose into a
-deletion.
+Provenance note, because the source comment is misleading: that call
+site is annotated `(INV-0011 B4, PR #71)`, but `git log -S` puts its
+introduction at `49a6424` — PR **#169**, IMPL-0021 — which
+`git describe --contains` resolves to **v1.10.1**. Anyone dating the
+regression from the comment will land on the wrong release.
 
 ### C. The blast radius is `Target`-shaped, not `Paths`-shaped
 
@@ -219,6 +236,29 @@ return"). The existing rule is stated in terms of *the mock's own prior
 writes*; this case shows it needs to extend to **state the mock never
 wrote** — inherited default-branch content.
 
+### E'. The fix already exists in this file, one function down
+
+`restoreInverseOrphans` — the absent-mode mirror added later by
+IMPL-0019 — does the check `discoverOrphans` is missing.
+`restoreRulePaths` (`drift.go:214-235`) probes the **default branch
+first** and only then the reconcile branch:
+
+```go
+onDefault, err := client.GetContents(ctx, owner, repo, path)   // default-branch-only helper
+...
+_, onBranch, err := client.GetContentsOnBranch(ctx, owner, repo, path, BranchName)
+```
+
+Both probes fail safe: any API error leaves the path untouched.
+
+So the newer mirror function establishes the correct pattern — never
+act on a path from branch state alone, always cross-reference the
+default branch — while the older function it was explicitly modelled on
+never had it. This is strong corroboration that the missing probe is an
+oversight in `discoverOrphans` rather than a deliberate asymmetry, and
+it means the fix has a working in-repo reference implementation twelve
+lines away.
+
 ### E. Latent since IMPL-0013 Phase 3
 
 `internal/checker/drift.go` was added whole in `ee80603` (IMPL-0013,
@@ -241,10 +281,15 @@ the default branch — and is force-freshened from it by
 deleted, producing an open PR that proposes removing a legitimate file.
 
 The bug is real, destructive, and reachable in the default
-configuration. It is not caused by the recent upgrade in the sense of
-being newly introduced by it — it has been latent since 1.7.0 — but an
-upgrade that restarted sweeps, or a fleet reaching its second sweep,
-would surface it exactly as reported.
+configuration. It has been latent since 1.7.0 and is present in the
+operator's reported v1.10.1; no version change is needed to explain the
+timeline. The single precondition that separates "first run fine" from
+"second run destructive" is the existence of an open repo-guardian PR,
+which only holds from the second sweep onward.
+
+Finding C's prediction — that only `.github/CODEOWNERS` repos are
+affected — was confirmed by the operator against the real fleet, which
+moves this from a plausible reading of the code to a diagnosis.
 
 ## Recommendation
 

--- a/docs/investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md
+++ b/docs/investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md
@@ -1,7 +1,7 @@
 ---
 id: INV-0014
 title: "Orphan cleanup deletes files the default branch legitimately owns"
-status: In Progress
+status: Concluded
 author: Donald Gifford
 created: 2026-08-03
 ---
@@ -9,7 +9,7 @@ created: 2026-08-03
 
 # INV 0014: Orphan cleanup deletes files the default branch legitimately owns
 
-**Status:** In Progress
+**Status:** Concluded
 **Author:** Donald Gifford
 **Date:** 2026-08-03
 
@@ -40,6 +40,7 @@ created: 2026-08-03
   - [Make the fake's blind spots loud, not plausible](#make-the-fakes-blind-spots-loud-not-plausible)
   - [The existing CLAUDE.md rule is too narrow](#the-existing-claudemd-rule-is-too-narrow)
   - [Tiered plan](#tiered-plan)
+- [What shipped](#what-shipped)
 - [Open questions for the operator](#open-questions-for-the-operator)
 - [References](#references)
 <!--toc:end-->
@@ -687,6 +688,30 @@ Proposed extension, to land with the fix:
    stores refs and trees, so branch semantics become structurally
    impossible to get wrong rather than correct-by-maintenance. Real
    work; explicitly not under this bug's time pressure.
+
+## What shipped
+
+| Commit | Change |
+|---|---|
+| `26c5869` | **Prevention** — `discoverOrphans` probes the default branch first; a path the default branch owns is never an orphan (R2 option 1) |
+| `6840117` | **Kill switch** — `orphan_cleanup` HCL attribute, `ORPHAN_CLEANUP` env, `policy.orphanCleanup` chart value, default on (R2 option 4) |
+| `34005a8` | **Repair** — `restoreInverseOrphans` generalised beyond absent rules, so branches already carrying the deletion self-heal on the next sweep |
+
+The fake-fidelity work in R1 shipped inside `26c5869`: `GetContentsOnBranch`
+now inherits from the default branch, with a tombstone map so deletions
+stick. Fixing it reproduced the bug immediately with production code
+untouched — `TestConvergence_RenovateFirst_RemovesDependabot` began deleting
+`renovate.json`, the reported failure on a different rule.
+
+Every behavioural change was neutralise-verified. Three of the tests written
+during this work were vacuous on first draft and were rebuilt after the
+neutralisation showed them passing against broken code — the same failure
+shape as the original defect, one level up.
+
+**Not shipped, tracked as follow-up:** the real-GitHub contract suite
+(Testing strategy, tier 2). Without it the repo is still in the position
+described under "The circularity" — our model checking our model — and
+nothing yet catches the next wrong belief about the GitHub API.
 
 ## Open questions for the operator
 

--- a/docs/investigation/README.md
+++ b/docs/investigation/README.md
@@ -26,6 +26,7 @@ Design docs, plans, and implementation docs can reference investigations by ID
 | INV-0011 | Tech debt cleanup inventory post IMPL-0019 | Open | 2026-07-23 | Donald Gifford | [0011-tech-debt-cleanup-inventory-post-impl-0019.md](0011-tech-debt-cleanup-inventory-post-impl-0019.md) |
 | INV-0012 | Inert BudgetTracker and untrustworthy alert pack | Concluded | 2026-07-25 | Donald Gifford | [0012-inert-budgettracker-and-untrustworthy-alert-pack.md](0012-inert-budgettracker-and-untrustworthy-alert-pack.md) |
 | INV-0013 | State-vs-event metrics, dashboard suite, and system observability | Open | 2026-08-01 | Donald Gifford | [0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md](0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md) |
+| INV-0014 | Orphan cleanup deletes files the default branch legitimately owns | In Progress | 2026-08-03 | Donald Gifford | [0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md](0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md) |
 <!-- END DOCZ AUTO-GENERATED -->
 <!-- BEGIN DOCZ AUTO-GENERATED -->
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/investigation/README.md
+++ b/docs/investigation/README.md
@@ -26,7 +26,7 @@ Design docs, plans, and implementation docs can reference investigations by ID
 | INV-0011 | Tech debt cleanup inventory post IMPL-0019 | Open | 2026-07-23 | Donald Gifford | [0011-tech-debt-cleanup-inventory-post-impl-0019.md](0011-tech-debt-cleanup-inventory-post-impl-0019.md) |
 | INV-0012 | Inert BudgetTracker and untrustworthy alert pack | Concluded | 2026-07-25 | Donald Gifford | [0012-inert-budgettracker-and-untrustworthy-alert-pack.md](0012-inert-budgettracker-and-untrustworthy-alert-pack.md) |
 | INV-0013 | State-vs-event metrics, dashboard suite, and system observability | Open | 2026-08-01 | Donald Gifford | [0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md](0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md) |
-| INV-0014 | Orphan cleanup deletes files the default branch legitimately owns | In Progress | 2026-08-03 | Donald Gifford | [0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md](0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md) |
+| INV-0014 | Orphan cleanup deletes files the default branch legitimately owns | Concluded | 2026-08-03 | Donald Gifford | [0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md](0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md) |
 <!-- END DOCZ AUTO-GENERATED -->
 <!-- BEGIN DOCZ AUTO-GENERATED -->
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/usage/policy-reference.md
+++ b/docs/usage/policy-reference.md
@@ -70,6 +70,7 @@ duplicate `type:name` pair fails validation.
 | `webhook_ip_allowlist_fail_open` | bool | `false` | Allow webhook requests when the allowlist can't be fetched. |
 | `trust_proxy_headers` | bool | `false` | Read client IP from `X-Forwarded-For` (required behind Tailscale Funnel or similar proxies). |
 | `auto_close_pr` | bool | `true` | Auto-close a guardian PR (and delete its branch) when every rule it addresses is satisfied on the default branch. Set `false` to keep PRs open for manual close-out. The `AUTO_CLOSE_PR` env var overrides the HCL value. |
+| `orphan_cleanup` | bool | `true` | Remove a file from repo-guardian's own reconcile branch once the rule that added it is satisfied on the default branch, so the PR stops proposing files that are no longer needed. Set `false` to disable all deletion from the reconcile branch. The `ORPHAN_CLEANUP` env var overrides the HCL value. |
 
 Unknown attributes in `guardian {}` fail load with an "Unsupported
 argument" error naming the file and line — typos are caught at startup,
@@ -611,6 +612,7 @@ overrides:
 | `WEBHOOK_IP_ALLOWLIST_FAIL_OPEN` | `guardian.webhook_ip_allowlist_fail_open` |
 | `TRUST_PROXY_HEADERS` | `guardian.trust_proxy_headers` |
 | `AUTO_CLOSE_PR` | `guardian.auto_close_pr` |
+| `ORPHAN_CLEANUP` | `guardian.orphan_cleanup` |
 
 Related policy/template env vars (not `guardian {}` attributes):
 

--- a/internal/checker/convergence_test.go
+++ b/internal/checker/convergence_test.go
@@ -554,3 +554,26 @@ func TestConvergence_GenuineOrphanIsStillDeleted(t *testing.T) {
 			"and was written to the branch by an earlier sweep. deletedFiles=%v", s.client.deletedFiles)
 	}
 }
+
+// TestConvergence_OrphanCleanupDisabled_NoDeletion pins the INV-0014
+// kill switch. It uses the genuine-orphan fixture — a file that SHOULD be
+// deleted — because a test built on a file that must not be deleted would
+// pass with the flag ignored entirely.
+func TestConvergence_OrphanCleanupDisabled_NoDeletion(t *testing.T) {
+	disabled := false
+
+	pol := policy.BuiltinDefaults()
+	pol.Guardian.DryRun = false
+	pol.Guardian.OrphanCleanup = &disabled
+
+	s := newStagedConvergenceWithPolicy(t, pol)
+	s.satisfyOnMain("CODEOWNERS")
+	s.addOrphanToBranch(".github/CODEOWNERS", "sha-codeowners")
+	s.openOurPR(1)
+
+	s.sweep()
+
+	if len(s.client.deletedFiles) != 0 {
+		t.Errorf("orphan_cleanup=false must delete nothing, deletedFiles=%v", s.client.deletedFiles)
+	}
+}

--- a/internal/checker/convergence_test.go
+++ b/internal/checker/convergence_test.go
@@ -121,6 +121,26 @@ func (s *stagedConvergenceState) addOrphanToBranch(path, sha string) {
 	s.client.branchContents[s.org+"/"+s.repo+"/"+s.branch+"/"+path] = sha
 }
 
+// deletedFromBranch marks a path as deleted on the reconcile branch by a
+// previous sweep, while leaving it present on the default branch.
+//
+// This has to be stated explicitly since INV-0014. Before the fake modelled
+// branch inheritance, "present on main" implied "absent from the branch"
+// purely because the fake had no way to represent the branch inheriting
+// anything — so a fixture could describe this state in a comment and get it
+// by accident. Now the branch really does inherit from main, and a test that
+// wants a file gone from the branch has to say so.
+func (s *stagedConvergenceState) deletedFromBranch(path string) {
+	key := s.org + "/" + s.repo + "/" + s.branch + "/" + path
+	delete(s.client.branchContents, key)
+
+	if s.client.branchDeleted == nil {
+		s.client.branchDeleted = make(map[string]bool)
+	}
+
+	s.client.branchDeleted[key] = true
+}
+
 func TestConvergence_Sweep1_OpensPR(t *testing.T) {
 	metrics.PRsCreatedTotal.Reset()
 
@@ -417,6 +437,7 @@ func TestConvergence_RenovateFirst_GateClosesMidFlight_RestoresDependabot(t *tes
 	// alive) and no_dependabot's gate closed. dependabot present on main but
 	// already deleted from the branch by a prior sweep.
 	s.satisfyOnMain(".github/dependabot.yml")
+	s.deletedFromBranch(".github/dependabot.yml")
 	s.client.fileContents[s.org+"/"+s.repo+"/.github/dependabot.yml"] = "restored-body"
 	s.openOurPR(6)
 
@@ -467,5 +488,69 @@ func TestConvergence_Bundle_AddAndRemove_RendersBothSections(t *testing.T) {
 
 	if !slices.Contains(s.client.deletedFiles, ".github/dependabot.yml") {
 		t.Errorf("expected dependabot.yml deleted, deletedFiles=%v", s.client.deletedFiles)
+	}
+}
+
+// TestConvergence_SatisfiedRuleNeverDeletesDefaultBranchFile is the
+// INV-0014 regression test: the reported production bug, in the shape it
+// was reported.
+//
+// A repo already has .github/CODEOWNERS and is missing dependabot. Sweep
+// one opens a PR adding dependabot; the reconcile branch is cut from main
+// and therefore carries CODEOWNERS, which repo-guardian did not write.
+// Sweep two finds the codeowners rule satisfied and — before the fix —
+// read "CODEOWNERS is on the branch" as "I put it there in an earlier
+// sweep", and committed a deletion. Merging that PR would have removed
+// CODEOWNERS from the default branch.
+//
+// This test can only fail against a fake that models branch inheritance.
+// Against the pre-INV-0014 fake the branch appeared empty, nothing was
+// ever a candidate for deletion, and the assertion below passed whether
+// or not the bug was present.
+func TestConvergence_SatisfiedRuleNeverDeletesDefaultBranchFile(t *testing.T) {
+	s := newStagedConvergence(t, nil)
+
+	// The repository owns CODEOWNERS at the rule's Target path. Only that
+	// layout is affected: a root-level CODEOWNERS is not the rule's Target
+	// and never becomes an orphan candidate (INV-0014 finding C).
+	s.satisfyOnMain(".github/CODEOWNERS")
+	s.openOurPR(1)
+
+	s.sweep()
+
+	if slices.Contains(s.client.deletedFiles, ".github/CODEOWNERS") {
+		t.Fatalf("deleted .github/CODEOWNERS, which the default branch owns; "+
+			"merging this PR would remove it from main. deletedFiles=%v", s.client.deletedFiles)
+	}
+}
+
+// TestConvergence_GenuineOrphanIsStillDeleted guards the other side of the
+// INV-0014 fix: the convergence behaviour IMPL-0013 Phase 3 was built for
+// must survive.
+//
+// repo-guardian wrote .github/CODEOWNERS to the branch in an earlier sweep;
+// a human then satisfied the rule by committing CODEOWNERS at the repo root
+// straight to main. The branch copy is now redundant, and — crucially —
+// .github/CODEOWNERS is NOT on main, so repo-guardian is the only party
+// that could have placed it there. That is a real orphan and must still be
+// removed, or the PR keeps proposing a duplicate CODEOWNERS forever.
+//
+// Without this test the INV-0014 fix could be "improved" into skipping
+// orphan cleanup entirely and nothing would complain.
+func TestConvergence_GenuineOrphanIsStillDeleted(t *testing.T) {
+	s := newStagedConvergence(t, nil)
+
+	// Rule satisfied by the root-level path on main...
+	s.satisfyOnMain("CODEOWNERS")
+	// ...while the branch still carries repo-guardian's earlier write at the
+	// Target path, which main does not have.
+	s.addOrphanToBranch(".github/CODEOWNERS", "sha-codeowners")
+	s.openOurPR(1)
+
+	s.sweep()
+
+	if !slices.Contains(s.client.deletedFiles, ".github/CODEOWNERS") {
+		t.Errorf("genuine orphan not cleaned up: .github/CODEOWNERS is absent from main "+
+			"and was written to the branch by an earlier sweep. deletedFiles=%v", s.client.deletedFiles)
 	}
 }

--- a/internal/checker/convergence_test.go
+++ b/internal/checker/convergence_test.go
@@ -577,3 +577,123 @@ func TestConvergence_OrphanCleanupDisabled_NoDeletion(t *testing.T) {
 		t.Errorf("orphan_cleanup=false must delete nothing, deletedFiles=%v", s.client.deletedFiles)
 	}
 }
+
+// TestConvergence_RepairsBranchThatDeletedADefaultBranchFile is the
+// INV-0014 in-place repair: a PR whose branch already carries the bad
+// deletion is fixed by the next sweep, rather than needing an operator to
+// close and rebuild it.
+//
+// This is the state every affected PR is in right now: .github/CODEOWNERS
+// present on main, deleted from the reconcile branch by a pre-fix sweep,
+// and the rule satisfied so nothing would otherwise touch it again.
+func TestConvergence_RepairsBranchThatDeletedADefaultBranchFile(t *testing.T) {
+	s := newStagedConvergence(t, nil)
+
+	// The repo owns CODEOWNERS; a pre-fix sweep deleted it from the branch.
+	s.satisfyOnMain(".github/CODEOWNERS")
+	s.deletedFromBranch(".github/CODEOWNERS")
+	s.client.fileContents[s.org+"/"+s.repo+"/.github/CODEOWNERS"] = "* @team"
+	s.openOurPR(1)
+
+	s.sweep()
+
+	if !slices.Contains(s.client.createdFiles, ".github/CODEOWNERS") {
+		t.Errorf("branch still proposes deleting .github/CODEOWNERS, which main owns; "+
+			"the open PR is not self-healing. createdFiles=%v", s.client.createdFiles)
+	}
+}
+
+// conflictingPolicy pairs an add rule whose Target is a path an absent
+// rule forbids. The add rule is satisfied on main (so non-actionable, and
+// therefore a restore candidate) while the absent rule is actionable and
+// wants that exact path gone.
+func conflictingPolicy() *policy.PolicyConfig {
+	return &policy.PolicyConfig{
+		Guardian: policy.BuiltinDefaults().Guardian,
+		FileRules: []policy.FileRuleConfig{
+			{
+				Type:     "file",
+				Name:     "needs_dependabot",
+				Check:    string(policy.CheckExists),
+				Paths:    []string{".github/dependabot.yml"},
+				Target:   ".github/dependabot.yml",
+				Template: "codeowners",
+			},
+			{
+				Type:   "file",
+				Name:   "needs_codeowners",
+				Check:  string(policy.CheckExists),
+				Paths:  []string{".github/CODEOWNERS"},
+				Target: ".github/CODEOWNERS",
+				// Keeps the PR alive so the existing-PR path runs.
+				Template: "codeowners",
+			},
+			{
+				Type:  "file",
+				Name:  "no_dependabot",
+				Check: string(policy.CheckAbsent),
+				Paths: []string{".github/dependabot.yml"},
+			},
+		},
+	}
+}
+
+// TestConvergence_RepairDoesNotFightAnActionableAbsentRule pins the
+// exclusion that keeps repair from flip-flopping.
+//
+// needs_dependabot is satisfied on main, so it is non-actionable and its
+// Target is a restore candidate. no_dependabot is actionable and wants that
+// same path deleted this sweep. Without the planned-deletion exclusion the
+// two undo each other on every sweep forever — a loop that burns rate limit
+// and never converges. The deletion must win: an actionable rule is a live
+// instruction, restoration only repairs a state nothing is asking for.
+func TestConvergence_RepairDoesNotFightAnActionableAbsentRule(t *testing.T) {
+	s := newStagedConvergenceWithPolicy(t, conflictingPolicy())
+
+	// dependabot.yml on main: satisfies needs_dependabot AND makes
+	// no_dependabot actionable. CODEOWNERS missing keeps the PR alive.
+	s.forbiddenOnMainAndBranch(".github/dependabot.yml", "dep-sha")
+	s.openOurPR(2)
+
+	s.sweep()
+
+	if slices.Contains(s.client.createdFiles, ".github/dependabot.yml") {
+		t.Errorf("restored a path an actionable absent rule is deleting this sweep; "+
+			"the two will undo each other forever. createdFiles=%v", s.client.createdFiles)
+	}
+
+	if !slices.Contains(s.client.deletedFiles, ".github/dependabot.yml") {
+		t.Errorf("the actionable absent rule must still delete its forbidden file, deletedFiles=%v",
+			s.client.deletedFiles)
+	}
+}
+
+// TestConvergence_RepairScopedToRuleTarget pins the deliberate scope
+// boundary: for non-absent rules, repair restores only the rule's Target.
+//
+// Target is the only path cleanupOrphans ever deletes, so Target is the
+// exact inverse and covers all the damage INV-0014 caused. A rule's wider
+// Paths set can be missing from the branch for reasons repo-guardian did
+// not cause — a human editing the branch, most obviously — and re-adding
+// those would turn a repair mechanism into a resurrection mechanism that
+// silently reverts deliberate edits.
+//
+// Here the codeowners rule is satisfied by the root-level CODEOWNERS, which
+// is in Paths but is not Target, and which is absent from the branch.
+// Restoring it is out of scope.
+func TestConvergence_RepairScopedToRuleTarget(t *testing.T) {
+	s := newStagedConvergence(t, nil)
+
+	s.satisfyOnMain("CODEOWNERS") // in Paths, not Target -> rule satisfied
+	s.deletedFromBranch("CODEOWNERS")
+	s.client.fileContents[s.org+"/"+s.repo+"/CODEOWNERS"] = "* @team"
+	s.openOurPR(3)
+
+	s.sweep()
+
+	if slices.Contains(s.client.createdFiles, "CODEOWNERS") {
+		t.Errorf("restored root CODEOWNERS, which is in the rule's Paths but is not its Target; "+
+			"repair must mirror cleanupOrphans, which only ever deletes Target. createdFiles=%v",
+			s.client.createdFiles)
+	}
+}

--- a/internal/checker/drift.go
+++ b/internal/checker/drift.go
@@ -61,13 +61,21 @@ type orphanFile struct {
 	SHA      string
 }
 
-// discoverOrphans returns files on the reconcile branch authored for
-// rules that are no longer actionable. Per IMPL-0013 Resolved
-// Decisions Q9, GetContentsOnBranch errors are treated as "still
-// actionable" — the file is omitted from the orphan list so the
-// downstream cleanup never deletes a file under a transient API
-// glitch. Errors are logged at Warn so operators can spot
-// systematic failures.
+// discoverOrphans returns files on the reconcile branch that
+// repo-guardian itself added for rules that are no longer actionable.
+//
+// A file qualifies only when it is absent from the default branch and
+// present on the reconcile branch. Both halves are load-bearing. The
+// branch is cut from the default branch, so presence on the branch alone
+// is not evidence of authorship — that mistake shipped in IMPL-0013 and
+// caused repo-guardian to propose deleting files repositories legitimately
+// owned (INV-0014). Absence from the default branch is what makes
+// repo-guardian the only party that could have placed the file there.
+//
+// Every API error is fail-safe in the same direction: treat the rule as
+// still actionable and omit it from the orphan list, so a transient glitch
+// can never cause a deletion. Errors are logged at Warn so operators can
+// spot systematic failures (IMPL-0013 Resolved Decisions Q9).
 func discoverOrphans(
 	ctx context.Context,
 	log *slog.Logger,
@@ -95,6 +103,28 @@ func discoverOrphans(
 		}
 
 		if r.Target == "" {
+			continue
+		}
+
+		// INV-0014: a path that exists on the default branch is NEVER an
+		// orphan. The reconcile branch is cut from the default branch (and
+		// re-merged with it by updateReconcileBranch), so "the file is on
+		// the branch" does not mean "we put it there" — it is equally the
+		// signature of a file the repository has always owned. Deleting one
+		// of those makes the PR propose removing a legitimate file.
+		//
+		// Probing default FIRST also makes the common case — a rule
+		// satisfied because the file is on the default branch — cost one
+		// API call instead of two.
+		onDefault, err := client.GetContents(ctx, owner, repo, r.Target)
+		if err != nil {
+			log.Warn("orphan discovery: default-branch probe failed, treating as still-actionable",
+				"rule", r.Name, "path", r.Target, "err", err)
+
+			continue
+		}
+
+		if onDefault {
 			continue
 		}
 

--- a/internal/checker/drift.go
+++ b/internal/checker/drift.go
@@ -185,12 +185,32 @@ func cleanupOrphans(
 	return removed
 }
 
-// restoreInverseOrphans restores forbidden files that an absent rule
-// previously deleted from the reconcile branch but which should no longer
-// be removed because the rule is no longer actionable (its when-gate
-// closed, or the file is gone from the default branch). It is the mirror
-// image of discoverOrphans/cleanupOrphans: instead of deleting a
-// no-longer-wanted added file, it re-adds a no-longer-forbidden file.
+// restoreInverseOrphans re-adds files the reconcile branch is proposing to
+// delete even though the default branch owns them, so the PR stops
+// proposing the deletion. It is the mirror image of
+// discoverOrphans/cleanupOrphans.
+//
+// It covers two cases that arrive at the same broken state:
+//
+//   - Absent rules (IMPL-0019 Phase 2), whose forbidden file the branch
+//     deleted but which are no longer actionable — the when-gate closed, or
+//     the file is gone from the default branch.
+//   - Every other mode (INV-0014). A defect in discoverOrphans deleted files
+//     that the repository legitimately owned, purely because they appeared on
+//     the reconcile branch — where they were only ever visible because the
+//     branch is cut from the default branch. Fixing discoverOrphans stops new
+//     damage; this repairs branches already carrying it, on the next sweep,
+//     without an operator having to triage each PR by hand.
+//
+// Together with the discoverOrphans fix this upgrades the guarantee from
+// "repo-guardian will not propose deleting a file the default branch owns"
+// to "repo-guardian actively repairs a branch that does" — so a future
+// regression of this class self-heals instead of accumulating.
+//
+// Scope differs by mode, deliberately. Absent rules restore every path they
+// could have deleted (all of r.Paths). Other modes restore only r.Target,
+// which is the exact inverse of what cleanupOrphans deletes; restoring the
+// wider Paths set would re-add files repo-guardian never removes.
 //
 // Fail-safe (mirrors cleanupOrphans / IMPL-0013 Q9): any API error leaves
 // the path untouched, logs at Warn, increments PROrphanLeftTotal, and the
@@ -207,12 +227,23 @@ func restoreInverseOrphans(
 		actionableSet[actionable[i].Name] = struct{}{}
 	}
 
+	// Paths an actionable absent rule intends to delete on this very sweep.
+	// Without this exclusion a non-actionable add rule and an actionable
+	// absent rule covering the same path would fight: one restores, the
+	// other deletes, on every sweep forever. The deletion wins — an
+	// actionable rule is a live instruction, whereas restoration only
+	// repairs a state nothing is asking for any more.
+	deleting := make(map[string]struct{})
+	for _, path := range plannedDeletions(actionable) {
+		deleting[path] = struct{}{}
+	}
+
 	var restored []string
 
 	for i := range allRules {
 		r := &allRules[i]
 
-		if !r.IsEnabled() || r.CheckMode() != policy.CheckAbsent {
+		if !r.IsEnabled() {
 			continue
 		}
 
@@ -220,7 +251,7 @@ func restoreInverseOrphans(
 			continue
 		}
 
-		if restoreRulePaths(ctx, log, client, r, owner, repo) {
+		if restoreRulePaths(ctx, log, client, r, restorablePaths(r), deleting, owner, repo) {
 			restored = append(restored, r.Name)
 		}
 	}
@@ -228,20 +259,44 @@ func restoreInverseOrphans(
 	return restored
 }
 
-// restoreRulePaths restores every path of a no-longer-actionable absent
-// rule that is present on the default branch but missing from the
-// reconcile branch. Returns true if at least one path was restored. Every
-// API error is fail-safe: the path is left untouched and retried next sweep.
+// restorablePaths returns the paths a no-longer-actionable rule may restore.
+// Absent rules could have deleted any of their paths; every other mode only
+// ever has its Target deleted by cleanupOrphans, so only Target can need
+// restoring.
+func restorablePaths(r *policy.FileRuleConfig) []string {
+	if r.CheckMode() == policy.CheckAbsent {
+		return r.Paths
+	}
+
+	if r.Target == "" {
+		return nil
+	}
+
+	return []string{r.Target}
+}
+
+// restoreRulePaths restores each of the given paths of a
+// no-longer-actionable rule that is present on the default branch but
+// missing from the reconcile branch. Paths in `deleting` are skipped:
+// another rule is actively removing them on this sweep. Returns true if at
+// least one path was restored. Every API error is fail-safe: the path is
+// left untouched and retried next sweep.
 func restoreRulePaths(
 	ctx context.Context,
 	log *slog.Logger,
 	client ghclient.Client,
 	r *policy.FileRuleConfig,
+	paths []string,
+	deleting map[string]struct{},
 	owner, repo string,
 ) bool {
 	var restoredAny bool
 
-	for _, path := range r.Paths {
+	for _, path := range paths {
+		if _, beingDeleted := deleting[path]; beingDeleted {
+			continue
+		}
+
 		onDefault, err := client.GetContents(ctx, owner, repo, path)
 		if err != nil {
 			logRestoreSkip(log, owner, r.Name, path, "default-branch probe failed", err)

--- a/internal/checker/engine_pr.go
+++ b/internal/checker/engine_pr.go
@@ -175,13 +175,19 @@ func (e *Engine) createOrUpdatePRFromPolicy(
 	// IMPL-0013 Phase 3: existing PR is being updated. Remove orphan
 	// files (rules that were in a previous version of the PR but are
 	// now satisfied on the default branch) and refresh the PR body.
-	orphans := discoverOrphans(ctx, log, client, e.policy.FileRules, actionable, owner, repo)
-
 	var removedOrphans []string
 
-	if len(orphans) > 0 {
-		log.Info("cleaning up orphan files", "count", len(orphans))
-		removedOrphans = cleanupOrphans(ctx, log, client, orphans, owner, repo)
+	// INV-0014 kill switch: orphan cleanup is the only path that deletes
+	// files, so it is the only one with an off switch. Gated before
+	// discovery, not before cleanup, so disabling it also stops the
+	// default-branch probes it would otherwise issue.
+	if e.policy.Guardian.OrphanCleanupEnabled() {
+		orphans := discoverOrphans(ctx, log, client, e.policy.FileRules, actionable, owner, repo)
+
+		if len(orphans) > 0 {
+			log.Info("cleaning up orphan files", "count", len(orphans))
+			removedOrphans = cleanupOrphans(ctx, log, client, orphans, owner, repo)
+		}
 	}
 
 	// IMPL-0019 Phase 2: inverse orphans — absent rules that stopped being

--- a/internal/checker/engine_test.go
+++ b/internal/checker/engine_test.go
@@ -25,6 +25,7 @@ type mockClient struct {
 
 	contents         map[string]bool                            // "owner/repo/path" -> exists
 	branchContents   map[string]string                          // "owner/repo/branch/path" -> sha (IMPL-0013 P3 orphan discovery)
+	branchDeleted    map[string]bool                            // "owner/repo/branch/path" -> tombstone (INV-0014)
 	fileContents     map[string]string                          // "owner/repo/path" -> content
 	customProperties map[string][]*ghclient.CustomPropertyValue // "owner/repo" -> values
 	setProperties    []*ghclient.CustomPropertyValue            // records what was set
@@ -170,6 +171,8 @@ func (m *mockClient) CreateOrUpdateFile(_ context.Context, owner, repo, branch, 
 	if m.branchContents != nil {
 		m.branchContents[owner+"/"+repo+"/"+branch+"/"+path] = "sha-" + path
 	}
+
+	delete(m.branchDeleted, owner+"/"+repo+"/"+branch+"/"+path)
 
 	m.createdFiles = append(m.createdFiles, path)
 
@@ -317,13 +320,28 @@ func (m *mockClient) GetContentsOnBranch(_ context.Context, owner, repo, path, b
 		return "", false, m.getContentsOnBranchErr
 	}
 
-	if m.branchContents == nil {
+	key := owner + "/" + repo + "/" + branch + "/" + path
+
+	// A tombstone means the path was deleted on this branch. It must not
+	// be inherited back from the default branch below, or a file the
+	// engine just deleted would immediately reappear — which is exactly
+	// the state restoreInverseOrphans depends on being able to observe.
+	if m.branchDeleted[key] {
 		return "", false, nil
 	}
 
-	key := owner + "/" + repo + "/" + branch + "/" + path
 	if sha, ok := m.branchContents[key]; ok {
 		return sha, true, nil
+	}
+
+	// INV-0014: a branch is cut from the default branch, so everything on
+	// default is readable on it unless the branch overrode or deleted the
+	// path. Before this, the only way a file appeared on a branch was for
+	// the engine to write it there — a world in which every file on the
+	// reconcile branch is by definition repo-guardian's own work, and
+	// therefore a world in which discoverOrphans could not be wrong.
+	if m.contents[owner+"/"+repo+"/"+path] {
+		return "sha-inherited-" + path, true, nil
 	}
 
 	return "", false, nil
@@ -336,6 +354,12 @@ func (m *mockClient) DeleteFile(_ context.Context, owner, repo, branch, path, _,
 
 	key := owner + "/" + repo + "/" + branch + "/" + path
 	delete(m.branchContents, key)
+
+	if m.branchDeleted == nil {
+		m.branchDeleted = make(map[string]bool)
+	}
+
+	m.branchDeleted[key] = true
 	m.deletedFiles = append(m.deletedFiles, path)
 
 	return nil

--- a/internal/github/mocks/client_mock.go
+++ b/internal/github/mocks/client_mock.go
@@ -8,8 +8,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/donaldgifford/repo-guardian/internal/github"
 	mock "github.com/stretchr/testify/mock"
+
+	"github.com/donaldgifford/repo-guardian/internal/github"
 )
 
 // NewMockClient creates a new instance of MockClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/internal/policy/loader.go
+++ b/internal/policy/loader.go
@@ -379,6 +379,7 @@ var guardianBodySchema = &hcl.BodySchema{
 		{Name: "webhook_ip_allowlist_fail_open"},
 		{Name: "trust_proxy_headers"},
 		{Name: "auto_close_pr"},
+		{Name: "orphan_cleanup"},
 	},
 }
 
@@ -434,6 +435,9 @@ func setGuardianAttr(g *GuardianConfig, name string, val cty.Value) {
 	case "auto_close_pr":
 		b := val.True()
 		g.AutoClosePR = &b
+	case "orphan_cleanup":
+		b := val.True()
+		g.OrphanCleanup = &b
 	}
 }
 
@@ -1167,6 +1171,10 @@ func mergeGuardianConfig(dst, src *GuardianConfig) {
 	if src.AutoClosePR != nil {
 		dst.AutoClosePR = src.AutoClosePR
 	}
+
+	if src.OrphanCleanup != nil {
+		dst.OrphanCleanup = src.OrphanCleanup
+	}
 }
 
 func applyEnvOverrides(g *GuardianConfig) {
@@ -1182,6 +1190,7 @@ func applyEnvOverrides(g *GuardianConfig) {
 	applyEnvBool("WEBHOOK_IP_ALLOWLIST_FAIL_OPEN", &g.WebhookIPAllowlistFailOpen)
 	applyEnvBool("TRUST_PROXY_HEADERS", &g.TrustProxyHeaders)
 	applyEnvBoolPtr("AUTO_CLOSE_PR", &g.AutoClosePR)
+	applyEnvBoolPtr("ORPHAN_CLEANUP", &g.OrphanCleanup)
 }
 
 func applyEnvBool(key string, dst *bool) {

--- a/internal/policy/loader_test.go
+++ b/internal/policy/loader_test.go
@@ -1223,3 +1223,55 @@ func TestLoad_AnnotationProperties_ListValue_FailsCleanly(t *testing.T) {
 		t.Errorf("error %q does not mention annotation_properties", err)
 	}
 }
+
+// TestLoad_OrphanCleanup_FromHCL closes the INV-0010 trap for the
+// INV-0014 kill switch: adding a GuardianConfig field needs the schema
+// attribute, the setGuardianAttr case AND the mergeGuardianConfig carry
+// in lockstep. auto_close_pr shipped with the field and the env override
+// but neither of the other two, so the HCL attribute silently did
+// nothing for four releases. This test drives the HCL path specifically,
+// which is the one that broke.
+func TestLoad_OrphanCleanup_FromHCL(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		wantSet     bool
+		wantEnabled bool
+	}{
+		{name: "explicit false", body: `orphan_cleanup = false`, wantSet: true, wantEnabled: false},
+		{name: "explicit true", body: `orphan_cleanup = true`, wantSet: true, wantEnabled: true},
+		{name: "unset defaults true", body: `log_level = "info"`, wantSet: false, wantEnabled: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := Load(writeGuardianHCL(t, tt.body))
+			if err != nil {
+				t.Fatalf("Load() error: %v", err)
+			}
+
+			if got := cfg.Guardian.OrphanCleanup != nil; got != tt.wantSet {
+				t.Errorf("OrphanCleanup set = %v, want %v", got, tt.wantSet)
+			}
+
+			if got := cfg.Guardian.OrphanCleanupEnabled(); got != tt.wantEnabled {
+				t.Errorf("OrphanCleanupEnabled() = %v, want %v", got, tt.wantEnabled)
+			}
+		})
+	}
+}
+
+// Env override must win over the HCL attribute because applyEnvOverrides
+// runs last in Load. Cannot use t.Parallel with t.Setenv.
+func TestLoad_OrphanCleanup_EnvOverridesHCL(t *testing.T) {
+	t.Setenv("ORPHAN_CLEANUP", "false")
+
+	cfg, err := Load(writeGuardianHCL(t, `orphan_cleanup = true`))
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.Guardian.OrphanCleanupEnabled() {
+		t.Error("ORPHAN_CLEANUP=false must override orphan_cleanup = true in HCL")
+	}
+}

--- a/internal/policy/types.go
+++ b/internal/policy/types.go
@@ -91,9 +91,35 @@ type GuardianConfig struct {
 	// a human closes it. Override via env AUTO_CLOSE_PR.
 	AutoClosePR *bool `hcl:"auto_close_pr,optional"`
 
+	// OrphanCleanup controls whether repo-guardian removes files from
+	// its own reconcile branch once the rule that added them is
+	// satisfied on the default branch (IMPL-0013 Phase 3). Default
+	// true; set to false to disable the behaviour entirely.
+	// Override via env ORPHAN_CLEANUP.
+	//
+	// The kill switch exists because this path deletes files, and a
+	// defect in it (INV-0014) once produced PRs proposing to remove
+	// files the repository legitimately owned. The defect is fixed —
+	// discoverOrphans now skips any path present on the default branch
+	// — so the default stays true, and turning it off costs only PR
+	// bodies that keep listing rules already satisfied on main.
+	OrphanCleanup *bool `hcl:"orphan_cleanup,optional"`
+
 	// ParsedScheduleInterval is the parsed duration from ScheduleInterval.
 	// It is not set from HCL directly but computed after loading.
 	ParsedScheduleInterval time.Duration `hcl:"-"`
+}
+
+// OrphanCleanupEnabled returns whether orphan cleanup is active.
+// Defaults to true when the field is unset — the behaviour is correct
+// post-INV-0014, and defaulting it off would regress the INV-0005
+// convergence fix for every operator.
+func (g *GuardianConfig) OrphanCleanupEnabled() bool {
+	if g == nil || g.OrphanCleanup == nil {
+		return true
+	}
+
+	return *g.OrphanCleanup
 }
 
 // AutoClosePREnabled returns whether the auto-close behaviour is

--- a/internal/queue/mocks/queue_mock.go
+++ b/internal/queue/mocks/queue_mock.go
@@ -8,8 +8,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/donaldgifford/repo-guardian/internal/queue"
 	mock "github.com/stretchr/testify/mock"
+
+	"github.com/donaldgifford/repo-guardian/internal/queue"
 )
 
 // NewMockQueue creates a new instance of MockQueue. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/internal/store/mocks/store_mock.go
+++ b/internal/store/mocks/store_mock.go
@@ -8,8 +8,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/donaldgifford/repo-guardian/internal/store"
 	mock "github.com/stretchr/testify/mock"
+
+	"github.com/donaldgifford/repo-guardian/internal/store"
 )
 
 // NewMockStore creates a new instance of MockStore. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,6 +70,7 @@ nav:
         - 'INV-0011: Tech debt cleanup inventory post IMPL-0019': investigation/0011-tech-debt-cleanup-inventory-post-impl-0019.md
         - 'INV-0012: Inert BudgetTracker and untrustworthy alert pack': investigation/0012-inert-budgettracker-and-untrustworthy-alert-pack.md
         - 'INV-0013: State-vs-event metrics, dashboard suite, and system observability': investigation/0013-state-vs-event-metrics-dashboard-suite-and-system-observability.md
+        - 'INV-0014: Orphan cleanup deletes files the default branch legitimately owns': investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md
     - Plans:
         - Overview: plan/README.md
     - RFCs:
@@ -83,7 +84,7 @@ nav:
         - Custom-properties security fix (IMPL-0020): operations/custom-properties-security-fix.md
         - Custom-property annotation migration (appVersion 1.9.1 → next minor): operations/annotation-properties-migration.md
         - Custom-property name charset correction (appVersion 1.10.1): operations/property-name-charset.md
-        - Delayed requeue — operator runbook (IMPL-0022): operations/delayed-requeue-runbook.md
+        - Delayed requeue — operator runbook: operations/delayed-requeue-runbook.md
         - ECR publish setup (maintainer-side): operations/ecr-publish-setup.md
         - External Postgres on RDS — Terraform variable reference: operations/rds-terraform-variables.md
         - Homelab CNPG cutover runbook: operations/cnpg-homelab-cutover.md

--- a/scripts/inv-0014-scan.sh
+++ b/scripts/inv-0014-scan.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# inv-0014-scan.sh - Measure the blast radius of the INV-0014 orphan-deletion bug.
+#
+# INV-0014: discoverOrphans misclassifies a file that exists on the default
+# branch as an orphan repo-guardian authored, and commits a deletion of it to
+# the reconcile branch of an open PR. Merging such a PR removes a legitimate
+# file from the default branch.
+#
+# This script is STRICTLY READ-ONLY. It performs no writes, no merges, no
+# closes, and no branch deletions. It answers three questions per affected
+# repository:
+#
+#   1. Does a repo-guardian PR carry a `chore: remove ...` orphan commit?
+#   2. Was that PR merged, closed, or is it still open?
+#   3. Does the deleted path exist on the default branch RIGHT NOW?
+#
+# Question 3 is the one that matters. A missing file with a merged PR is
+# confirmed data loss and needs restoring; a missing file with an unmerged PR
+# means something else removed it; an open PR with the file still present is
+# containment — close the PR before anyone merges it.
+#
+# Usage:
+#   ./scripts/inv-0014-scan.sh ORG [ORG...]
+#
+# Requires: gh (authenticated), jq
+#
+# Output: TSV on stdout (repo, pr, pr_state, path, on_default, verdict) plus a
+# human summary on stderr, so `./scripts/inv-0014-scan.sh myorg > findings.tsv`
+# gives a clean file to work from.
+
+set -euo pipefail
+
+readonly BRANCH="repo-guardian/add-missing-files"
+# Matches the commit message built in internal/checker/drift.go cleanupOrphans.
+readonly ORPHAN_MSG_RE='^chore: remove (.+) \(rule "(.+)" satisfied on default branch\)$'
+
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+readonly RED YELLOW GREEN NC
+
+die() {
+  printf '%berror:%b %s\n' "$RED" "$NC" "$1" >&2
+  exit 1
+}
+
+note() {
+  printf '%s\n' "$1" >&2
+}
+
+usage() {
+  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+  exit "${1:-0}"
+}
+
+check_deps() {
+  command -v gh >/dev/null 2>&1 || die "gh is not installed"
+  command -v jq >/dev/null 2>&1 || die "jq is not installed"
+  gh auth status >/dev/null 2>&1 || die "gh is not authenticated; run: gh auth login"
+}
+
+# find_prs lists "owner/repo<TAB>number" for every PR in the org whose head
+# branch is the reconcile branch, in any state. Search is capped at 1000
+# results; the count is echoed so a truncated fleet is visible rather than
+# silently partial.
+find_prs() {
+  local org=$1
+  gh search prs "head:${BRANCH}" --owner "$org" --limit 1000 \
+    --json repository,number \
+    --jq '.[] | "\(.repository.nameWithOwner)\t\(.number)"'
+}
+
+# pr_state returns "merged", "closed", or "open".
+pr_state() {
+  local repo=$1 num=$2
+  gh api "repos/${repo}/pulls/${num}" \
+    --jq 'if .merged then "merged" else .state end'
+}
+
+# orphan_paths prints every path removed by an orphan-cleanup commit on the
+# given PR, one per line. A PR with no such commit prints nothing.
+orphan_paths() {
+  local repo=$1 num=$2
+  gh api "repos/${repo}/pulls/${num}/commits" --paginate --jq '.[].commit.message' |
+    # Commit messages are multi-line; only the subject can match.
+    head -c 100000 |
+    sed -nE "s/${ORPHAN_MSG_RE}/\1/p"
+}
+
+# path_on_default is "yes" if the path exists on the repo's default branch
+# today, "no" if GitHub returns 404, "unknown" on any other failure. Unknown is
+# never treated as safe.
+path_on_default() {
+  local repo=$1 path=$2 status
+  status=$(gh api "repos/${repo}/contents/${path}" \
+    --silent --include 2>/dev/null | head -1 | grep -oE '[0-9]{3}' | head -1 || true)
+
+  case "$status" in
+    200) printf 'yes' ;;
+    404) printf 'no' ;;
+    *) printf 'unknown' ;;
+  esac
+}
+
+# verdict maps (pr_state, on_default) to the operator action.
+verdict() {
+  local state=$1 on_default=$2
+
+  case "${state}:${on_default}" in
+    merged:no) printf 'DATA LOSS - restore from git history' ;;
+    merged:yes) printf 'merged but file present - verify manually' ;;
+    open:yes) printf 'CONTAINMENT - close PR before it is merged' ;;
+    open:no) printf 'file already absent - PR would re-delete nothing' ;;
+    closed:no) printf 'file absent, PR not merged - another cause' ;;
+    closed:yes) printf 'no action - PR closed unmerged' ;;
+    *:unknown) printf 'INDETERMINATE - probe failed, check by hand' ;;
+    *) printf 'review' ;;
+  esac
+}
+
+scan_pr() {
+  local repo=$1 num=$2 state path on_default v
+  local -i found=0
+
+  state=$(pr_state "$repo" "$num")
+
+  while IFS= read -r path; do
+    [[ -n "$path" ]] || continue
+    found=1
+    on_default=$(path_on_default "$repo" "$path")
+    v=$(verdict "$state" "$on_default")
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$repo" "$num" "$state" "$path" "$on_default" "$v"
+
+    case "$v" in
+      DATA*) note "$(printf '  %b%s%b #%s %s (%s)' "$RED" "$repo" "$NC" "$num" "$path" "$v")" ;;
+      CONTAINMENT*) note "$(printf '  %b%s%b #%s %s (%s)' "$YELLOW" "$repo" "$NC" "$num" "$path" "$v")" ;;
+      *) note "$(printf '  %s #%s %s (%s)' "$repo" "$num" "$path" "$v")" ;;
+    esac
+  done < <(orphan_paths "$repo" "$num")
+
+  return $((found == 0))
+}
+
+main() {
+  [[ $# -gt 0 ]] || usage 1
+  [[ "${1:-}" != "--help" && "${1:-}" != "-h" ]] || usage 0
+
+  check_deps
+
+  printf 'repo\tpr\tpr_state\tpath\ton_default\tverdict\n'
+
+  local -i scanned=0 affected=0
+
+  for org in "$@"; do
+    note "scanning ${org} for PRs with head ${BRANCH} ..."
+
+    while IFS=$'\t' read -r repo num; do
+      [[ -n "$repo" ]] || continue
+      scanned+=1
+
+      if scan_pr "$repo" "$num"; then
+        affected+=1
+      fi
+    done < <(find_prs "$org")
+  done
+
+  note ''
+  note "$(printf '%bscanned %d repo-guardian PRs; %d carry an orphan-deletion commit%b' \
+    "$GREEN" "$scanned" "$affected" "$NC")"
+  note 'Rows marked DATA LOSS or CONTAINMENT need action. This script changed nothing.'
+}
+
+main "$@"


### PR DESCRIPTION
Fixes a data-destructive defect in orphan cleanup. Repositories with `.github/CODEOWNERS` were getting open PRs that proposed deleting it; merging one would have removed the file from the default branch.

Investigation: [INV-0014](docs/investigation/0014-orphan-cleanup-deletes-files-the-default-branch-legitimately.md).

## The bug

`discoverOrphans` decided a file was repo-guardian's own earlier work from a single fact: the path exists on the reconcile branch. That branch is cut from the default branch — and re-merged with it by `updateReconcileBranch` — so presence on the branch is equally the signature of a file the repository has always owned. A satisfied rule therefore produced a deletion.

Latent since IMPL-0013 / appVersion 1.7.0. It needs an already-open PR, which is why a first sweep looks clean and the second does the damage.

Not codeowners-specific. Any non-actionable rule whose `Target` is on the default branch hits it — the test reproduction deletes `renovate.json`.

## What's here

| Commit | |
|---|---|
| `26c5869` | **Prevention** — probe the default branch first; a path it owns is never an orphan |
| `6840117` | **Kill switch** — `orphan_cleanup` / `ORPHAN_CLEANUP` / `policy.orphanCleanup`, default on |
| `34005a8` | **Repair** — branches already carrying the deletion self-heal on the next sweep, keeping PR number, discussion and review state |

The genuine orphan is still cleaned up: repo-guardian wrote `.github/CODEOWNERS`, a human then satisfied the rule with a root-level `CODEOWNERS` on main, and the branch copy is absent from main. That is the INV-0005 convergence case IMPL-0013 was built for, and a test pins it so the fix cannot be "improved" into disabling cleanup.

## Why the tests missed it

The fake could not express the failing state. `branchContents` was only ever written by the fake's own `CreateOrUpdateFile`, so every file on a branch was by construction repo-guardian's own — a world in which `discoverOrphans` cannot be wrong. `GetContentsOnBranch` now inherits from the default branch like a real branch does, with a tombstone map because `DeleteFile` does a bare `delete()` and inheritance would otherwise resurrect deleted files.

Fixing the fake reproduced the bug immediately with production code untouched.

One fixture was relying on that gap: `GateClosesMidFlight` claimed in a comment that dependabot was "already deleted from the branch by a prior sweep" but only seeded the file on main. It now says so explicitly.

## Verification

Every behavioural change was neutralise-verified. Notably, reverting the fake while keeping the fix makes the regression test pass green **with the bug present** — which is what the pre-existing suite was doing, and why the fake change is load-bearing rather than incidental.

Three tests were vacuous on first draft and were rebuilt after neutralisation showed them passing against broken code.

`make lint` 0 issues · `go test -race ./...` green · helm-unittest 103/103.

## Operator notes

- Any open repo-guardian PR carrying a `chore: remove ...` commit must not be merged. `scripts/inv-0014-scan.sh ORG` finds them fleet-wide (read-only) and reports whether each deleted path still exists on the default branch.
- A merged deletion is not recoverable by this change — that is git history, not branch state.
- The real-GitHub contract suite proposed in the investigation is **not** in this PR. It is the only thing that would catch the next wrong assumption about the GitHub API, and it is tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)