### PR TITLE
feat: park repositories out of the stale sweep (INV-0015)

### DIFF
--- a/charts/repo-guardian/templates/prometheusrule.yaml
+++ b/charts/repo-guardian/templates/prometheusrule.yaml
@@ -89,13 +89,13 @@ spec:
         {{- $alert := default dict $a.RepoAccessDenied -}}
         {{- if ne (default true (get $alert "enabled")) false }}
         - alert: RepoGuardianRepoAccessDenied
-          expr: increase(repo_guardian_repo_access_denied_total[1h]) > {{ default 0 (get $alert "threshold") }}
+          expr: increase(repo_guardian_repos_parked_total{reason="access_denied"}[1h]) > {{ default 0 (get $alert "threshold") }}
           for: {{ default "15m" (get $alert "for") | quote }}
           labels:
             severity: {{ default "warning" (get $alert "severity") | quote }}
           annotations:
             summary: "repo-guardian cannot read repositories it was asked to check"
-            description: "repositories were parked because the installation cannot read them — the App was uninstalled from them, lost a permission, or they were deleted. Parked repos are skipped by the sweep and rejoin automatically when discovery sees them again."
+            description: "repositories were parked because the installation cannot read them — the App was uninstalled from them, lost a permission, or they were deleted. Only reason=access_denied is alerted; archived and fork parking is routine. Parked repos are skipped by the sweep and rejoin automatically when discovery sees them again."
         {{- end }}
         {{- /* StaleOpenPRs — IMPL-0013 Phase 1 drift visibility */ -}}
         {{- $alert := default dict $a.StaleOpenPRs -}}

--- a/charts/repo-guardian/templates/prometheusrule.yaml
+++ b/charts/repo-guardian/templates/prometheusrule.yaml
@@ -85,6 +85,18 @@ spec:
             summary: "repo-guardian GitHub rate-limit nearly exhausted"
             description: "an installation has fewer than the configured threshold rate-limit budget remaining; the reserve gate will start blocking sweeps."
         {{- end }}
+        {{- /* RepoAccessDenied — INV-0015 circuit breaker */ -}}
+        {{- $alert := default dict $a.RepoAccessDenied -}}
+        {{- if ne (default true (get $alert "enabled")) false }}
+        - alert: RepoGuardianRepoAccessDenied
+          expr: increase(repo_guardian_repo_access_denied_total[1h]) > {{ default 0 (get $alert "threshold") }}
+          for: {{ default "15m" (get $alert "for") | quote }}
+          labels:
+            severity: {{ default "warning" (get $alert "severity") | quote }}
+          annotations:
+            summary: "repo-guardian cannot read repositories it was asked to check"
+            description: "repositories were parked because the installation cannot read them — the App was uninstalled from them, lost a permission, or they were deleted. Parked repos are skipped by the sweep and rejoin automatically when discovery sees them again."
+        {{- end }}
         {{- /* StaleOpenPRs — IMPL-0013 Phase 1 drift visibility */ -}}
         {{- $alert := default dict $a.StaleOpenPRs -}}
         {{- if ne (default true (get $alert "enabled")) false }}

--- a/charts/repo-guardian/tests/prometheusrule_test.yaml
+++ b/charts/repo-guardian/tests/prometheusrule_test.yaml
@@ -202,3 +202,35 @@ tests:
           path: spec.groups[0].rules
           content:
             alert: RepoGuardianJobsExhausted
+
+  # INV-0015: parking has three reasons (access_denied, archived, fork) but
+  # only one is a problem. Archived and fork parks are routine bookkeeping and
+  # would page on every normal onboarding sweep, so the reason selector is
+  # load-bearing — this locks the expression, not just the alert name.
+  - it: should render RepoAccessDenied filtered to reason=access_denied
+    set:
+      prometheusRule:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.groups[0].rules
+          content:
+            alert: RepoGuardianRepoAccessDenied
+            expr: increase(repo_guardian_repos_parked_total{reason="access_denied"}[1h]) > 0
+            for: 15m
+            labels:
+              severity: warning
+          any: true
+
+  - it: should allow RepoAccessDenied to be disabled
+    set:
+      prometheusRule:
+        enabled: true
+        alerts:
+          RepoAccessDenied:
+            enabled: false
+    asserts:
+      - notContains:
+          path: spec.groups[0].rules
+          content:
+            alert: RepoGuardianRepoAccessDenied

--- a/docs/operations/migrations.md
+++ b/docs/operations/migrations.md
@@ -27,6 +27,7 @@ CREATE TABLE repo_state (
     last_check_status TEXT    NOT NULL DEFAULT 'pending',
     last_error        TEXT,
     policy_version    TEXT    NOT NULL DEFAULT '',
+    active            BOOLEAN NOT NULL DEFAULT true,
     PRIMARY KEY (installation_id, owner, repo)
 );
 
@@ -35,6 +36,10 @@ CREATE INDEX idx_repo_state_freshness
 
 CREATE INDEX idx_repo_state_policy_version
     ON repo_state(policy_version);
+
+CREATE INDEX idx_repo_state_active_freshness
+    ON repo_state(last_checked_at NULLS FIRST)
+    WHERE active;
 ```
 
 The two indexes drive the stale-sweep query in
@@ -43,15 +48,60 @@ The two indexes drive the stale-sweep query in
 ```sql
 SELECT ...
 FROM repo_state
-WHERE last_checked_at IS NULL
-   OR last_checked_at < $1
-   OR policy_version <> $2
+WHERE active
+  AND (last_checked_at IS NULL
+       OR last_checked_at < $1
+       OR policy_version <> $2)
 ORDER BY last_checked_at NULLS FIRST
 LIMIT $3
 ```
 
 Both `last_checked_at` and `policy_version` are indexed so the OR-of-three
 filter doesn't degrade to a sequential scan even at 100k+ rows.
+
+Note the parentheses. `AND` binds tighter than `OR`, so writing
+`... OR policy_version <> $2 AND active` would gate only the last arm and
+a parked repository would return to the sweep the moment the policy hash
+changed. `TestPostgresStore_DeactivateExcludesFromSweep` covers exactly
+this.
+
+### `active` — the access-denied circuit breaker (INV-0015)
+
+`active` is `true` for every row unless the worker parked it. A
+repository is parked when a check fails with 403/404, meaning the
+installation cannot read it: the App was uninstalled from that
+repository, lost a permission, or the repository was deleted.
+
+Before this column, such a repository failed every attempt, exhausted
+`MAX_JOB_ATTEMPTS`, and was then handed straight back by the next stale
+sweep — burning the full attempt budget every cycle, forever, with
+failures indistinguishable from a transient 500.
+
+Parked rows are **kept, never deleted**, so the history stays queryable:
+
+```sql
+SELECT installation_id, owner, repo, last_error
+FROM repo_state
+WHERE NOT active
+ORDER BY owner, repo;
+```
+
+**Only discovery can un-park a row.** Discovery is the one component that
+observes the installation's real repository set, so a repository whose
+access is restored rejoins the sweep on the next discovery pass with no
+operator action. Reactivation deliberately does not touch
+`last_checked_at` or `policy_version`; overwriting those would reset the
+freshness gate and re-check the whole fleet on every discovery pass.
+
+There is intentionally no way to reactivate from the check path, and none
+from SQL that we document — if you set `active = true` by hand on a
+repository the App still cannot read, it will simply be parked again on
+its next check.
+
+Watch `repo_guardian_repo_access_denied_total` and the
+`RepoGuardianRepoAccessDenied` alert. A steady trickle is normal in a
+large org (repositories get deleted); a step change means the App lost
+access to something it used to have.
 
 ## Out-of-band migration runs
 

--- a/docs/operations/migrations.md
+++ b/docs/operations/migrations.md
@@ -1,7 +1,7 @@
 # Postgres schema operations
 
 This is the operator-facing guide for managing the `repo_state` table
-under `STORE_BACKEND=postgres`. The schema is small (one table, two
+under `STORE_BACKEND=postgres`. The schema is small (one table, three
 indexes) and migrations apply at binary startup; most operators won't
 touch this page in normal operation.
 
@@ -42,7 +42,7 @@ CREATE INDEX idx_repo_state_active_freshness
     WHERE active;
 ```
 
-The two indexes drive the stale-sweep query in
+The indexes drive the stale-sweep query in
 `internal/store/postgres/postgres.go.StaleRepos`:
 
 ```sql
@@ -57,7 +57,10 @@ LIMIT $3
 ```
 
 Both `last_checked_at` and `policy_version` are indexed so the OR-of-three
-filter doesn't degrade to a sequential scan even at 100k+ rows.
+filter doesn't degrade to a sequential scan even at 100k+ rows. The
+partial index carries the `WHERE active` predicate, so parked rows are
+absent from it entirely rather than scanned and discarded — the sweep
+does not get slower as an org accumulates archived repositories.
 
 Note the parentheses. `AND` binds tighter than `OR`, so writing
 `... OR policy_version <> $2 AND active` would gate only the last arm and
