### PR TITLE
fix(chart): rc.11 / appVersion 1.11.1 so the chart ships the INV-0014 fix

### DIFF
--- a/charts/repo-guardian/Chart.yaml
+++ b/charts/repo-guardian/Chart.yaml
@@ -4,5 +4,5 @@ apiVersion: v2
 name: repo-guardian
 description: GitHub App that automates repository onboarding and compliance
 type: application
-version: 1.0.0-rc.10
-appVersion: "1.11.0"
+version: 1.0.0-rc.11
+appVersion: "1.11.1"

--- a/charts/repo-guardian/README.md
+++ b/charts/repo-guardian/README.md
@@ -13,7 +13,7 @@ SLSA Level 3 provenance attestations.
 ```bash
 helm install repo-guardian \
   oci://ghcr.io/donaldgifford/charts/repo-guardian \
-  --version 1.0.0-rc.10 \
+  --version 1.0.0-rc.11 \
   --namespace repo-guardian \
   --create-namespace \
   -f values.yaml
@@ -28,7 +28,7 @@ aws ecr get-login-password --region <region> | \
 
 helm install repo-guardian \
   oci://<account>.dkr.ecr.<region>.amazonaws.com/repo-guardian-chart \
-  --version 1.0.0-rc.10 \
+  --version 1.0.0-rc.11 \
   --namespace repo-guardian \
   --create-namespace \
   -f values.yaml
@@ -64,7 +64,7 @@ secrets:
 ```bash
 helm install repo-guardian \
   oci://ghcr.io/donaldgifford/charts/repo-guardian \
-  --version 1.0.0-rc.10 \
+  --version 1.0.0-rc.11 \
   --namespace repo-guardian \
   --create-namespace \
   -f values.yaml
@@ -220,7 +220,7 @@ cosign verify \
     '^https://github.com/donaldgifford/repo-guardian/.+' \
   --certificate-oidc-issuer \
     'https://token.actions.githubusercontent.com' \
-  ghcr.io/donaldgifford/charts/repo-guardian:1.0.0-rc.10
+  ghcr.io/donaldgifford/charts/repo-guardian:1.0.0-rc.11
 ```
 
 ### SLSA provenance
@@ -231,7 +231,7 @@ cosign verify-attestation --type slsaprovenance \
     '^https://github.com/slsa-framework/slsa-github-generator/.+' \
   --certificate-oidc-issuer \
     'https://token.actions.githubusercontent.com' \
-  ghcr.io/donaldgifford/charts/repo-guardian:1.0.0-rc.10
+  ghcr.io/donaldgifford/charts/repo-guardian:1.0.0-rc.11
 ```
 
 The provenance attestation records the build workflow path, source

--- a/charts/repo-guardian/tests/deployment_test.yaml
+++ b/charts/repo-guardian/tests/deployment_test.yaml
@@ -34,7 +34,7 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: "ghcr.io/donaldgifford/repo-guardian:1\\.11\\.0"
+          pattern: "ghcr.io/donaldgifford/repo-guardian:1\\.11\\.1"
 
   - it: should use custom image tag when set
     set:


### PR DESCRIPTION
Chart `1.0.0-rc.10` deploys a binary **without** the INV-0014 fix, and the published rc.10 artifact is not the chart in this repo. Two silent defects:

**1. appVersion never followed the tag.** PR #174 carried the `patch` label and cut `v1.11.1`, but `Chart.yaml` stayed at `appVersion: "1.11.0"`. `deployment.yaml` defaults `image.tag` to `.Chart.AppVersion`, so a default install pulls `1.11.0` — the version whose `discoverOrphans` deletes files the default branch owns. Same shape as the IMPL-0017 appVersion divergence already recorded in CLAUDE.md.

**2. The published rc.10 diverged from the repo's rc.10.** PR #174 added `ORPHAN_CLEANUP` to `deployment.yaml` and `policy.orphanCleanup` to `values.yaml` but left `Chart.yaml` at rc.10 — a version already published by PR #172. The chart publish job is idempotent via a `helm pull` precheck, so it skipped republishing and the registry kept serving the pre-fix chart under an identical version string. Confirmed:

```
helm pull oci://ghcr.io/donaldgifford/charts/repo-guardian --version 1.0.0-rc.10 --untar
grep -r ORPHAN_CLEANUP repo-guardian/   # absent
```

Two different charts, one version number, no error anywhere. Bumping the version fixes both: rc.11 does not exist in the registry, so the precheck cannot skip it.

## Verification

- Default render is `ghcr.io/donaldgifford/repo-guardian:1.11.1` with no `image.tag` override.
- `policy.orphanCleanup` renders both `"true"` and `"false"`. The kill switch is the point of this release and sprig's `default` silently swallows `false`, so the false path was checked explicitly rather than assumed.
- 103 helm-unittest cases pass.
- The pinned appVersion assertion was neutralized — reverted to `1.11.0` and confirmed the suite fails `1 failed, 102 passed` — so it binds to appVersion rather than passing regardless.

## Label

`dont-release`: `v1.11.1` already exists as a binary tag; this publishes the chart only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)