### PR TITLE
fix(checker): never restore a path an actionable rule just wrote (INV-0015 A4b)

### DIFF
--- a/internal/checker/convergence_test.go
+++ b/internal/checker/convergence_test.go
@@ -735,10 +735,11 @@ func writeCollisionPolicy() *policy.PolicyConfig {
 //
 // syncActionableFiles commits .github/CODEOWNERS for needs_docs, then
 // restoreInverseOrphans considers the same path for the satisfied
-// needs_codeowners. Real GitHub lags that write by ~120ms, so the branch
-// probe reports the path missing and the restore overwrites the rule's
-// fresh output with default-branch content — or fails outright with the
-// INV-0003 422 "sha wasn't supplied".
+// needs_codeowners. Real GitHub lags that write — 116ms on a user repo,
+// 1.301s on an org repo (A7) — so the branch probe reports the path
+// missing and the restore overwrites the rule's fresh output with
+// default-branch content, or fails outright with the INV-0003 422 "sha
+// wasn't supplied".
 //
 // staleBranchReads is what gives this test teeth: without it the fake
 // reflects the write instantly, the probe correctly reports the path

--- a/internal/checker/convergence_test.go
+++ b/internal/checker/convergence_test.go
@@ -697,3 +697,75 @@ func TestConvergence_RepairScopedToRuleTarget(t *testing.T) {
 			s.client.createdFiles)
 	}
 }
+
+// writeCollisionPolicy pairs an actionable add rule whose Target is a path
+// a second, satisfied rule would restore.
+//
+// The asymmetry that makes this reachable is the one behind INV-0014: a rule
+// is satisfied by ANY of its Paths but writes to its single Target. So
+// needs_docs is actionable (docs/README.md is missing) yet commits to
+// .github/CODEOWNERS, while needs_codeowners is satisfied by that same path
+// existing on the default branch and is therefore a restore candidate.
+func writeCollisionPolicy() *policy.PolicyConfig {
+	return &policy.PolicyConfig{
+		Guardian: policy.BuiltinDefaults().Guardian,
+		FileRules: []policy.FileRuleConfig{
+			{
+				Type:     "file",
+				Name:     "needs_docs",
+				Check:    string(policy.CheckExists),
+				Paths:    []string{"docs/README.md"},
+				Target:   ".github/CODEOWNERS",
+				Template: "codeowners",
+			},
+			{
+				Type:     "file",
+				Name:     "needs_codeowners",
+				Check:    string(policy.CheckExists),
+				Paths:    []string{".github/CODEOWNERS"},
+				Target:   ".github/CODEOWNERS",
+				Template: "codeowners",
+			},
+		},
+	}
+}
+
+// TestConvergence_RestoreSkipsPathAnActionableRuleJustWrote pins the
+// INV-0015 A4b fix.
+//
+// syncActionableFiles commits .github/CODEOWNERS for needs_docs, then
+// restoreInverseOrphans considers the same path for the satisfied
+// needs_codeowners. Real GitHub lags that write by ~120ms, so the branch
+// probe reports the path missing and the restore overwrites the rule's
+// fresh output with default-branch content — or fails outright with the
+// INV-0003 422 "sha wasn't supplied".
+//
+// staleBranchReads is what gives this test teeth: without it the fake
+// reflects the write instantly, the probe correctly reports the path
+// present, and the test passes whether or not the exclusion exists.
+func TestConvergence_RestoreSkipsPathAnActionableRuleJustWrote(t *testing.T) {
+	s := newStagedConvergenceWithPolicy(t, writeCollisionPolicy())
+
+	s.satisfyOnMain(".github/CODEOWNERS") // satisfies needs_codeowners
+	s.deletedFromBranch(".github/CODEOWNERS")
+	s.client.fileContents[s.org+"/"+s.repo+"/.github/CODEOWNERS"] = "* @team"
+	s.openOurPR(4)
+
+	s.client.staleBranchReads = true
+
+	s.sweep()
+
+	var writes int
+
+	for _, path := range s.client.createdFiles {
+		if path == ".github/CODEOWNERS" {
+			writes++
+		}
+	}
+
+	if writes != 1 {
+		t.Errorf("writes to .github/CODEOWNERS = %d, want 1 (needs_docs owns it); "+
+			"a restore raced its sibling and would clobber the rule output or 422. createdFiles=%v",
+			writes, s.client.createdFiles)
+	}
+}