@@ -65,26 +68,42 @@ a parked repository would return to the sweep the moment the policy hash
 changed. `TestPostgresStore_DeactivateExcludesFromSweep` covers exactly
 this.
 
-### `active` — the access-denied circuit breaker (INV-0015)
+### `active` — the parking column (INV-0015)
 
-`active` is `true` for every row unless the worker parked it. A
-repository is parked when a check fails with 403/404, meaning the
-installation cannot read it: the App was uninstalled from that
-repository, lost a permission, or the repository was deleted.
+`active` is `true` for every row unless the worker parked it. Parking
+means "stop handing this repository to the sweep," and there are three
+reasons, all carried on `repo_guardian_repos_parked_total{reason}`:
 
-Before this column, such a repository failed every attempt, exhausted
-`MAX_JOB_ATTEMPTS`, and was then handed straight back by the next stale
-sweep — burning the full attempt budget every cycle, forever, with
-failures indistinguishable from a transient 500.
+| `reason` | Trigger | Normal? |
+|---|---|---|
+| `access_denied` | Check failed with 403/404 — the App was uninstalled from that repository, lost a permission, or the repository was deleted | A trickle is expected; a step change is not |
+| `archived` | `skip_archived` is on and the repository is archived | Yes |
+| `fork` | `skip_forks` is on and the repository is a fork | Yes |
+
+Before this column each of the three burned budget indefinitely, in two
+different ways. An unreadable repository failed every attempt, exhausted
+`MAX_JOB_ATTEMPTS`, and was handed straight back by the next stale sweep
+— the full attempt budget every cycle, forever, with failures
+indistinguishable from a transient 500. An archived or forked repository
+was cheaper but just as permanent: enqueue, installation client,
+`GetRepository`, skip, write back success, and round again every
+freshness cycle for as long as the repository exists.
 
 Parked rows are **kept, never deleted**, so the history stays queryable:
 
 ```sql
-SELECT installation_id, owner, repo, last_error
+SELECT installation_id, owner, repo, last_check_status, last_error
 FROM repo_state
 WHERE NOT active
 ORDER BY owner, repo;
 ```
+
+`last_check_status` distinguishes the two kinds: access-denied parks
+record `'error'` with the underlying API failure in `last_error`, while
+archived and fork parks record `'skipped'`, because nothing went wrong.
+Both put something in `last_error` — there is no separate reason column,
+and the reason is what makes the query above answer *why* a row is
+parked, so a skip stores its bare reason (`archived`, `fork`) there.
 
 **Only discovery can un-park a row.** Discovery is the one component that
 observes the installation's real repository set, so a repository whose
@@ -98,10 +117,32 @@ from SQL that we document — if you set `active = true` by hand on a
 repository the App still cannot read, it will simply be parked again on
 its next check.
 
-Watch `repo_guardian_repo_access_denied_total` and the
-`RepoGuardianRepoAccessDenied` alert. A steady trickle is normal in a
-large org (repositories get deleted); a step change means the App lost
-access to something it used to have.
+Un-archiving a repository, or the App regaining access to one, therefore
+needs no operator action at all: discovery stops filtering it, upserts
+it, and the row goes live again.
+
+#### Why only these three reasons park
+
+Parking is stable only when the check path's skip conditions are a
+**subset** of discovery's filters. Discovery filters archived and fork
+repositories, so a repository parked for either reason is not offered
+back — it settles.
+
+An *empty* repository (no default branch yet) is skipped by the engine
+too, but discovery does **not** filter it. Parking it would have
+discovery re-upsert the row on its very next pass, flipping `active`
+back to `true`, and the two would churn against each other at the
+discovery interval forever. So empty repositories are skipped the old
+way, with an ordinary success write-back, and freshness governs the next
+check. `TestPool_EmptyRepo_IsSkippedButNotParked` pins this boundary; the
+invariant is restated on `checker.skipReason`, which is where a fourth
+skip reason would be added.
+
+Watch `repo_guardian_repos_parked_total`. Only
+`reason="access_denied"` is alerted (`RepoGuardianRepoAccessDenied`) —
+archived and fork parks are routine bookkeeping. A steady access-denied
+trickle is normal in a large org (repositories get deleted); a step
+change means the App lost access to something it used to have.
 
 ## Out-of-band migration runs
 

--- a/internal/checker/engine.go
+++ b/internal/checker/engine.go
@@ -104,8 +104,16 @@ func (e *Engine) CheckRepo(ctx context.Context, client ghclient.Client, owner, r
 
 	// Authoritative skip checks — the scheduler pre-filters as an
 	// optimization, but the engine is the single source of truth.
-	if skip, reason := e.shouldSkip(repoInfo); skip {
-		log.Info(reason)
+	if reason, durable := e.skipReason(repoInfo); reason != "" {
+		log.Info("skipping repository", "reason", reason, "durable", durable)
+
+		if durable {
+			// Surfaced as an error so the worker can park the row. The
+			// repo is otherwise re-enqueued and re-fetched every
+			// freshness cycle for as long as it exists (INV-0015).
+			return &SkippedError{Reason: reason}
+		}
+
 		return nil
 	}
 
@@ -123,23 +131,6 @@ func (e *Engine) CheckRepo(ctx context.Context, client ghclient.Client, owner, r
 	}
 
 	return e.checkRepoWithPolicy(ctx, log, client, owner, repo, repoInfo.DefaultRef, openPRs)
-}
-
-// shouldSkip returns true and a reason if the repository should be skipped.
-func (e *Engine) shouldSkip(repo *ghclient.Repository) (bool, string) {
-	if e.skipArchived && repo.Archived {
-		return true, "skipping archived repository"
-	}
-
-	if e.skipForks && repo.Fork {
-		return true, "skipping forked repository"
-	}
-
-	if !repo.HasBranch || repo.DefaultRef == "" {
-		return true, "skipping empty repository with no default branch"
-	}
-
-	return false, ""
 }
 
 // findOurPR returns the open repo-guardian PR (head ref ==

--- a/internal/checker/engine_test.go
+++ b/internal/checker/engine_test.go
@@ -584,60 +584,70 @@ func TestCheckRepo_MissingFiles_ThirdPartyPR(t *testing.T) {
 	}
 }
 
-func TestCheckRepo_Archived(t *testing.T) {
+// TestCheckRepo_Skips covers every repository state the engine declines to
+// act on, and how it reports that decision.
+//
+// Two of the three are DURABLE: archived and fork are properties the
+// repository will keep until somebody changes them, and discovery filters
+// both, so the worker parks them out of the sweep. Empty is not durable —
+// discovery does not filter empty repositories, so parking one would have
+// discovery re-activate it every pass. It reports a plain nil and stays in
+// the rotation, which is also correct on the merits: an empty repository
+// stops being empty on its first push.
+//
+// The wantSkip == "" case therefore isn't a filler row; it's the boundary.
+func TestCheckRepo_Skips(t *testing.T) {
 	t.Parallel()
 
-	engine := testEngine(false)
-	client := newMockClient()
-	client.repo = &ghclient.Repository{
-		Owner: "org", Name: "repo", Archived: true, HasBranch: true, DefaultRef: "main",
+	tests := []struct {
+		name     string
+		repo     ghclient.Repository
+		wantSkip string // "" means skipped silently, no parking
+	}{
+		{
+			name:     "archived",
+			repo:     ghclient.Repository{Archived: true, HasBranch: true, DefaultRef: "main"},
+			wantSkip: SkipArchived,
+		},
+		{
+			name:     "fork",
+			repo:     ghclient.Repository{Fork: true, HasBranch: true, DefaultRef: "main"},
+			wantSkip: SkipFork,
+		},
+		{
+			name: "empty repo is skipped but not durable",
+			repo: ghclient.Repository{HasBranch: false, DefaultRef: ""},
+		},
 	}
 
-	err := engine.CheckRepo(context.Background(), client, "org", "repo")
-	if err != nil {
-		t.Fatalf("CheckRepo: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	if client.createdPR != nil {
-		t.Error("should not create PR for archived repo")
-	}
-}
+			engine := testEngine(false)
+			client := newMockClient()
+			client.repo = &tt.repo
+			client.repo.Owner, client.repo.Name = "org", "repo"
 
-func TestCheckRepo_Fork(t *testing.T) {
-	t.Parallel()
+			err := engine.CheckRepo(context.Background(), client, "org", "repo")
 
-	engine := testEngine(false)
-	client := newMockClient()
-	client.repo = &ghclient.Repository{
-		Owner: "org", Name: "repo", Fork: true, HasBranch: true, DefaultRef: "main",
-	}
+			skip, durable := AsSkipped(err)
 
-	err := engine.CheckRepo(context.Background(), client, "org", "repo")
-	if err != nil {
-		t.Fatalf("CheckRepo: %v", err)
-	}
+			switch {
+			case tt.wantSkip == "":
+				if err != nil {
+					t.Fatalf("CheckRepo() = %v, want nil; a non-durable skip must not surface an error", err)
+				}
+			case !durable:
+				t.Fatalf("CheckRepo() = %v, want *SkippedError{Reason: %q}", err, tt.wantSkip)
+			case skip.Reason != tt.wantSkip:
+				t.Errorf("skip reason = %q, want %q", skip.Reason, tt.wantSkip)
+			}
 
-	if client.createdPR != nil {
-		t.Error("should not create PR for forked repo")
-	}
-}
-
-func TestCheckRepo_EmptyRepo(t *testing.T) {
-	t.Parallel()
-
-	engine := testEngine(false)
-	client := newMockClient()
-	client.repo = &ghclient.Repository{
-		Owner: "org", Name: "repo", HasBranch: false, DefaultRef: "",
-	}
-
-	err := engine.CheckRepo(context.Background(), client, "org", "repo")
-	if err != nil {
-		t.Fatalf("CheckRepo: %v", err)
-	}
-
-	if client.createdPR != nil {
-		t.Error("should not create PR for empty repo")
+			if client.createdPR != nil {
+				t.Errorf("created PR %v; a skipped repository must not be touched", client.createdPR)
+			}
+		})
 	}
 }
 

--- a/internal/checker/skip.go
+++ b/internal/checker/skip.go
@@ -1,0 +1,76 @@
+package checker
+
+import (
+	"errors"
+	"fmt"
+
+	ghclient "github.com/donaldgifford/repo-guardian/internal/github"
+)
+
+// Skip reasons. Durable ones park the repo_state row; transient ones do
+// not. See SkippedError.
+const (
+	SkipArchived = "archived"
+	SkipFork     = "fork"
+	SkipEmpty    = "empty"
+)
+
+// SkippedError reports that a repository was skipped before any rule was
+// evaluated. It is returned from CheckRepo only for durable conditions,
+// so that the worker can park the row instead of paying for the repo on
+// every sweep forever.
+//
+// Durable means the condition is also filtered by discovery, which is
+// what makes parking stable: discovery is the only thing that can
+// un-park a row, so parking on a condition discovery does NOT filter
+// would have the row reactivated on the next discovery pass and parked
+// again on the next sweep, churning at the discovery interval rather
+// than settling.
+//
+//	archived  discovery skips it  -> durable
+//	fork      discovery skips it  -> durable
+//	empty     discovery keeps it  -> NOT durable
+//
+// The two durable reasons are exact rather than coincidental: this and
+// Discoverer.discoverInstallation both read the same
+// policyCfg.Guardian.SkipArchived / SkipForks, so with the flag off
+// neither skips and nothing is parked, and with it on both agree.
+//
+// If a skip condition is ever added here, check discoverInstallation
+// before marking it durable.
+type SkippedError struct {
+	Reason string
+}
+
+func (e *SkippedError) Error() string {
+	return fmt.Sprintf("repository skipped: %s", e.Reason)
+}
+
+// AsSkipped reports whether err is a durable skip, and which one.
+func AsSkipped(err error) (*SkippedError, bool) {
+	var skip *SkippedError
+	if errors.As(err, &skip) {
+		return skip, true
+	}
+
+	return nil, false
+}
+
+// skipReason returns why the repository should be skipped, or nil if it
+// should be checked. A durable reason is returned as an error by
+// CheckRepo; a transient one is only logged.
+func (e *Engine) skipReason(repo *ghclient.Repository) (reason string, durable bool) {
+	switch {
+	case e.skipArchived && repo.Archived:
+		return SkipArchived, true
+	case e.skipForks && repo.Fork:
+		return SkipFork, true
+	case !repo.HasBranch || repo.DefaultRef == "":
+		// Transient by nature: the first push gives the repo a default
+		// branch, and the push webhook enqueues it directly. Parking it
+		// would fight discovery, which does not filter empty repos.
+		return SkipEmpty, false
+	default:
+		return "", false
+	}
+}

--- a/internal/checker/sweep_test.go
+++ b/internal/checker/sweep_test.go
@@ -312,3 +312,5 @@ func TestStaleSweeper_PolicyVersionMismatchEnqueuesAll(t *testing.T) {
 		t.Fatalf("trigger: got %q want %q", jobs[0].Trigger, queue.TriggerScheduler)
 	}
 }
+
+func (*fakeStore) Deactivate(context.Context, int64, string, string) error { return nil }

--- a/internal/github/access.go
+++ b/internal/github/access.go
@@ -1,0 +1,43 @@
+package github
+
+import (
+	"errors"
+	"net/http"
+
+	gh "github.com/google/go-github/v68/github"
+)
+
+// IsAccessDenied reports whether err means the App cannot reach a
+// repository at all, as opposed to a transient failure worth retrying.
+//
+// GitHub answers "you may not see this" with 404 rather than 403, so a
+// repository outside the installation is indistinguishable from one that
+// does not exist — and both are equally permanent from our side. 403
+// covers the cases GitHub does name, such as an org IP allowlist.
+//
+// This is the terminal counterpart to AsThrottled: throttling means try
+// again later, access denial means do not try again until discovery says
+// otherwise. Callers MUST test AsThrottled first, because a secondary
+// rate limit also surfaces as 403 and is emphatically not permanent.
+func IsAccessDenied(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// A throttle is never an access denial, whatever its status code.
+	if thr, throttled := AsThrottled(err); throttled && thr != nil {
+		return false
+	}
+
+	var resp *gh.ErrorResponse
+	if !errors.As(err, &resp) || resp.Response == nil {
+		return false
+	}
+
+	switch resp.Response.StatusCode {
+	case http.StatusNotFound, http.StatusForbidden:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/github/access_test.go
+++ b/internal/github/access_test.go
@@ -1,0 +1,76 @@
+package github_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	gh "github.com/google/go-github/v68/github"
+
+	ghclient "github.com/donaldgifford/repo-guardian/internal/github"
+)
+
+// respErr builds the shape go-github returns for a failed API call.
+func respErr(status int) error {
+	return &gh.ErrorResponse{
+		Response: &http.Response{StatusCode: status},
+		Message:  http.StatusText(status),
+	}
+}
+
+func TestIsAccessDenied(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{
+			// GitHub answers "you may not see this" with 404, so a repo
+			// outside the installation looks exactly like a deleted one.
+			// Both are permanent from our side.
+			name: "404 not found",
+			err:  respErr(http.StatusNotFound),
+			want: true,
+		},
+		{"403 forbidden", respErr(http.StatusForbidden), true},
+		{
+			// The classifier must see through wrapping: CheckRepo returns
+			// fmt.Errorf("getting repository info: %w", err).
+			name: "wrapped 404",
+			err:  fmt.Errorf("getting repository info: %w", respErr(http.StatusNotFound)),
+			want: true,
+		},
+		{
+			// The trap this classifier exists alongside: a secondary rate
+			// limit is also a 403, and is emphatically not permanent.
+			// Treating it as access denial would park a repo for an hour
+			// of throttling.
+			name: "throttle is never access denial",
+			err:  &ghclient.ThrottledError{ResetAt: time.Now().Add(time.Hour), Remaining: 0, Limit: 5000},
+			want: false,
+		},
+		{
+			name: "wrapped throttle is never access denial",
+			err:  fmt.Errorf("check repo: %w", &ghclient.ThrottledError{ResetAt: time.Now(), Limit: 5000}),
+			want: false,
+		},
+		{"500 is transient", respErr(http.StatusInternalServerError), false},
+		{"422 is a real request error", respErr(http.StatusUnprocessableEntity), false},
+		{"non-API error", errors.New("dial tcp: connection refused"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := ghclient.IsAccessDenied(tt.err); got != tt.want {
+				t.Errorf("IsAccessDenied(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -84,6 +84,16 @@ var (
 		Help: "Errors encountered.",
 	}, []string{"operation", labelOrg})
 
+	// RepoAccessDeniedTotal counts repositories parked because the
+	// installation cannot read them. Its own series rather than a label
+	// on ErrorsTotal: this needs to be alertable on its own, and adding
+	// a label value would force every existing ErrorsTotal query to be
+	// rewritten to exclude it (INV-0015).
+	RepoAccessDeniedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "repo_guardian_repo_access_denied_total",
+		Help: "Repositories parked because the installation cannot read them.",
+	}, []string{labelOrg, "installation_id"})
+
 	// GitHubRateRemaining tracks the GitHub API rate limit remaining.
 	GitHubRateRemaining = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "repo_guardian_github_rate_remaining",

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -84,15 +84,18 @@ var (
 		Help: "Errors encountered.",
 	}, []string{"operation", labelOrg})
 
-	// RepoAccessDeniedTotal counts repositories parked because the
-	// installation cannot read them. Its own series rather than a label
-	// on ErrorsTotal: this needs to be alertable on its own, and adding
-	// a label value would force every existing ErrorsTotal query to be
-	// rewritten to exclude it (INV-0015).
-	RepoAccessDeniedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "repo_guardian_repo_access_denied_total",
-		Help: "Repositories parked because the installation cannot read them.",
-	}, []string{labelOrg, "installation_id"})
+	// ReposParkedTotal counts repositories taken out of the sweep, by
+	// reason. Its own metric rather than a label on ErrorsTotal, which is
+	// pre-existing and widely queried; carrying `reason` from birth costs
+	// nothing and keeps one series as parking reasons grow (INV-0015).
+	//
+	// reason="access_denied" is the actionable one and what the shipped
+	// alert watches. archived and fork are routine and expected to climb
+	// slowly in any long-lived org.
+	ReposParkedTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "repo_guardian_repos_parked_total",
+		Help: "Repositories parked (removed from the stale sweep), by reason.",
+	}, []string{labelOrg, "installation_id", "reason"})
 
 	// GitHubRateRemaining tracks the GitHub API rate limit remaining.
 	GitHubRateRemaining = promauto.NewGauge(prometheus.GaugeOpts{

--- a/internal/scheduler/discoverer_test.go
+++ b/internal/scheduler/discoverer_test.go
@@ -284,3 +284,5 @@ func TestDiscoverer_ContextCancelled_ReturnsErr(t *testing.T) {
 		t.Error("expected ctx.Err(), got nil")
 	}
 }
+
+func (*fakeDiscoveryStore) Deactivate(context.Context, int64, string, string) error { return nil }

--- a/internal/store/mocks/store_mock.go
+++ b/internal/store/mocks/store_mock.go
@@ -84,6 +84,75 @@ func (_c *MockStore_Close_Call) RunAndReturn(run func() error) *MockStore_Close_
 	return _c
 }
 