--- a/internal/checker/drift.go
+++ b/internal/checker/drift.go
@@ -240,12 +240,19 @@ func restoreInverseOrphans(
 	// Writes: syncActionableFiles already committed the path earlier in
 	// this same reconcile. Restoring would overwrite fresh rule output
 	// with default-branch content. INV-0015 A4b showed it can also fail
-	// outright — the contents API lags writes by ~120ms, so the branch
-	// probe in restoreRulePaths can report a path missing that was just
-	// created, sending CreateOrUpdateFile down its create path against a
-	// file that exists and back into the INV-0003 422. Excluding the path
-	// is the correct fix rather than retrying the write, because a
-	// successful retry would silently clobber the rule's own output.
+	// outright — the contents API is read-after-write EVENTUALLY
+	// consistent, so the branch probe in restoreRulePaths can report a
+	// path missing that was just created, sending CreateOrUpdateFile down
+	// its create path against a file that exists and back into the
+	// INV-0003 422.
+	//
+	// Do not "fix" this by waiting out the window. A7 measured the lag at
+	// 116ms on a user repo and 1.301s on an org repo — variable and
+	// unbounded from our side, so no sleep is long enough to be correct.
+	// Nor by retrying the write: a retry that succeeded would silently
+	// clobber the rule's own output, turning a loud 422 into quiet
+	// corruption. Excluding the path is the only fix that is right
+	// regardless of timing.
 	claimed := make(map[string]struct{})
 	for _, path := range plannedDeletions(actionable) {
 		claimed[path] = struct{}{}

--- a/internal/checker/drift.go
+++ b/internal/checker/drift.go
@@ -227,15 +227,32 @@ func restoreInverseOrphans(
 		actionableSet[actionable[i].Name] = struct{}{}
 	}
 
-	// Paths an actionable absent rule intends to delete on this very sweep.
+	// Paths an actionable rule is already managing on this very sweep.
+	// Restoration must not touch them, for two different reasons.
+	//
+	// Deletions: an actionable absent rule intends to remove the path.
 	// Without this exclusion a non-actionable add rule and an actionable
 	// absent rule covering the same path would fight: one restores, the
 	// other deletes, on every sweep forever. The deletion wins — an
 	// actionable rule is a live instruction, whereas restoration only
 	// repairs a state nothing is asking for any more.
-	deleting := make(map[string]struct{})
+	//
+	// Writes: syncActionableFiles already committed the path earlier in
+	// this same reconcile. Restoring would overwrite fresh rule output
+	// with default-branch content. INV-0015 A4b showed it can also fail
+	// outright — the contents API lags writes by ~120ms, so the branch
+	// probe in restoreRulePaths can report a path missing that was just
+	// created, sending CreateOrUpdateFile down its create path against a
+	// file that exists and back into the INV-0003 422. Excluding the path
+	// is the correct fix rather than retrying the write, because a
+	// successful retry would silently clobber the rule's own output.
+	claimed := make(map[string]struct{})
 	for _, path := range plannedDeletions(actionable) {
-		deleting[path] = struct{}{}
+		claimed[path] = struct{}{}
+	}
+
+	for _, path := range plannedWrites(actionable) {
+		claimed[path] = struct{}{}
 	}
 
 	var restored []string
@@ -251,7 +268,7 @@ func restoreInverseOrphans(
 			continue
 		}
 
-		if restoreRulePaths(ctx, log, client, r, restorablePaths(r), deleting, owner, repo) {
+		if restoreRulePaths(ctx, log, client, r, restorablePaths(r), claimed, owner, repo) {
 			restored = append(restored, r.Name)
 		}
 	}
@@ -277,9 +294,9 @@ func restorablePaths(r *policy.FileRuleConfig) []string {
 
 // restoreRulePaths restores each of the given paths of a
 // no-longer-actionable rule that is present on the default branch but
-// missing from the reconcile branch. Paths in `deleting` are skipped:
-// another rule is actively removing them on this sweep. Returns true if at
-// least one path was restored. Every API error is fail-safe: the path is
+// missing from the reconcile branch. Paths in `claimed` are skipped:
+// another rule is actively writing or removing them on this sweep.
+// Returns true if at least one path was restored. Every API error is fail-safe: the path is
 // left untouched and retried next sweep.
 func restoreRulePaths(
 	ctx context.Context,
@@ -287,13 +304,13 @@ func restoreRulePaths(
 	client ghclient.Client,
 	r *policy.FileRuleConfig,
 	paths []string,
-	deleting map[string]struct{},
+	claimed map[string]struct{},
 	owner, repo string,
 ) bool {
 	var restoredAny bool
 
 	for _, path := range paths {
-		if _, beingDeleted := deleting[path]; beingDeleted {
+		if _, byAnotherRule := claimed[path]; byAnotherRule {
 			continue
 		}
 

--- a/internal/checker/engine_policy.go
+++ b/internal/checker/engine_policy.go
@@ -553,9 +553,6 @@ func policyRuleNames(rr []policy.FileRuleConfig) []string {
 	return names
 }
 
-// plannedDeletions lists the forbidden paths every actionable absent rule
-// would delete, so the dry-run log is reviewable before the engine's first
-// destructive remediation actually runs (IMPL-0019 Phase 2 task 2.2).
 // plannedWrites returns the paths syncActionableFiles commits on this
 // sweep: the Target of every actionable rule that is not in absent mode.
 // Mirror of plannedDeletions.
@@ -571,6 +568,9 @@ func plannedWrites(actionable []policy.FileRuleConfig) []string {
 	return paths
 }
 
+// plannedDeletions lists the forbidden paths every actionable absent rule
+// would delete, so the dry-run log is reviewable before the engine's first
+// destructive remediation actually runs (IMPL-0019 Phase 2 task 2.2).
 func plannedDeletions(actionable []policy.FileRuleConfig) []string {
 	var paths []string
 

--- a/internal/checker/engine_policy.go
+++ b/internal/checker/engine_policy.go
@@ -556,6 +556,21 @@ func policyRuleNames(rr []policy.FileRuleConfig) []string {
 // plannedDeletions lists the forbidden paths every actionable absent rule
 // would delete, so the dry-run log is reviewable before the engine's first
 // destructive remediation actually runs (IMPL-0019 Phase 2 task 2.2).
+// plannedWrites returns the paths syncActionableFiles commits on this
+// sweep: the Target of every actionable rule that is not in absent mode.
+// Mirror of plannedDeletions.
+func plannedWrites(actionable []policy.FileRuleConfig) []string {
+	var paths []string
+
+	for i := range actionable {
+		if actionable[i].CheckMode() != policy.CheckAbsent && actionable[i].Target != "" {
+			paths = append(paths, actionable[i].Target)
+		}
+	}
+
+	return paths
+}
+
 func plannedDeletions(actionable []policy.FileRuleConfig) []string {
 	var paths []string
 

--- a/internal/checker/engine_test.go
+++ b/internal/checker/engine_test.go
@@ -23,9 +23,19 @@ type mockClient struct {
 	// new API needs fake behavior, rather than a silent zero value.
 	mocks.MockClient
 
-	contents         map[string]bool                            // "owner/repo/path" -> exists
-	branchContents   map[string]string                          // "owner/repo/branch/path" -> sha (IMPL-0013 P3 orphan discovery)
-	branchDeleted    map[string]bool                            // "owner/repo/branch/path" -> tombstone (INV-0014)
+	contents       map[string]bool   // "owner/repo/path" -> exists
+	branchContents map[string]string // "owner/repo/branch/path" -> sha (IMPL-0013 P3 orphan discovery)
+	branchDeleted  map[string]bool   // "owner/repo/branch/path" -> tombstone (INV-0014)
+
+	// staleBranchReads makes a write invisible to GetContentsOnBranch for
+	// the rest of the sweep, modelling the ~120ms contents-API lag that
+	// INV-0015 A7 measured against real GitHub. Opt-in, because every
+	// other test needs a write to be immediately readable (IMPL-0019 task
+	// 2.8) — which is true, just not instantly. Without this the fake is
+	// read-after-write consistent and cannot disagree with us about
+	// same-sweep write-then-read ordering, which is the exact circularity
+	// INV-0014 was caused by.
+	staleBranchReads bool
 	fileContents     map[string]string                          // "owner/repo/path" -> content
 	customProperties map[string][]*ghclient.CustomPropertyValue // "owner/repo" -> values
 	setProperties    []*ghclient.CustomPropertyValue            // records what was set
@@ -167,12 +177,16 @@ func (m *mockClient) CreateOrUpdateFile(_ context.Context, owner, repo, branch, 
 
 	// Reflect the write on the branch so a later GetContentsOnBranch sees
 	// it — required for the inverse-orphan restoration path to be testable
-	// (IMPL-0019 task 2.8 mock-fidelity contract).
-	if m.branchContents != nil {
-		m.branchContents[owner+"/"+repo+"/"+branch+"/"+path] = "sha-" + path
-	}
+	// (IMPL-0019 task 2.8 mock-fidelity contract). Unless the test asked
+	// for A7 semantics, in which case the write lands but stays unreadable
+	// for the rest of the sweep.
+	if !m.staleBranchReads {
+		if m.branchContents != nil {
+			m.branchContents[owner+"/"+repo+"/"+branch+"/"+path] = "sha-" + path
+		}
 
-	delete(m.branchDeleted, owner+"/"+repo+"/"+branch+"/"+path)
+		delete(m.branchDeleted, owner+"/"+repo+"/"+branch+"/"+path)
+	}
 
 	m.createdFiles = append(m.createdFiles, path)
 

--- a/internal/checker/engine_test.go
+++ b/internal/checker/engine_test.go
@@ -28,8 +28,10 @@ type mockClient struct {
 	branchDeleted  map[string]bool   // "owner/repo/branch/path" -> tombstone (INV-0014)
 
 	// staleBranchReads makes a write invisible to GetContentsOnBranch for
-	// the rest of the sweep, modelling the ~120ms contents-API lag that
-	// INV-0015 A7 measured against real GitHub. Opt-in, because every
+	// the rest of the sweep, modelling the contents-API lag INV-0015 A7
+	// measured against real GitHub (116ms user repo, 1.301s org repo —
+	// variable and unbounded, which is why the fix excludes the path
+	// rather than waiting). Opt-in, because every
 	// other test needs a write to be immediately readable (IMPL-0019 task
 	// 2.8) — which is true, just not instantly. Without this the fake is
 	// read-after-write consistent and cannot disagree with us about


### PR DESCRIPTION
Found by the INV-0015 contract suite running against real GitHub.

`restoreInverseOrphans` excluded paths another rule was **deleting** this sweep, but not paths another rule had just **written**. `syncActionableFiles` commits a rule's `Target` (`engine_pr.go:167`), then `restoreInverseOrphans` probes that same path on the branch a few calls later (`drift.go:311`).

INV-0015 A7 measured the contents API lagging writes against real GitHub — **116ms** on a user repo, **1.301s** on an org repo — so that probe can report a path missing when it was just created. The restore then either:

- overwrites the rule's fresh output with default-branch content, or
- fails with `422 ... "sha" wasn't supplied` — the INV-0003 error, reachable again because `CreateOrUpdateFile` picks create-vs-update from a GET that read pre-write state.

Excluding the path is the right fix rather than retrying the write on 422. **A successful retry would silently clobber the rule's own output**, converting a loud failure into quiet corruption.

## Reachability

Needs two rules naming one path with different actionability, which requires a hand-written policy — the four built-in rules have distinct targets. The asymmetry that makes it possible is the same one behind INV-0014: a rule is satisfied by **any** of its `Paths` but writes to its single `Target`.

Fixed anyway, because one of the two failure modes is silent.

## The fake could not have caught this

`mockClient.CreateOrUpdateFile` reflected writes instantly, so the branch probe always correctly reported the path present and the regression test passed with or without the exclusion. That is the same circularity that let INV-0014 through: a fake we wrote cannot disagree with a belief we hold.

The fake gains an opt-in `staleBranchReads` mode that makes a write unreadable for the rest of the sweep, modelling A7. Existing tests are untouched — they need the write visible (IMPL-0019 task 2.8), which is true, just not instantly.

## Verification

Neutralized the exclusion and confirmed the test fails for the right reason:

```
writes to .github/CODEOWNERS = 2, want 1 ... createdFiles=[.github/CODEOWNERS .github/CODEOWNERS]
```

Two writes is the clobber. Restored → 1. Full `go test -race ./...` green, `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Update (post-review)

Two comment-only corrections pushed in `9bd4e2e`; the fix and its test are unchanged.

- **Displaced doc comment.** `plannedWrites` was inserted above `plannedDeletions` using its signature as the anchor, landing it between `plannedDeletions` and its doc block — so `plannedWrites` carried `plannedDeletions`' documentation and `plannedDeletions` had none. Both are unexported, so revive had nothing to say. Repaired.
- **Retracted `~120ms` figure.** The original body and three code comments cited ~120ms. INV-0015 retracts that as a sample of one repository; the org-repo measurement was **1.301s**, and the real property is that the lag is *variable and unbounded from our side*. That distinction is the whole argument for this change — `~120ms` invites the conclusion that a short sleep or retry would cover the window, which is exactly what this fix rejects. Comments now carry both measurements and state why waiting is not an option.

Re-verified after the edits: merges cleanly onto current `main` (which has moved by #177 and #178), builds, `make lint` clean, `./internal/checker/` passes, and the regression test still fails when the `plannedWrites` exclusion is neutralized (`writes = 2, want 1`).