+// Deactivate provides a mock function for the type MockStore
+func (_mock *MockStore) Deactivate(ctx context.Context, installationID int64, owner string, repo string) error {
+	ret := _mock.Called(ctx, installationID, owner, repo)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Deactivate")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int64, string, string) error); ok {
+		r0 = returnFunc(ctx, installationID, owner, repo)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockStore_Deactivate_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Deactivate'
+type MockStore_Deactivate_Call struct {
+	*mock.Call
+}
+
+// Deactivate is a helper method to define mock.On call
+//   - ctx context.Context
+//   - installationID int64
+//   - owner string
+//   - repo string
+func (_e *MockStore_Expecter) Deactivate(ctx any, installationID any, owner any, repo any) *MockStore_Deactivate_Call {
+	return &MockStore_Deactivate_Call{Call: _e.mock.On("Deactivate", ctx, installationID, owner, repo)}
+}
+
+func (_c *MockStore_Deactivate_Call) Run(run func(ctx context.Context, installationID int64, owner string, repo string)) *MockStore_Deactivate_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 int64
+		if args[1] != nil {
+			arg1 = args[1].(int64)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		var arg3 string
+		if args[3] != nil {
+			arg3 = args[3].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+		)
+	})
+	return _c
+}
+
+func (_c *MockStore_Deactivate_Call) Return(err error) *MockStore_Deactivate_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockStore_Deactivate_Call) RunAndReturn(run func(ctx context.Context, installationID int64, owner string, repo string) error) *MockStore_Deactivate_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetRepoState provides a mock function for the type MockStore
 func (_mock *MockStore) GetRepoState(ctx context.Context, installationID int64, owner string, repo string) (*store.RepoState, error) {
 	ret := _mock.Called(ctx, installationID, owner, repo)

--- a/internal/store/postgres/migrations/0002_repo_active.down.sql
+++ b/internal/store/postgres/migrations/0002_repo_active.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_repo_state_active_freshness;
+
+ALTER TABLE repo_state
+    DROP COLUMN active;

--- a/internal/store/postgres/migrations/0002_repo_active.up.sql
+++ b/internal/store/postgres/migrations/0002_repo_active.up.sql
@@ -1,0 +1,19 @@
+-- INV-0015: a repository the App cannot read must stop being re-enqueued.
+--
+-- The check path aborts on GetRepository (engine.go), so an inaccessible
+-- repo fails every attempt, exhausts MAX_JOB_ATTEMPTS, and is then handed
+-- straight back by the next stale sweep — burning the full attempt budget
+-- per cycle, forever, against a repo that will never succeed.
+--
+-- active gates the sweep. Only discovery may set it back to true: it is
+-- the one component that observes the installation's real repo set, so a
+-- repo whose permissions are restored rejoins the normal flow on the next
+-- discovery pass with no operator action.
+ALTER TABLE repo_state
+    ADD COLUMN active BOOLEAN NOT NULL DEFAULT true;
+
+-- The sweep reads only active rows, so index the common case rather than
+-- the whole table.
+CREATE INDEX idx_repo_state_active_freshness
+    ON repo_state(last_checked_at NULLS FIRST)
+    WHERE active;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -172,6 +172,17 @@ func (s *Store) UpsertIfMissing(ctx context.Context, rs *store.RepoState) (bool,
 }
 
 func (s *Store) upsertIfMissingInner(ctx context.Context, rs *store.RepoState) (bool, error) {
+	// The ON CONFLICT arm reactivates: discovery seeing a repository is
+	// proof the App can reach it again, so a row parked by the
+	// access-denied circuit breaker rejoins the sweep with no operator
+	// action (INV-0015). The WHERE keeps this a no-op write for rows that
+	// are already active, so a discovery pass over an untouched fleet
+	// still costs nothing.
+	//
+	// It does NOT touch last_checked_at or policy_version: overwriting
+	// those would reset the freshness gate and re-check the whole fleet
+	// on every discovery pass.
+	//
 	// Single-statement upsert-or-discover. The trailing SELECT runs only
 	// when the INSERT was suppressed by ON CONFLICT DO NOTHING (i.e. the
 	// row already existed) — UNION ALL on the empty-ins case returns the
@@ -183,7 +194,9 @@ func (s *Store) upsertIfMissingInner(ctx context.Context, rs *store.RepoState) (
 				installation_id, owner, repo,
 				last_checked_at, last_check_status, last_error, policy_version
 			) VALUES ($1, $2, $3, NULL, $4, '', $5)
-			ON CONFLICT (installation_id, owner, repo) DO NOTHING
+			ON CONFLICT (installation_id, owner, repo) DO UPDATE
+				SET active = true
+				WHERE NOT repo_state.active
 			RETURNING (xmax = 0) AS created
 		)
 		SELECT created FROM ins
@@ -213,10 +226,30 @@ func (s *Store) upsertIfMissingInner(ctx context.Context, rs *store.RepoState) (
 	return created, nil
 }
 
-// StaleRepos returns up to limit rows whose last_checked_at is older
-// than freshness OR whose policy_version differs from
+// Deactivate parks a repository so the sweep stops returning it.
+// One-way by design: only discovery may reactivate a row, via
+// UpsertIfMissing (INV-0015).
+func (s *Store) Deactivate(ctx context.Context, installationID int64, owner, repo string) error {
+	start := time.Now()
+
+	const q = `UPDATE repo_state SET active = false
+	           WHERE installation_id = $1 AND owner = $2 AND repo = $3`
+
+	_, err := s.pool.Exec(ctx, q, installationID, owner, repo)
+	observeQuery("deactivate", start, err)
+
+	if err != nil {
+		return fmt.Errorf("deactivating %s/%s: %w", owner, repo, err)
+	}
+
+	return nil
+}
+
+// StaleRepos returns up to limit ACTIVE rows whose last_checked_at is
+// older than freshness OR whose policy_version differs from
 // currentPolicyVersion. NULL last_checked_at sorts first to ensure
-// never-checked repos are reconciled before stale ones.
+// never-checked repos are reconciled before stale ones. Inactive rows
+// are never returned; see Deactivate.
 func (s *Store) StaleRepos(ctx context.Context, freshness time.Duration, currentPolicyVersion string, limit int) ([]store.RepoState, error) {
 	start := time.Now()
 
@@ -231,9 +264,10 @@ func (s *Store) staleReposInner(ctx context.Context, freshness time.Duration, cu
 		SELECT installation_id, owner, repo,
 		       last_checked_at, last_check_status, last_error, policy_version
 		FROM repo_state
-		WHERE last_checked_at IS NULL
-		   OR last_checked_at < $1
-		   OR policy_version <> $2
+		WHERE active
+		  AND (last_checked_at IS NULL
+		       OR last_checked_at < $1
+		       OR policy_version <> $2)
 		ORDER BY last_checked_at NULLS FIRST
 		LIMIT $3
 	`

--- a/internal/store/postgres/postgres_integration_test.go
+++ b/internal/store/postgres/postgres_integration_test.go
@@ -370,3 +370,115 @@ func mustUpdate(ctx context.Context, t *testing.T, s *postgres.Store, rs *store.
 		t.Fatalf("UpdateRepoState %s/%s: %v", rs.Owner, rs.Repo, err)
 	}
 }
+
+// TestPostgresStore_DeactivateExcludesFromSweep pins the INV-0015
+// circuit breaker's store half: a parked repository must stop being
+// handed back by the sweep, and must stay parked across sweeps.
+func TestPostgresStore_DeactivateExcludesFromSweep(t *testing.T) {
+	ctx := context.Background()
+	dsn := startPostgres(ctx, t)
+	s := newStore(ctx, t, dsn)
+
+	old := time.Now().UTC().Add(-2 * time.Hour)
+
+	for _, repo := range []string{"reachable", "denied"} {
+		mustUpdate(ctx, t, s, &store.RepoState{
+			InstallationID: 1, Owner: "o", Repo: repo,
+			LastCheckedAt: &old, LastCheckStatus: store.StatusSuccess, PolicyVersion: "v1",
+		})
+	}
+
+	if err := s.Deactivate(ctx, 1, "o", "denied"); err != nil {
+		t.Fatalf("Deactivate() = %v, want nil error", err)
+	}
+
+	stale, err := s.StaleRepos(ctx, time.Hour, "v1", 10)
+	if err != nil {
+		t.Fatalf("StaleRepos() = _, %v, want nil error", err)
+	}
+
+	if len(stale) != 1 || stale[0].Repo != "reachable" {
+		t.Fatalf("StaleRepos() returned %+v, want only [reachable]; a parked repo must not be re-enqueued", stale)
+	}
+
+	// A policy-version bump must not resurrect it either: the freshness
+	// clause is a disjunction, so `active` has to gate the whole group
+	// rather than binding to the last OR arm.
+	stale, err = s.StaleRepos(ctx, time.Hour, "v2", 10)
+	if err != nil {
+		t.Fatalf("StaleRepos() = _, %v, want nil error", err)
+	}
+
+	for _, rs := range stale {
+		if rs.Repo == "denied" {
+			t.Errorf("a policy-version change resurrected a parked repo; `active` is binding to one OR arm instead of the group")
+		}
+	}
+
+	// Idempotent, and harmless on a row that does not exist.
+	if err := s.Deactivate(ctx, 1, "o", "denied"); err != nil {
+		t.Errorf("second Deactivate() = %v, want nil error", err)
+	}
+
+	if err := s.Deactivate(ctx, 1, "o", "ghost"); err != nil {
+		t.Errorf("Deactivate() on an absent row = %v, want nil error", err)
+	}
+}
+
+// TestPostgresStore_DiscoveryReactivates pins the other half: discovery
+// is the only thing that may un-park a repository, and doing so must not
+// disturb the freshness gate.
+func TestPostgresStore_DiscoveryReactivates(t *testing.T) {
+	ctx := context.Background()
+	dsn := startPostgres(ctx, t)
+	s := newStore(ctx, t, dsn)
+
+	checked := time.Now().UTC().Add(-2 * time.Hour)
+
+	mustUpdate(ctx, t, s, &store.RepoState{
+		InstallationID: 1, Owner: "o", Repo: "r",
+		LastCheckedAt: &checked, LastCheckStatus: store.StatusSuccess, PolicyVersion: "v1",
+	})
+
+	if err := s.Deactivate(ctx, 1, "o", "r"); err != nil {
+		t.Fatalf("Deactivate() = %v, want nil error", err)
+	}
+
+	// Discovery seeing the repo again is proof the App can reach it.
+	created, err := s.UpsertIfMissing(ctx, &store.RepoState{
+		InstallationID: 1, Owner: "o", Repo: "r",
+		LastCheckStatus: store.StatusPending,
+	})
+	if err != nil {
+		t.Fatalf("UpsertIfMissing() = _, %v, want nil error", err)
+	}
+
+	if created {
+		t.Errorf("UpsertIfMissing() = true, want false — reactivating an existing row is not a creation")
+	}
+
+	stale, err := s.StaleRepos(ctx, time.Hour, "v1", 10)
+	if err != nil {
+		t.Fatalf("StaleRepos() = _, %v, want nil error", err)
+	}
+
+	if len(stale) != 1 || stale[0].Repo != "r" {
+		t.Fatalf("StaleRepos() returned %+v, want [r] — discovery must return a parked repo to the sweep", stale)
+	}
+
+	// Reactivation must not reset the freshness gate. Overwriting
+	// last_checked_at or policy_version here would re-check the entire
+	// fleet on every discovery pass.
+	got, err := s.GetRepoState(ctx, 1, "o", "r")
+	if err != nil {
+		t.Fatalf("GetRepoState() = _, %v, want nil error", err)
+	}
+
+	if got.LastCheckedAt == nil || !got.LastCheckedAt.Equal(checked) {
+		t.Errorf("LastCheckedAt = %v, want %v unchanged", got.LastCheckedAt, checked)
+	}
+
+	if got.PolicyVersion != "v1" {
+		t.Errorf("PolicyVersion = %q, want %q unchanged", got.PolicyVersion, "v1")
+	}
+}

--- a/internal/store/postgres/postgres_integration_test.go
+++ b/internal/store/postgres/postgres_integration_test.go
@@ -482,3 +482,43 @@ func TestPostgresStore_DiscoveryReactivates(t *testing.T) {
 		t.Errorf("PolicyVersion = %q, want %q unchanged", got.PolicyVersion, "v1")
 	}
 }
+
+// TestPostgresStore_UpdateRepoStateDoesNotUnpark pins the boundary
+// between the two writers.
+//
+// UpdateRepoState is called on every processed job (worker write-back)
+// and on every push webhook, so if it reset active the parking would be
+// undone within one cycle by the very path that set it. The column is
+// deliberately absent from its ON CONFLICT list; this test fails if
+// someone adds it, or switches the statement to a whole-row upsert.
+func TestPostgresStore_UpdateRepoStateDoesNotUnpark(t *testing.T) {
+	ctx := context.Background()
+	dsn := startPostgres(ctx, t)
+	s := newStore(ctx, t, dsn)
+
+	old := time.Now().UTC().Add(-2 * time.Hour)
+
+	mustUpdate(ctx, t, s, &store.RepoState{
+		InstallationID: 1, Owner: "o", Repo: "r",
+		LastCheckedAt: &old, LastCheckStatus: store.StatusSuccess, PolicyVersion: "v1",
+	})
+
+	if err := s.Deactivate(ctx, 1, "o", "r"); err != nil {
+		t.Fatalf("Deactivate() = %v, want nil error", err)
+	}
+
+	// Exactly what the worker write-back and the push webhook do.
+	mustUpdate(ctx, t, s, &store.RepoState{
+		InstallationID: 1, Owner: "o", Repo: "r",
+		LastCheckedAt: &old, LastCheckStatus: store.StatusError, PolicyVersion: "v1",
+	})
+
+	stale, err := s.StaleRepos(ctx, time.Hour, "v1", 10)
+	if err != nil {
+		t.Fatalf("StaleRepos() = _, %v, want nil error", err)
+	}
+
+	if len(stale) != 0 {
+		t.Errorf("StaleRepos() returned %+v, want none — UpdateRepoState un-parked the row it was told nothing about", stale)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -70,5 +70,17 @@ type Store interface {
 	UpdateRepoState(ctx context.Context, s *RepoState) error
 	UpsertIfMissing(ctx context.Context, s *RepoState) (created bool, err error)
 	StaleRepos(ctx context.Context, freshness time.Duration, currentPolicyVersion string, limit int) ([]RepoState, error)
+
+	// Deactivate marks a repository inactive so StaleRepos stops
+	// returning it. It is deliberately one-way: nothing here can set a
+	// row active again, because only discovery observes the
+	// installation's real repository set and is therefore the only
+	// component entitled to say a repository is reachable (INV-0015).
+	// Reactivation happens in UpsertIfMissing.
+	//
+	// Idempotent: deactivating an already-inactive or absent row is not
+	// an error.
+	Deactivate(ctx context.Context, installationID int64, owner, repo string) error
+
 	Close() error
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -187,7 +187,14 @@ func (p *Pool) processJob(ctx context.Context, log *slog.Logger, j queue.Job) er
 		// below. Order matters: deferralFor runs first because a
 		// secondary rate limit is also a 403 (INV-0015).
 		if ghclient.IsAccessDenied(err) {
-			return p.dropInaccessible(ctx, jobLog, j, err)
+			return p.park(ctx, jobLog, j, parkAccessDenied, err)
+		}
+
+		// A durable skip (archived, fork) is not a failure at all — the
+		// repo is in its desired state and nothing will change that until
+		// discovery sees it differently.
+		if skip, ok := checker.AsSkipped(err); ok {
+			return p.park(ctx, jobLog, j, skip.Reason, nil)
 		}
 
 		jobLog.Error("job failed", "error", err, "duration", time.Since(start))
@@ -206,27 +213,44 @@ func (p *Pool) processJob(ctx context.Context, log *slog.Logger, j queue.Job) er
 	return nil
 }
 
-// dropInaccessible parks a repository the App cannot reach.
+// parkAccessDenied is the park reason for a repository the installation
+// cannot read. The others come from checker.SkippedError.
+const parkAccessDenied = "access_denied"
+
+// park takes a repository out of the stale sweep.
 //
-// Without this the job takes the generic error path: nack, requeue,
-// Attempts++, up to MAX_JOB_ATTEMPTS — and then the next stale sweep
-// hands it straight back, so an inaccessible repository burns the whole
-// attempt budget every cycle, forever, and its failures are
-// indistinguishable from a transient 500 in both logs and metrics.
+// Without this, both parked conditions cost forever. An unreadable repo
+// took the generic error path — nack, requeue, Attempts++, to
+// MAX_JOB_ATTEMPTS — and the next sweep handed it straight back, so it
+// burned the whole attempt budget every cycle with failures
+// indistinguishable from a transient 500. An archived or forked repo was
+// cheaper but equally endless: enqueue, installation client,
+// GetRepository, skip, write back success, and round again every
+// freshness cycle for as long as the repository exists.
+//
+// cause is nil for a skip, which is not a failure: the repository is in
+// its desired state, so the row records StatusSkipped rather than an
+// error, and the log is Info rather than Error.
 //
 // Returns nil so the queue acks and drops, exactly as dropExhausted
-// does; returning an error here would rebuild the retry loop this
-// exists to break.
+// does; returning an error would rebuild the retry loop this exists to
+// break.
 //
 //nolint:gocritic // hugeParam: queue.Job-by-value matches Subscribe's contract
-func (p *Pool) dropInaccessible(ctx context.Context, log *slog.Logger, j queue.Job, cause error) error {
-	log.Error("repository is not accessible to this installation; parking it until discovery sees it again",
-		"error", cause,
-	)
+func (p *Pool) park(ctx context.Context, log *slog.Logger, j queue.Job, reason string, cause error) error {
+	if cause != nil {
+		log.Error("parking repository until discovery sees it again", "reason", reason, "error", cause)
+	} else {
+		log.Info("parking repository until discovery sees it again", "reason", reason)
+	}
 
-	metrics.RepoAccessDeniedTotal.WithLabelValues(j.Owner, strconv.FormatInt(j.InstallationID, 10)).Inc()
+	metrics.ReposParkedTotal.WithLabelValues(j.Owner, strconv.FormatInt(j.InstallationID, 10), reason).Inc()
 
-	p.writeBack(ctx, log, j, fmt.Errorf("repository not accessible to installation %d: %w", j.InstallationID, cause))
+	if cause != nil {
+		p.writeBack(ctx, log, j, fmt.Errorf("repository not accessible to installation %d: %w", j.InstallationID, cause))
+	} else {
+		p.writeBackStatus(ctx, log, j, store.StatusSkipped, reason)
+	}
 
 	// Best-effort, and deliberately after the write-back: if this fails
 	// the repo simply stays in the sweep and we retry next cycle, which
@@ -375,7 +399,42 @@ func (p *Pool) writeBack(ctx context.Context, log *slog.Logger, j queue.Job, che
 		state.LastError = store.Truncate(checkErr.Error(), errMaxRunes)
 	}
 
-	installLabel := strconv.FormatInt(j.InstallationID, 10)
+	p.persist(ctx, log, j.InstallationID, state)
+}
+
+// writeBackStatus records an explicit terminal status, for an outcome
+// that is neither a success nor a failure. A durable skip is the only
+// such case today: nothing went wrong, so StatusError would be a lie,
+// and StatusSuccess would claim rules were evaluated when none were.
+//
+// detail lands in LastError despite not being an error. There is no
+// park_reason column, and last_error is the only free-text slot, so it
+// is what lets an operator see why a row was parked from SQL alone;
+// LastCheckStatus is what says whether it was a failure.
+//
+//nolint:gocritic // hugeParam: queue.Job-by-value matches Subscribe's contract
+func (p *Pool) writeBackStatus(ctx context.Context, log *slog.Logger, j queue.Job, status, detail string) {
+	if p.stateStore == nil {
+		return
+	}
+
+	now := time.Now().UTC()
+
+	p.persist(ctx, log, j.InstallationID, &store.RepoState{
+		InstallationID:  j.InstallationID,
+		Owner:           j.Owner,
+		Repo:            j.Repo,
+		LastCheckedAt:   &now,
+		PolicyVersion:   p.policyVersion,
+		LastCheckStatus: status,
+		LastError:       store.Truncate(detail, errMaxRunes),
+	})
+}
+
+// persist is the shared best-effort tail of every write-back: one Store
+// call, timed and counted, never propagated. The queue.Job remains the
+// source of truth for "did we do the work".
+func (p *Pool) persist(ctx context.Context, log *slog.Logger, installationID int64, state *store.RepoState) {
 	wbStart := time.Now()
 
 	err := p.stateStore.UpdateRepoState(ctx, state)
@@ -388,5 +447,5 @@ func (p *Pool) writeBack(ctx context.Context, log *slog.Logger, j queue.Job, che
 		log.Warn("store write-back failed; sweep will re-enqueue", "error", err)
 	}
 
-	metrics.StoreWritebackTotal.WithLabelValues(installLabel, outcome).Inc()
+	metrics.StoreWritebackTotal.WithLabelValues(strconv.FormatInt(installationID, 10), outcome).Inc()
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -183,6 +183,13 @@ func (p *Pool) processJob(ctx context.Context, log *slog.Logger, j queue.Job) er
 			return retry
 		}
 
+		// Access denial is terminal, so it must not take the retry path
+		// below. Order matters: deferralFor runs first because a
+		// secondary rate limit is also a 403 (INV-0015).
+		if ghclient.IsAccessDenied(err) {
+			return p.dropInaccessible(ctx, jobLog, j, err)
+		}
+
 		jobLog.Error("job failed", "error", err, "duration", time.Since(start))
 		metrics.ErrorsTotal.WithLabelValues("check_repo", j.Owner).Inc()
 		p.writeBack(ctx, jobLog, j, err)
@@ -195,6 +202,40 @@ func (p *Pool) processJob(ctx context.Context, log *slog.Logger, j queue.Job) er
 	metrics.CheckDurationSeconds.Observe(duration.Seconds())
 	p.writeBack(ctx, jobLog, j, nil)
 	jobLog.Info("job completed", "duration", duration)
+
+	return nil
+}
+
+// dropInaccessible parks a repository the App cannot reach.
+//
+// Without this the job takes the generic error path: nack, requeue,
+// Attempts++, up to MAX_JOB_ATTEMPTS — and then the next stale sweep
+// hands it straight back, so an inaccessible repository burns the whole
+// attempt budget every cycle, forever, and its failures are
+// indistinguishable from a transient 500 in both logs and metrics.
+//
+// Returns nil so the queue acks and drops, exactly as dropExhausted
+// does; returning an error here would rebuild the retry loop this
+// exists to break.
+//
+//nolint:gocritic // hugeParam: queue.Job-by-value matches Subscribe's contract
+func (p *Pool) dropInaccessible(ctx context.Context, log *slog.Logger, j queue.Job, cause error) error {
+	log.Error("repository is not accessible to this installation; parking it until discovery sees it again",
+		"error", cause,
+	)
+
+	metrics.RepoAccessDeniedTotal.WithLabelValues(j.Owner, strconv.FormatInt(j.InstallationID, 10)).Inc()
+
+	p.writeBack(ctx, log, j, fmt.Errorf("repository not accessible to installation %d: %w", j.InstallationID, cause))
+
+	// Best-effort, and deliberately after the write-back: if this fails
+	// the repo simply stays in the sweep and we retry next cycle, which
+	// is the pre-existing behaviour rather than a new failure mode.
+	if p.stateStore != nil {
+		if err := p.stateStore.Deactivate(ctx, j.InstallationID, j.Owner, j.Repo); err != nil {
+			log.Warn("deactivate failed; repo stays in the sweep and will retry", "error", err)
+		}
+	}
 
 	return nil
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -265,7 +265,7 @@ func (*notFoundClient) GetRepository(context.Context, string, string) (*ghclient
 // stops re-enqueuing it, and the failure lands on its own metric series.
 func TestPool_AccessDenied_ParksRepoWithoutRetrying(t *testing.T) {
 	// Not parallel: reads a package-global metric after Reset.
-	metrics.RepoAccessDeniedTotal.Reset()
+	metrics.ReposParkedTotal.Reset()
 
 	// No file rules: CheckRepo fails at the GetRepository probe before it
 	// evaluates any, so rules would only add reconciler wiring this test
@@ -329,11 +329,187 @@ func TestPool_AccessDenied_ParksRepoWithoutRetrying(t *testing.T) {
 
 	// 3. Its own series, so an operator can alert on "the App lost access"
 	// without it being buried among transient 500s.
-	if v := testutil.ToFloat64(metrics.RepoAccessDeniedTotal.WithLabelValues("acme", "9")); v != 1 {
-		t.Errorf("repo_access_denied_total{org=acme, installation_id=9} = %v, want 1", v)
+	if v := testutil.ToFloat64(metrics.ReposParkedTotal.WithLabelValues("acme", "9", "access_denied")); v != 1 {
+		t.Errorf("repos_parked_total{org=acme, installation_id=9, reason=access_denied} = %v, want 1", v)
 	}
 
 	if v := testutil.ToFloat64(metrics.ErrorsTotal.WithLabelValues("check_repo", "acme")); v != 0 {
 		t.Errorf("errors_total{operation=check_repo} = %v, want 0 — access denial must not land in the generic bucket", v)
+	}
+}
+
+// repoStateClient reports a repository that exists and is readable, in
+// whatever lifecycle state the test needs. Every skip reason the engine can
+// return is a property of this struct, so the parked and not-parked cases are
+// the same fake with one field flipped.
+type repoStateClient struct {
+	mocks.MockClient
+
+	repo ghclient.Repository
+}
+
+func (c *repoStateClient) CreateInstallationClient(context.Context, int64) (ghclient.Client, error) {
+	return c, nil
+}
+
+func (c *repoStateClient) GetRepository(_ context.Context, owner, repo string) (*ghclient.Repository, error) {
+	r := c.repo
+	r.Owner, r.Name = owner, repo
+
+	return &r, nil
+}
+
+// TestPool_ArchivedRepo_IsParkedNotRechecked pins the second half of the
+// INV-0015 parking work.
+//
+// An archived repository was skipped correctly but never stopped costing
+// anything: enqueue, installation client, GetRepository, skip, write back
+// success, and round again every freshness cycle for as long as the repo
+// exists. Discovery filters archived repos, so parking is stable — and it
+// self-heals, because an unarchived repo stops being filtered and
+// UpsertIfMissing reactivates it.
+//
+// StatusSkipped, not StatusError: nothing went wrong.
+func TestPool_ArchivedRepo_IsParkedNotRechecked(t *testing.T) {
+	// Not parallel: reads a package-global metric after Reset.
+	metrics.ReposParkedTotal.Reset()
+
+	cfg := &policy.PolicyConfig{Guardian: policy.BuiltinDefaults().Guardian}
+
+	eng, err := checker.NewEngine(cfg, rules.NewTemplateStore(), slog.Default(), reconciler.NewRegistry())
+	if err != nil {
+		t.Fatalf("NewEngine() = _, %v, want nil error", err)
+	}
+
+	q := &deliverOnceQueue{
+		job: queue.Job{
+			ID: "arch", InstallationID: 4, Owner: "acme", Repo: "old",
+			Trigger: queue.TriggerScheduler,
+		},
+		result: make(chan error, 1),
+	}
+	st := &capturingStore{}
+	client := &repoStateClient{repo: ghclient.Repository{Archived: true, HasBranch: true, DefaultRef: "main"}}
+	p := worker.New(q, eng, client, st, "pv1", 10, 1, slog.Default())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p.Start(ctx)
+
+	var res error
+	select {
+	case res = <-q.result:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler never invoked")
+	}
+
+	cancel()
+	p.Stop()
+
+	if res != nil {
+		t.Errorf("handler returned %v, want nil — a skip is not a failure", res)
+	}
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	want := "4/acme/old"
+	if len(st.deactivated) != 1 || st.deactivated[0] != want {
+		t.Errorf("Deactivate calls = %v, want exactly [%s]; an archived repo must leave the sweep", st.deactivated, want)
+	}
+
+	if len(st.states) != 1 {
+		t.Fatalf("UpdateRepoState calls = %d, want exactly 1", len(st.states))
+	}
+
+	if got := st.states[0].LastCheckStatus; got != store.StatusSkipped {
+		t.Errorf("LastCheckStatus = %q, want %q — nothing failed, and no rules were evaluated either",
+			got, store.StatusSkipped)
+	}
+
+	// There is no park_reason column; last_error is the only free-text slot,
+	// and it is what makes `SELECT ... WHERE NOT active` answer *why* a row
+	// is parked. The documented operator query in docs/operations/migrations.md
+	// depends on this.
+	if got := st.states[0].LastError; got != checker.SkipArchived {
+		t.Errorf("LastError = %q, want %q — the park reason must be recoverable from SQL",
+			got, checker.SkipArchived)
+	}
+
+	if v := testutil.ToFloat64(metrics.ReposParkedTotal.WithLabelValues("acme", "4", "archived")); v != 1 {
+		t.Errorf("repos_parked_total{reason=archived} = %v, want 1", v)
+	}
+
+	if v := testutil.ToFloat64(metrics.ErrorsTotal.WithLabelValues("check_repo", "acme")); v != 0 {
+		t.Errorf("errors_total{operation=check_repo} = %v, want 0 — an archived repo is not an error", v)
+	}
+}
+
+// TestPool_EmptyRepo_IsSkippedButNotParked is the boundary of the parking
+// change, and the reason skipReason returns a durable flag rather than just a
+// reason string.
+//
+// Parking is only stable when the engine's skip conditions are a SUBSET of
+// discovery's filters. Discovery filters archived and fork repos, so a parked
+// one stays parked. Discovery does NOT filter empty repos — it would re-upsert
+// this repo on its very next pass, flipping active back to true, and the pair
+// would churn against each other at the discovery interval forever.
+//
+// So an empty repo is skipped the old way: no park, no error, and a normal
+// success write-back that lets freshness govern the next check. An empty repo
+// also stops being empty on its first push, which is a webhook away.
+func TestPool_EmptyRepo_IsSkippedButNotParked(t *testing.T) {
+	t.Parallel()
+
+	cfg := &policy.PolicyConfig{Guardian: policy.BuiltinDefaults().Guardian}
+
+	eng, err := checker.NewEngine(cfg, rules.NewTemplateStore(), slog.Default(), reconciler.NewRegistry())
+	if err != nil {
+		t.Fatalf("NewEngine() = _, %v, want nil error", err)
+	}
+
+	q := &deliverOnceQueue{
+		job: queue.Job{
+			ID: "empty", InstallationID: 4, Owner: "acme", Repo: "fresh",
+			Trigger: queue.TriggerScheduler,
+		},
+		result: make(chan error, 1),
+	}
+	st := &capturingStore{}
+	client := &repoStateClient{repo: ghclient.Repository{HasBranch: false}}
+	p := worker.New(q, eng, client, st, "pv1", 10, 1, slog.Default())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p.Start(ctx)
+
+	select {
+	case err := <-q.result:
+		if err != nil {
+			t.Errorf("handler returned %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler never invoked")
+	}
+
+	cancel()
+	p.Stop()
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	if len(st.deactivated) != 0 {
+		t.Errorf("Deactivate calls = %v, want none; discovery does not filter empty repos, "+
+			"so parking one makes discovery and the sweep fight over it every interval", st.deactivated)
+	}
+
+	if len(st.states) != 1 {
+		t.Fatalf("UpdateRepoState calls = %d, want exactly 1", len(st.states))
+	}
+
+	if got := st.states[0].LastCheckStatus; got != store.StatusSuccess {
+		t.Errorf("LastCheckStatus = %q, want %q", got, store.StatusSuccess)
 	}
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -3,16 +3,25 @@ package worker_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	gh "github.com/google/go-github/v68/github"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
+	"github.com/donaldgifford/repo-guardian/internal/checker"
+	ghclient "github.com/donaldgifford/repo-guardian/internal/github"
+	"github.com/donaldgifford/repo-guardian/internal/github/mocks"
 	"github.com/donaldgifford/repo-guardian/internal/metrics"
+	"github.com/donaldgifford/repo-guardian/internal/policy"
 	"github.com/donaldgifford/repo-guardian/internal/queue"
+	"github.com/donaldgifford/repo-guardian/internal/reconciler"
+	"github.com/donaldgifford/repo-guardian/internal/rules"
 	"github.com/donaldgifford/repo-guardian/internal/store"
 	"github.com/donaldgifford/repo-guardian/internal/worker"
 )
@@ -106,8 +115,9 @@ var errUnimplemented = errors.New("not implemented in capturingStore")
 // capturingStore records UpdateRepoState calls; every other Store
 // method is a no-op.
 type capturingStore struct {
-	mu     sync.Mutex
-	states []store.RepoState
+	mu          sync.Mutex
+	states      []store.RepoState
+	deactivated []string
 }
 
 func (*capturingStore) GetRepoState(context.Context, int64, string, string) (*store.RepoState, error) {
@@ -209,3 +219,121 @@ func TestPool_AttemptCap_TerminalDisposition(t *testing.T) {
 // pump-correctness behaviour is covered by the queue/valkey
 // integration tests (EnqueueDequeue + CloseUnblocksSubscribe under
 // the integration build tag).
+
+// Deactivate records the park so the access-denied test can assert the
+// repo was taken out of the sweep, not merely that the job was acked.
+func (c *capturingStore) Deactivate(_ context.Context, installationID int64, owner, repo string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.deactivated = append(c.deactivated, fmt.Sprintf("%d/%s/%s", installationID, owner, repo))
+
+	return nil
+}
+
+// notFoundClient is a ghclient.Client whose GetRepository fails the way
+// GitHub answers a repository the installation cannot see: 404, not 403.
+// Everything else panics via the embedded generated mock, which is the
+// point — this test must fail loudly if the engine starts reaching past
+// the repository probe.
+type notFoundClient struct {
+	mocks.MockClient
+}
+
+func (c *notFoundClient) CreateInstallationClient(context.Context, int64) (ghclient.Client, error) {
+	return c, nil
+}
+
+func (*notFoundClient) GetRepository(context.Context, string, string) (*ghclient.Repository, error) {
+	return nil, &gh.ErrorResponse{
+		Response: &http.Response{StatusCode: http.StatusNotFound},
+		Message:  "Not Found",
+	}
+}
+
+// TestPool_AccessDenied_ParksRepoWithoutRetrying pins the INV-0015
+// circuit breaker.
+//
+// Before it, a repository the App could not read took the generic error
+// path: nack, requeue, Attempts++, up to MAX_JOB_ATTEMPTS — and the next
+// stale sweep handed it straight back, so it burned the whole attempt
+// budget every cycle, forever, while its failures were indistinguishable
+// from a transient 500 in both logs and metrics.
+//
+// Three things must hold together: the handler acks (returns nil) so the
+// job is dropped rather than retried, the row is deactivated so the sweep
+// stops re-enqueuing it, and the failure lands on its own metric series.
+func TestPool_AccessDenied_ParksRepoWithoutRetrying(t *testing.T) {
+	// Not parallel: reads a package-global metric after Reset.
+	metrics.RepoAccessDeniedTotal.Reset()
+
+	// No file rules: CheckRepo fails at the GetRepository probe before it
+	// evaluates any, so rules would only add reconciler wiring this test
+	// does not exercise.
+	cfg := &policy.PolicyConfig{Guardian: policy.BuiltinDefaults().Guardian}
+
+	eng, err := checker.NewEngine(cfg, rules.NewTemplateStore(), slog.Default(), reconciler.NewRegistry())
+	if err != nil {
+		t.Fatalf("NewEngine() = _, %v, want nil error", err)
+	}
+
+	q := &deliverOnceQueue{
+		job: queue.Job{
+			ID:             "denied",
+			InstallationID: 9,
+			Owner:          "acme",
+			Repo:           "secret",
+			Trigger:        queue.TriggerScheduler,
+		},
+		result: make(chan error, 1),
+	}
+	st := &capturingStore{}
+	p := worker.New(q, eng, &notFoundClient{}, st, "pv1", 10, 1, slog.Default())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p.Start(ctx)
+
+	var res error
+	select {
+	case res = <-q.result:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler never invoked")
+	}
+
+	cancel()
+	p.Stop()
+
+	// 1. Acked. Returning an error here would rebuild the retry loop.
+	if res != nil {
+		t.Errorf("handler returned %v, want nil — an error re-nacks and the job retries against a repo that can never succeed", res)
+	}
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	// 2. Parked, so the sweep stops handing it back.
+	want := "9/acme/secret"
+	if len(st.deactivated) != 1 || st.deactivated[0] != want {
+		t.Errorf("Deactivate calls = %v, want exactly [%s]", st.deactivated, want)
+	}
+
+	if len(st.states) != 1 {
+		t.Fatalf("UpdateRepoState calls = %d, want exactly 1", len(st.states))
+	}
+
+	if got := st.states[0]; got.LastCheckStatus != store.StatusError {
+		t.Errorf("LastCheckStatus = %q, want %q", got.LastCheckStatus, store.StatusError)
+	}
+
+	// 3. Its own series, so an operator can alert on "the App lost access"
+	// without it being buried among transient 500s.
+	if v := testutil.ToFloat64(metrics.RepoAccessDeniedTotal.WithLabelValues("acme", "9")); v != 1 {
+		t.Errorf("repo_access_denied_total{org=acme, installation_id=9} = %v, want 1", v)
+	}
+
+	if v := testutil.ToFloat64(metrics.ErrorsTotal.WithLabelValues("check_repo", "acme")); v != 0 {
+		t.Errorf("errors_total{operation=check_repo} = %v, want 0 — access denial must not land in the generic bucket", v)
+	}
+}


### PR DESCRIPTION
## What

Adds a `repo_state.active` column and a parking path that takes a repository out of the stale sweep when checking it can never succeed. Three reasons park today:

| `reason` | Trigger | Normal? |
|---|---|---|
| `access_denied` | Check failed 403/404 — App uninstalled from the repo, lost a permission, or the repo was deleted | a trickle, yes; a step change, no |
| `archived` | `skip_archived` on and the repo is archived | yes |
| `fork` | `skip_forks` on and the repo is a fork | yes |

## Why

Each of these burned budget forever, in two different shapes.

An **unreadable** repository took the generic error path: nack, requeue, `Attempts++`, to `MAX_JOB_ATTEMPTS` — and then the next stale sweep handed it straight back. It burned the full attempt budget every cycle, indefinitely, and its failures were indistinguishable from a transient 500 in both logs and metrics. There was exactly one error classifier in the worker (`AsThrottled`); a permissions failure had nowhere else to go.

An **archived or forked** repository was cheaper but just as endless: enqueue, installation client, `GetRepository`, skip, write back success, and round again every freshness cycle for as long as the repository exists. It was skipped correctly and still never stopped costing anything.

## Design

**Rows are parked, never deleted.** History stays queryable, and `last_check_status` distinguishes the kinds — `error` with the API failure in `last_error` for access-denied, `skipped` with the bare reason for archived/fork.

**Only discovery can un-park.** Discovery is the one component that observes the installation's real repository set, so restored access or an un-archived repository rejoins the sweep on the next discovery pass with no operator action. Reactivation deliberately leaves `last_checked_at` and `policy_version` alone — overwriting them would reset the freshness gate and re-check the whole fleet on every discovery pass.

**Parking is only stable when the engine's skip conditions are a subset of discovery's filters.** This is why `empty` is deliberately *not* durable: discovery does not filter empty repositories, so parking one would have discovery re-activate it on its very next pass, and the two would churn against each other at the discovery interval instead of settling. `TestPool_EmptyRepo_IsSkippedButNotParked` pins that boundary. The two durable reasons read the same `policyCfg.Guardian.SkipArchived/SkipForks` that discovery reads, so the subset relation is exact rather than coincidental — flag off, neither skips and nothing parks.

**One metric, `reason` from birth.** `repo_access_denied_total` → `repos_parked_total{org, installation_id, reason}`. The alert keeps its prior meaning by selecting `reason="access_denied"`; archived and fork parks are routine and would otherwise page on every normal onboarding sweep. The helm-unittest locks that selector, not just the alert name.

## SQL precedence

`AND` binds tighter than `OR`, so the whole freshness disjunction is parenthesised:

```sql
WHERE active AND (last_checked_at IS NULL OR last_checked_at < $1 OR policy_version <> $2)
```

Without the parens only the last arm would be gated, and a parked repository would return to the sweep the moment the policy hash changed. `TestPostgresStore_DeactivateExcludesFromSweep` covers exactly this.

## Blast radius

`active` gates whether a repository is worked at all, so every `repo_state` writer was audited. Five call sites; the one untested boundary was that `UpdateRepoState` must not reset `active` — a parked repo writes state on its way out, and an upsert that reset the flag would un-park it immediately. Now covered by `TestPostgresStore_UpdateRepoStateDoesNotUnpark`.

## Testing

Postgres integration (10 pass, incl. 3 new): `DeactivateExcludesFromSweep`, `DiscoveryReactivates`, `UpdateRepoStateDoesNotUnpark`.
Worker: `AccessDenied_ParksRepoWithoutRetrying`, `ArchivedRepo_IsParkedNotRechecked`, `EmptyRepo_IsSkippedButNotParked`.
Checker: `TestCheckRepo_Skips` (table over archived/fork/empty).
Chart: 105 helm-unittest cases pass, incl. 2 new locking the alert expression.

Both new checks verified non-vacuous by neutralising the thing they test — flipping the archived skip to non-durable fails all three of its assertions, and dropping the `reason` selector from the alert fails the helm-unittest.

Refs: INV-0015