### PR TITLE
docs: DESIGN-0023 + IMPL-0024 — operator-owned ingress (Tailscale sidecar + IP-allowlist middleware removal)

### DIFF
--- a/docs/design/0023-operator-owned-ingress-remove-the-tailscale-sidecar-and-ip.md
+++ b/docs/design/0023-operator-owned-ingress-remove-the-tailscale-sidecar-and-ip.md
@@ -173,20 +173,19 @@ Post-removal behavior (all decided in INV-0016, all intended):
 Every consumer of the deleted telemetry, and what happens to it:
 
 - **`metrics.WebhookRejectedTotal`** — sole producer is the deleted
-  middleware. Disposition per Open Question 1 (recommendation:
-  repoint at the HMAC 401 path with `reason="signature"`, making the
-  counter's one remaining reason true and cheap).
+  middleware. **Decided (OQ1 = a): repoint at the HMAC path** — the
+  401 branch of `webhook.Handler.ServeHTTP` increments
+  `webhook_rejected_total{reason="signature"}`. The
+  `ip_not_allowed`/`allowlist_unavailable` reasons disappear; the
+  counter's one remaining reason is true and cheap.
 - **`RepoGuardianWebhookRejectionsHigh`**
   (`internal/monitoring/alert/alert.go:154`) — exists only in the
   catalogue/generated tier; the chart's PrometheusRule does **not**
   carry it (verified 2026-08-15), so there is no hand-mirrored copy
-  to keep in step. Under OQ1(a) the alert survives with its
-  `Description` rewritten (the current text promises allowlist 403s
-  that will no longer exist and signature 401s that today never
-  reach the counter). Under OQ1(b/c) the alert is deleted or
-  re-expressed over otelhttp series
-  (`http_server_request_duration_seconds_count` by
-  `http_response_status_code`, the E3 vocabulary).
+  to keep in step. The alert survives with its `Description`
+  rewritten (the current text promises allowlist 403s that will no
+  longer exist and signature 401s that today never reach the
+  counter).
 - **E4 dashboard** (`internal/monitoring/dashboard/e4.go:33-37`) —
   `logRejectedIP` ("rejected request from non-GitHub IP") and
   `logNoIP` stop being emitted; `webhookRejectedRe` reduces to
@@ -239,8 +238,24 @@ Both mechanisms from precedent, layered:
    produces one legible sentence. They fire at different layers
    (`helm lint`/CI vs render), which is why both exist.
 
-Chart version: per Open Question 3 (recommendation: stay in the rc
-series).
+**Chart version (OQ3 decided): this change ships as `1.0.0` stable**,
+graduating the rc series. Preconditions, because the publish
+workflow's `helm pull` idempotency precheck would *silently skip*
+publishing if a `1.0.0` already existed:
+
+- GHCR verified clean 2026-08-15: `helm show chart
+  oci://ghcr.io/donaldgifford/charts/repo-guardian --version 1.0.0`
+  → "not found".
+- ECR could not be checked from the workstation; the IMPL carries a
+  release-checklist step to verify no `1.0.0` exists in ECR before
+  tagging (an `aws ecr describe-images` or `helm show chart` against
+  the ECR OCI ref).
+
+Prerelease semantics make this clean: every `1.0.0-rc.*` sorts below
+`1.0.0`, and breaking changes inside the rc series were the series'
+stated purpose (IMPL-0016, IMPL-0018 precedent). The stable cut also
+means the migration note is part of the chart's 1.0.0 story rather
+than an rc-to-rc footnote.
 
 ### D6: Documentation — the ingress options matrix
 
@@ -262,9 +277,22 @@ snippets), what sets `X-Forwarded-For` (telemetry-only post-removal),
 the source-IP enforcement setup where one exists, the CIDR-refresh
 ownership note for static allowlists, and the observability story
 (which edge-native signal plus which repo-guardian OTEL series answer
-"is traffic arriving / being rejected"). A closing section documents
-the checkbox contract: a box is checked only after the option carries
-a real GitHub App delivery end-to-end.
+"is traffic arriving / being rejected"). Two decided specifics:
+
+- **(OQ6 = a)** the cloudflared-sidecar row ships a complete,
+  copy-pasteable kustomize strategic-merge patch — container with a
+  **pinned, renovate-annotated** image (the supply-chain hygiene the
+  old sidecar lacked), tunnel-token Secret reference, and nothing
+  else, since remotely-managed tunnels keep the sidecar stateless.
+- **(OQ5 = a)** no in-app client-IP telemetry replaces the deleted
+  header read. Each matrix row documents where its edge's client-IP
+  evidence lives (ALB access logs, Cloudflare dashboard/Logpush,
+  ngrok inspector, Funnel — empirical checkbox item); otelhttp
+  metrics stay IP-free by design (cardinality), and E4 answers
+  "which repository", not "which caller".
+
+A closing section documents the checkbox contract: a box is checked
+only after the option carries a real GitHub App delivery end-to-end.
 
 ### D7: Historical-doc supersession
 
@@ -293,9 +321,9 @@ a real GitHub App delivery end-to-end.
   `trust_proxy_headers` (fail load if still present).
 - **Removed chart values:** `tailscale.*`, `webhookIPAllowlist.*`
   (fail render if still present).
-- **Metric:** `repo_guardian_webhook_rejected_total{reason}` — per
-  OQ1; under (a) the `ip_not_allowed`/`allowlist_unavailable` reasons
-  disappear and `signature` appears.
+- **Metric:** `repo_guardian_webhook_rejected_total{reason}` — the
+  `ip_not_allowed`/`allowlist_unavailable` reasons disappear;
+  `signature` appears (OQ1 = a).
 - **No Go interface changes.** `github.Client`, `Store`, `Queue`,
   the reconcilers, and the webhook `Handler` signature are untouched;
   no mock regeneration needed.
@@ -328,11 +356,10 @@ post-upgrade sweep burst isn't mistaken for a bug).
   regeneration; `make lint-alerts-contrib` re-parses the generated
   rules. No new machinery needed — the design leans on gates
   IMPL-0023 already built.
-- **OQ1(a) case:** if the counter is repointed, a handler test
-  asserting the 401 path increments
-  `webhook_rejected_total{reason="signature"}` exactly once
-  (`testutil.ToFloat64`), and the webhook 202 contract tests keep
-  passing unchanged.
+- **Repointed counter (OQ1 = a):** a handler test asserting the 401
+  path increments `webhook_rejected_total{reason="signature"}`
+  exactly once (`testutil.ToFloat64`), and the webhook 202 contract
+  tests keep passing unchanged.
 - **Render sweep:** `helm template` output diffed for exactly the
   expected deletions (no sidecar container, no allowlist env, no
   tailscale volumes/ConfigMap/RBAC) — the PR #67 namespace-stamping
@@ -340,13 +367,17 @@ post-upgrade sweep burst isn't mistaken for a bug).
 
 ## Migration / Rollout Plan
 
-1. **One release, both halves.** Binary and chart ship together
-   (per OQ4 recommendation): appVersion bump `minor`, chart bump per
-   OQ3. Shipping the chart removal against an old binary would leave
-   the allowlist enabled-by-default with no values to disable it;
-   shipping the binary first would strand chart values that render
-   env vars the binary ignores. Atomic is simpler than either skew.
-2. **Operator steps, in the migration note** (placement per OQ2):
+1. **One release, both halves (OQ4 = a).** Binary and chart ship
+   together in one atomic PR: appVersion bump `minor`, chart
+   `1.0.0` stable (OQ3). Shipping the chart removal against an old
+   binary would leave the allowlist enabled-by-default with no
+   values to disable it; shipping the binary first would strand
+   chart values that render env vars the binary ignores. Atomic is
+   simpler than either skew.
+2. **Operator steps, in the migration note** (OQ2 = a — a
+   "Migrating from the baked sidecar" section at the top of
+   `docs/operations/ingress.md`; the chart guard message and the
+   startup-error pointer both name that one URL):
    remove `tailscale.*` and `webhookIPAllowlist.*` from values;
    remove the three `guardian.hcl` attributes; delete any stale env
    patches (silently ignored, but confusing to future readers);
@@ -369,10 +400,15 @@ post-upgrade sweep burst isn't mistaken for a bug).
 
 ## Open Questions
 
-Format: (a) is the recommendation; pick a letter or write in
-**other**.
+**All six decided 2026-08-15** (operator review): 1a, 2a,
+3 = other (cut as `1.0.0` stable, after verifying no published
+`1.0.0` exists — GHCR verified clean; ECR check moves to the release
+checklist), 4a, 5a, 6a. Decisions are folded into the sections above
+(D3, D5, D6, Migration); the original options are preserved below
+for the record.
 
 **1. Disposition of `webhook_rejected_total` and its alert.**
+*Decided: (a).*
 The deleted middleware is the counter's only producer today; the
 HMAC 401 path increments nothing (INV-0016 Observation 5).
 
@@ -397,6 +433,7 @@ HMAC 401 path increments nothing (INV-0016 Observation 5).
 - other: ____
 
 **2. Where the migration note lives.**
+*Decided: (a).*
 
 - (a) **A section in `docs/operations/ingress.md` itself** —
   "Migrating from the baked sidecar" at the top of the doc every
@@ -414,6 +451,8 @@ HMAC 401 path increments nothing (INV-0016 Observation 5).
 - other: ____
 
 **3. Chart version for the breaking change.**
+*Decided: other — ship as `1.0.0` stable (see D5 for the
+published-version preconditions).*
 
 - (a) **Stay in the rc series (`1.0.0-rc.13`)** — the chart has
   never shipped a stable 1.0.0; rc semantics permit breaking
@@ -430,6 +469,7 @@ HMAC 401 path increments nothing (INV-0016 Observation 5).
 - other: ____
 
 **4. Sequencing of the removal.**
+*Decided: (a).*
 
 - (a) **One atomic PR** — binary + chart + docs + generated
   monitoring together. The drift gates effectively force D1+D3
@@ -447,6 +487,7 @@ HMAC 401 path increments nothing (INV-0016 Observation 5).
 - other: ____
 
 **5. Does anything replace the client-IP telemetry?**
+*Decided: (a).*
 Post-removal, nothing in the app reads `X-Forwarded-For`; the
 `RemoteAddr` behind every documented edge is a proxy/sidecar
 address. INV-0016 flagged Funnel's forwarded-header behavior as
@@ -468,6 +509,7 @@ unverified.
 
 **6. Does the sidecar image reference survive anywhere as a worked
 example?**
+*Decided: (a).*
 INV-0016 Observation 9 makes the operator-injected cloudflared
 sidecar a first-class matrix row, and the homelab consumes the chart
 via kustomize+helm in ArgoCD.

--- a/docs/design/0023-operator-owned-ingress-remove-the-tailscale-sidecar-and-ip.md
+++ b/docs/design/0023-operator-owned-ingress-remove-the-tailscale-sidecar-and-ip.md
@@ -1,0 +1,497 @@
+---
+id: DESIGN-0023
+title: "Operator-owned ingress: remove the Tailscale sidecar and IP-allowlist middleware"
+status: Draft
+author: Donald Gifford
+created: 2026-08-15
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# DESIGN 0023: Operator-owned ingress: remove the Tailscale sidecar and IP-allowlist middleware
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-08-15
+
+<!--toc:start-->
+- [Overview](#overview)
+- [Goals and Non-Goals](#goals-and-non-goals)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Background](#background)
+- [Detailed Design](#detailed-design)
+  - [D1: Binary — delete the allowlist middleware](#d1-binary--delete-the-allowlist-middleware)
+  - [D2: Binary — config-surface removal](#d2-binary--config-surface-removal)
+  - [D3: Observability disposition](#d3-observability-disposition)
+  - [D4: Chart — delete the Tailscale and allowlist surfaces](#d4-chart--delete-the-tailscale-and-allowlist-surfaces)
+  - [D5: Chart — reject removed values at render time](#d5-chart--reject-removed-values-at-render-time)
+  - [D6: Documentation — the ingress options matrix](#d6-documentation--the-ingress-options-matrix)
+  - [D7: Historical-doc supersession](#d7-historical-doc-supersession)
+- [API / Interface Changes](#api--interface-changes)
+- [Data Model](#data-model)
+- [Testing Strategy](#testing-strategy)
+- [Migration / Rollout Plan](#migration--rollout-plan)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Overview
+
+Remove every Tailscale-specific surface from the Helm chart and the
+webhook IP-allowlist middleware from the binary, per INV-0016's
+concluded findings: the middleware is spoofable behind every proxy we
+document, the sidecar path already forces it fail-open, and source-IP
+enforcement belongs at the edge layer that sees the true source
+address. Ingress becomes operator-owned and is documented as an
+**options matrix** (`docs/operations/ingress.md`) — no crowned winner,
+per-option validation checkboxes. HMAC remains the sole app-layer
+defense; OTEL (IMPL-0023) observes whichever edge the operator chose.
+
+## Goals and Non-Goals
+
+### Goals
+
+- Delete the chart's `tailscale.*` surface: values block, sidecar
+  container, volumes, serve-config ConfigMap, RBAC, env fork, tests.
+- Delete the chart's `webhookIPAllowlist.*` values and env wiring.
+- Delete `internal/webhook/allowlist.go` (+ test), its `main.go`
+  wiring, and the three config knobs across env + HCL
+  (`WEBHOOK_IP_ALLOWLIST`, `WEBHOOK_IP_ALLOWLIST_FAIL_OPEN`,
+  `TRUST_PROXY_HEADERS`).
+- Fail loudly for operators still carrying the removed config:
+  HCL strict decode at binary startup, values rejection at chart
+  render, both pointing at a migration note.
+- Ship `docs/operations/ingress.md` as the seven-row options matrix
+  from INV-0016 with per-option recipes and validation checkboxes.
+- Rewrite SECURITY.md's webhook trust model; supersede INV-0001,
+  DESIGN-0003, DESIGN-0004.
+- Keep the E4 evidence tier and alert catalogue truthful — no matcher
+  that matches nothing, no alert that cannot fire.
+
+### Non-Goals
+
+- **Picking a homelab ingress winner.** The matrix documents; the
+  deployment chooses (INV-0016 Recommendation, decided 2026-08-15).
+- **Building any replacement IP filtering in the app.** The entire
+  point is that the app stops pretending to do this.
+- **Automating CIDR refresh** for the edge allowlists (ALB prefix
+  list, Cloudflare list, ngrok policy). The matrix names the refresh
+  ownership question per option; automation is per-deployment
+  tooling (e.g. Terraform), not repo-guardian scope.
+- **Validating matrix rows.** Checkboxes get checked when an option
+  is exercised against a real GitHub App delivery, not in this
+  change.
+- **Removing `repo_guardian_webhook_received_total` or the
+  WebhookSilence alert** — webhook liveness is unrelated to ingress
+  choice.
+
+## Background
+
+INV-0016 (Concluded 2026-08-15) established:
+
+- The Tailscale surface is **chart-only**; the binary's webhook
+  handling is ingress-agnostic (Observation 1–2).
+- `tailscale.enabled=true` hard-forces
+  `WEBHOOK_IP_ALLOWLIST_FAIL_OPEN=true` + `TRUST_PROXY_HEADERS=true`
+  (`deployment.yaml:103-113`), so the SECURITY.md "two-layer defense"
+  is one layer on the public-facing path (Observation 3).
+- The middleware validates the **leftmost** (client-controlled)
+  `X-Forwarded-For` entry (`allowlist.go:154`), making it spoofable
+  behind every documented proxy; proxies append the true source to
+  the end of the chain (Observation 5).
+- `TRUST_PROXY_HEADERS` has exactly one consumer (the allowlist
+  constructor); `repo_guardian_webhook_rejected_total` has exactly
+  one producer (the allowlist — the HMAC 401 path increments
+  nothing) (Observation 5).
+- Gateway API reality per path: AWS LBC GA (v2.14.0+); Tailscale
+  operator none (Funnel is `Ingress`-class-only); ngrok operator
+  native; Cloudflare Tunnel via community operators or an
+  operator-injected stateless cloudflared sidecar (Observations
+  6–9).
+
+Precedents this design reuses:
+
+- **IMPL-0016** — remove-the-baked-thing pattern: values-schema
+  rejection of removed identifiers at render time, binary startup
+  error pointing at a migration doc.
+- **IMPL-0018** — `_helpers.tpl` render-time `fail` guards
+  (`validateBackendSecrets`) for values that are set but meaningless.
+- **INV-0010** — `guardian {}` strict decode: removed HCL attributes
+  fail load with "Unsupported argument" by construction; the straight
+  removal (no deprecation shim) was decided in INV-0016.
+- **IMPL-0023** — the generated monitoring tier and its drift gates
+  (`make lint-monitoring`, `TestLogLines_AreStillEmittedByTheBinary`),
+  which force D3's E4 changes to ship in the same PR as D1.
+
+## Detailed Design
+
+### D1: Binary — delete the allowlist middleware
+
+Deletions, verified against the current tree:
+
+| Surface | Location | Notes |
+|---|---|---|
+| Middleware + meta fetcher | `internal/webhook/allowlist.go` (207 LOC) | takes the `api.github.com/meta` outbound dependency, the 24h refresh goroutine, and fail-open/fail-closed semantics with it |
+| Tests | `internal/webhook/allowlist_test.go` (304 LOC) | |
+| Wiring | `cmd/repo-guardian/main.go.wrapWebhookAllowlist` (~line 665) and its call site (~line 188) | the webhook handler mounts directly; no replacement wrapper |
+
+The webhook route keeps its existing otelhttp instrumentation
+(OUTERMOST per the IMPL-0022/0023 transport-ordering contract) and
+the HMAC validation in `webhook.Handler.ServeHTTP`
+(`gh.ValidatePayload` → 401). HMAC is now the only app-layer gate,
+which SECURITY.md states plainly (D7).
+
+### D2: Binary — config-surface removal
+
+Three knobs, each with two surfaces (env + HCL):
+
+- `internal/config/config.go`: drop `WebhookIPAllowlist`,
+  `WebhookIPAllowlistFailOpen`, `TrustProxyHeaders` fields and their
+  `envOrDefaultBool` loads (~lines 63–70, 278–290).
+- `internal/policy/types.go`: drop the three `GuardianConfig` fields
+  (`webhook_ip_allowlist`, `webhook_ip_allowlist_fail_open`,
+  `trust_proxy_headers`).
+- `internal/policy/loader.go`: the INV-0010 lockstep rule applies in
+  reverse — remove all three spots per attribute or the loader
+  breaks: the `guardianBodySchema` entries (~line 378), the
+  `setGuardianAttr` cases (~line 429), and the `mergeGuardianConfig`
+  carries (~line 1167). Plus the `applyEnvOverrides` lines (~line
+  1191) and `internal/policy/defaults.go` (~line 111).
+
+Post-removal behavior (all decided in INV-0016, all intended):
+
+- A `guardian.hcl` still carrying any of the three attributes **fails
+  load** with HCL's "Unsupported argument" diagnostic. No deprecation
+  shim — the loud failure is what strict mode is for.
+- A stale raw env var on a Deployment (e.g. a kustomize patch still
+  setting `TRUST_PROXY_HEADERS=true`) is **silently ignored** — env
+  removal has no rejection surface. The migration note carries this
+  asymmetry.
+
+### D3: Observability disposition
+
+Every consumer of the deleted telemetry, and what happens to it:
+
+- **`metrics.WebhookRejectedTotal`** — sole producer is the deleted
+  middleware. Disposition per Open Question 1 (recommendation:
+  repoint at the HMAC 401 path with `reason="signature"`, making the
+  counter's one remaining reason true and cheap).
+- **`RepoGuardianWebhookRejectionsHigh`**
+  (`internal/monitoring/alert/alert.go:154`) — exists only in the
+  catalogue/generated tier; the chart's PrometheusRule does **not**
+  carry it (verified 2026-08-15), so there is no hand-mirrored copy
+  to keep in step. Under OQ1(a) the alert survives with its
+  `Description` rewritten (the current text promises allowlist 403s
+  that will no longer exist and signature 401s that today never
+  reach the counter). Under OQ1(b/c) the alert is deleted or
+  re-expressed over otelhttp series
+  (`http_server_request_duration_seconds_count` by
+  `http_response_status_code`, the E3 vocabulary).
+- **E4 dashboard** (`internal/monitoring/dashboard/e4.go:33-37`) —
+  `logRejectedIP` ("rejected request from non-GitHub IP") and
+  `logNoIP` stop being emitted; `webhookRejectedRe` reduces to
+  `logInvalidPayload` ("invalid webhook payload"). The webhook
+  panel's description (line ~207, which currently explains
+  allowlist-vs-signature and `TRUST_PROXY_HEADERS` behind Tailscale)
+  is rewritten. `TestLogLines_AreStillEmittedByTheBinary` **fails
+  the build** if the matcher edit doesn't ship in the same PR as D1
+  — the drift gate working as designed, and the reason D1+D3 are one
+  atomic change.
+- **`make lint-monitoring`** — `contrib/generated/` (rules.yaml +
+  repo-guardian-logs.json) regenerates in the same PR or CI goes
+  red.
+- **Replacement signal** for "someone is knocking": otelhttp
+  status-code metrics on the webhook route (401 rate), E4's
+  invalid-payload log line, and each edge's native telemetry (ALB
+  access logs, Cloudflare/Tailscale/ngrok dashboards). Documented in
+  `ingress.md` (D6).
+
+### D4: Chart — delete the Tailscale and allowlist surfaces
+
+| Surface | Location | Action |
+|---|---|---|
+| `webhookIPAllowlist:` block | `values.yaml:174-180` | delete |
+| `tailscale:` block | `values.yaml:182-196` | delete |
+| Env fork + allowlist env | `templates/deployment.yaml:100-113` (`WEBHOOK_IP_ALLOWLIST`, the `tailscale.enabled` fork over `WEBHOOK_IP_ALLOWLIST_FAIL_OPEN`/`TRUST_PROXY_HEADERS`) | delete |
+| Sidecar container + volumes | `templates/deployment.yaml` (tailscale container, `tailscale-state` emptyDir, serve-config mount) | delete |
+| Serve config | `templates/tailscale-configmap.yaml` | delete file |
+| RBAC | `templates/tailscale-rbac.yaml` | delete file |
+| Chart tests | `tests/deployment_test.yaml` sidecar assertions | delete; add negative render tests (D5) |
+| README | `README.md.gotmpl` → `make helm-docs` | regenerated rows disappear; any prose mentioning Tailscale/allowlist updated in the `.gotmpl`, never the rendered README |
+
+### D5: Chart — reject removed values at render time
+
+Both mechanisms from precedent, layered:
+
+1. **`values.schema.json`** — the IMPL-0016 pattern. Add `tailscale`
+   and `webhookIPAllowlist` as explicitly rejected properties (JSON
+   Schema `"not": {}` with a `"description"` naming the migration
+   doc), so machine validation catches them even outside `helm
+   template`. Note INV-0016 Observation 1: `tailscale` never had a
+   schema entry at all, so this is the block's first and last
+   appearance in the schema.
+2. **`_helpers.tpl` `fail` guard** — the IMPL-0018
+   `validateBackendSecrets` pattern, included at the top of
+   `deployment.yaml`: if `.Values.tailscale` or
+   `.Values.webhookIPAllowlist` is present, fail render with a
+   message naming the removed block and the migration doc URL.
+   Schema violations produce JSON-Schema error walls; the helper
+   produces one legible sentence. They fire at different layers
+   (`helm lint`/CI vs render), which is why both exist.
+
+Chart version: per Open Question 3 (recommendation: stay in the rc
+series).
+
+### D6: Documentation — the ingress options matrix
+
+New `docs/operations/ingress.md`, inheriting INV-0016's matrix
+verbatim as its spine:
+
+| Option | Environment fit | K8s routing API | Source-IP enforcement | Cost | Validated |
+|---|---|---|---|---|---|
+| AWS LBC + Gateway API (`HTTPRoute` → ALB) | EKS / production | Gateway API | SG + GitHub prefix list, fail-closed | AWS | ☐ |
+| Tailscale operator Funnel | homelab / tailnet clusters | `Ingress` (class `tailscale`) | none — HMAC-only, stated plainly | free | ☐ |
+| Cloudflare Tunnel, operator-injected cloudflared sidecar | homelab / any cluster | none (edge → pod) | CF WAF allowlist, fail-closed | free + owned domain | ☐ |
+| Cloudflare Tunnel via community operator (cfgate / lexfrei) | homelab / any cluster | Gateway API | CF WAF allowlist, fail-closed | free + owned domain | ☐ |
+| Cloudflare Tunnel via STRRL controller | homelab / any cluster | `Ingress` (class `cloudflare-tunnel`) | CF WAF allowlist, fail-closed | free + owned domain | ☐ |
+| ngrok Kubernetes operator | homelab / any cluster | Gateway API + `Ingress` | `restrict-ips` Traffic Policy, fail-closed | ~$20/mo | ☐ |
+| ngrok CLI / `cloudflared` quick tunnel against localhost | local dev (`make run-local` + docker-compose dev services) | n/a | none (ngrok policy is paid) | free | ☑ ngrok; ☐ quick tunnel |
+
+Per-option sections carry: the recipe (manifests/annotations/policy
+snippets), what sets `X-Forwarded-For` (telemetry-only post-removal),
+the source-IP enforcement setup where one exists, the CIDR-refresh
+ownership note for static allowlists, and the observability story
+(which edge-native signal plus which repo-guardian OTEL series answer
+"is traffic arriving / being rejected"). A closing section documents
+the checkbox contract: a box is checked only after the option carries
+a real GitHub App delivery end-to-end.
+
+### D7: Historical-doc supersession
+
+- **SECURITY.md** — the "two-layer defense" and Tailscale/Funnel
+  sections are rewritten: HMAC is the app-layer boundary; source-IP
+  enforcement is the operator's edge layer per `ingress.md`; the
+  removed middleware's history gets one paragraph pointing at
+  INV-0016 (including the spoofability finding, so nobody
+  reintroduces it as a "cheap second layer").
+- **INV-0001, DESIGN-0003** — superseded banners pointing at
+  INV-0016 + this design (docz status untouched; these are
+  historical records).
+- **DESIGN-0004** — status → Superseded (it designed the middleware
+  being deleted).
+- **`docs/operations/ent-setup.md`** and the chart's
+  `homelab-smoke.md` — Tailscale-sidecar references replaced with a
+  pointer to `ingress.md`.
+
+## API / Interface Changes
+
+- **Removed env vars:** `WEBHOOK_IP_ALLOWLIST`,
+  `WEBHOOK_IP_ALLOWLIST_FAIL_OPEN`, `TRUST_PROXY_HEADERS` (ignored
+  if still set — the asymmetry is documented).
+- **Removed HCL attributes** on `guardian {}`:
+  `webhook_ip_allowlist`, `webhook_ip_allowlist_fail_open`,
+  `trust_proxy_headers` (fail load if still present).
+- **Removed chart values:** `tailscale.*`, `webhookIPAllowlist.*`
+  (fail render if still present).
+- **Metric:** `repo_guardian_webhook_rejected_total{reason}` — per
+  OQ1; under (a) the `ip_not_allowed`/`allowlist_unavailable` reasons
+  disappear and `signature` appears.
+- **No Go interface changes.** `github.Client`, `Store`, `Queue`,
+  the reconcilers, and the webhook `Handler` signature are untouched;
+  no mock regeneration needed.
+
+## Data Model
+
+None. No store schema, queue payload, or policy-version-relevant
+changes — `policy.Version` hashes the policy struct, and removing
+`GuardianConfig` fields changes the hash exactly once at upgrade,
+which re-enqueues the fleet on the next sweep: harmless and expected
+(same class as any policy edit; note it in the migration doc so the
+post-upgrade sweep burst isn't mistaken for a bug).
+
+## Testing Strategy
+
+- **Loader regression:** a test asserting that a `guardian {}` block
+  containing `webhook_ip_allowlist = true` fails `Load` with
+  "Unsupported argument" — pinning the intended breakage so a future
+  schema addition can't silently resurrect the attribute. Verify
+  non-vacuously (add the attribute back to the schema, watch the
+  test fail, remove it).
+- **Chart negative tests:** helm-unittest cases asserting render
+  failure for `tailscale.enabled=true` and
+  `webhookIPAllowlist.enabled=true` with the migration message
+  (extend `tests/values_guard_test.yaml`, the IMPL-0018 suite), plus
+  removal of the sidecar assertions from `deployment_test.yaml`.
+- **Monitoring drift gates (existing, load-bearing):**
+  `TestLogLines_AreStillEmittedByTheBinary` forces the E4 matcher
+  edit; `make lint-monitoring` forces `contrib/generated/`
+  regeneration; `make lint-alerts-contrib` re-parses the generated
+  rules. No new machinery needed — the design leans on gates
+  IMPL-0023 already built.
+- **OQ1(a) case:** if the counter is repointed, a handler test
+  asserting the 401 path increments
+  `webhook_rejected_total{reason="signature"}` exactly once
+  (`testutil.ToFloat64`), and the webhook 202 contract tests keep
+  passing unchanged.
+- **Render sweep:** `helm template` output diffed for exactly the
+  expected deletions (no sidecar container, no allowlist env, no
+  tailscale volumes/ConfigMap/RBAC) — the PR #67 namespace-stamping
+  check pattern.
+
+## Migration / Rollout Plan
+
+1. **One release, both halves.** Binary and chart ship together
+   (per OQ4 recommendation): appVersion bump `minor`, chart bump per
+   OQ3. Shipping the chart removal against an old binary would leave
+   the allowlist enabled-by-default with no values to disable it;
+   shipping the binary first would strand chart values that render
+   env vars the binary ignores. Atomic is simpler than either skew.
+2. **Operator steps, in the migration note** (placement per OQ2):
+   remove `tailscale.*` and `webhookIPAllowlist.*` from values;
+   remove the three `guardian.hcl` attributes; delete any stale env
+   patches (silently ignored, but confusing to future readers);
+   stand up the chosen `ingress.md` option **before** upgrading (the
+   old sidecar path dies with the upgrade — for the homelab that
+   means the Funnel `Ingress` or cloudflared sidecar must be
+   receiving deliveries first).
+3. **Failure modes are loud and immediate:** stale values → render
+   failure with the migration message; stale HCL → startup failure
+   with "Unsupported argument". Both precede any traffic impact.
+4. **Post-upgrade expectations, documented:** one full-fleet
+   re-enqueue from the policy-hash change (Data Model note); webhook
+   delivery gap during cutover recovered by the stale sweep
+   (INV-0016 Observation 9 — the system tolerates missed webhooks by
+   design, but GitHub's recent-deliveries view is the place to
+   redeliver anything urgent).
+5. **Rollback:** re-deploy the previous chart+binary pair and
+   restore the removed values/attrs. No data migration in either
+   direction.
+
+## Open Questions
+
+Format: (a) is the recommendation; pick a letter or write in
+**other**.
+
+**1. Disposition of `webhook_rejected_total` and its alert.**
+The deleted middleware is the counter's only producer today; the
+HMAC 401 path increments nothing (INV-0016 Observation 5).
+
+- (a) **Repoint the counter at the HMAC path** — increment
+  `webhook_rejected_total{reason="signature"}` on the 401 branch of
+  `webhook.Handler.ServeHTTP`. One line of producer; the
+  purpose-built low-cardinality counter and the
+  `RepoGuardianWebhookRejectionsHigh` alert survive with a truthful
+  description (which today promises signature visibility that
+  doesn't exist). E4 keeps a bespoke rejection series to graph next
+  to the invalid-payload log line.
+- (b) Delete the counter and alert; re-express rejection monitoring
+  over otelhttp (`http_server_request_duration_seconds_count` by
+  `http_response_status_code`, the E3 vocabulary). One less bespoke
+  metric, but the alert loses the `reason` label and inherits
+  otel-semconv naming risk, and 401-rate-on-one-route is a clumsier
+  alert expression than a purpose-built counter.
+- (c) Delete the counter and alert outright; rejected webhooks are
+  visible only in E4's invalid-payload log line and edge telemetry.
+  Smallest surface, but a silent-HMAC-failure regression (wrong
+  secret after a rotation) would page nobody.
+- other: ____
+
+**2. Where the migration note lives.**
+
+- (a) **A section in `docs/operations/ingress.md` itself** —
+  "Migrating from the baked sidecar" at the top of the doc every
+  affected operator must read anyway; the chart guard message and
+  startup-error pointer both name one URL. One doc owns ingress
+  past, present, and future.
+- (b) Extend `docs/operations/migrations.md` (the IMPL-0016 memory-
+  backend precedent lives there), keeping all breaking-change notes
+  in one file at the cost of splitting ingress reading across two
+  docs.
+- (c) A standalone `docs/operations/ingress-migration.md`,
+  mirroring `template-migration.md`/`annotation-properties-migration.md`
+  precedent — cleanest separation, one more file to eventually
+  tombstone.
+- other: ____
+
+**3. Chart version for the breaking change.**
+
+- (a) **Stay in the rc series (`1.0.0-rc.13`)** — the chart has
+  never shipped a stable 1.0.0; rc semantics permit breaking
+  changes, and every prior breaking rc (IMPL-0016's backend
+  removal, IMPL-0018) did exactly this. The migration note and
+  render guard carry the signal.
+- (b) Jump to `2.0.0-rc.1` to signal loudly in the version number
+  itself — honest semver-major optics, but it majors a chart whose
+  1.0.0 never existed and breaks the rc narrative for the eventual
+  stable cut.
+- (c) Cut `1.0.0` stable first, then `2.0.0-rc.1` with this change —
+  maximal semver correctness, two releases of ceremony for an
+  audience of one deployment fleet.
+- other: ____
+
+**4. Sequencing of the removal.**
+
+- (a) **One atomic PR** — binary + chart + docs + generated
+  monitoring together. The drift gates effectively force D1+D3
+  atomicity already; splitting chart from binary creates the skew
+  states described in Migration step 1, and the whole diff is
+  mostly deletions (~500 LOC Go, ~100 lines chart, plus docs).
+- (b) Two PRs: binary first (middleware + knobs + monitoring), chart
+  + docs second — smaller reviews, but the intermediate state ships
+  a binary that ignores env vars the current chart still renders,
+  and both PRs need the same migration doc.
+- (c) Three phases IMPL-style (binary / chart / docs) — matches the
+  IMPL-0014 cleanup shape, but this change is a fraction of that
+  size and the docs are load-bearing for the other two phases'
+  failure messages.
+- other: ____
+
+**5. Does anything replace the client-IP telemetry?**
+Post-removal, nothing in the app reads `X-Forwarded-For`; the
+`RemoteAddr` behind every documented edge is a proxy/sidecar
+address. INV-0016 flagged Funnel's forwarded-header behavior as
+unverified.
+
+- (a) **Nothing in-app; document per-edge.** otelhttp does not
+  record client IPs in metrics (cardinality), request logs at the
+  edge (ALB access logs, CF, ngrok inspector) are strictly better
+  evidence, and the one consumer that ever cared is being deleted
+  for cause. `ingress.md` notes where each edge's client-IP evidence
+  lives, and the Funnel XFF question stays an empirical checkbox
+  item on that row.
+- (b) Log the leftmost XFF value (clearly labeled untrusted) on the
+  webhook handler's Warn paths only — cheap forensic breadcrumb on
+  rejected requests, at the cost of resurrecting a header read this
+  design just finished calling spoofable, in the exact place a
+  future reader might mistake it for enforcement.
+- other: ____
+
+**6. Does the sidecar image reference survive anywhere as a worked
+example?**
+INV-0016 Observation 9 makes the operator-injected cloudflared
+sidecar a first-class matrix row, and the homelab consumes the chart
+via kustomize+helm in ArgoCD.
+
+- (a) **Yes — ship a complete kustomize strategic-merge patch example
+  in `ingress.md`** for the cloudflared sidecar row (container,
+  token Secret reference, pinned+renovate-annotated image), so the
+  first operator to validate that row starts from a copy-pasteable
+  patch that already has the supply-chain hygiene the old sidecar
+  lacked. The chart itself stays ingress-free.
+- (b) No example manifests in `ingress.md` — links to vendor docs
+  only. Less to maintain, but every operator re-derives the same
+  patch and the hygiene lessons (pinned image, no `:latest`) don't
+  carry.
+- other: ____
+
+## References
+
+- [INV-0016](../investigation/0016-retire-the-baked-tailscale-sidecar-for-operator-managed-ingress.md) — the concluded investigation this design executes (Observations 1–9, options matrix, straight-removal decision)
+- [DESIGN-0004](0004-github-webhook-ip-allowlist-middleware.md) — the middleware being removed (to be marked Superseded)
+- [DESIGN-0003](0003-tailscale-integration-research.md) — the sidecar being removed (supersession pointer)
+- [INV-0001](../investigation/0001-tailscale-funnel-for-webhook-testing.md) — the Funnel origin (supersession pointer)
+- [IMPL-0016](../impl/0016-deprecate-memory-backend.md) — the remove-the-baked-thing precedent (schema rejection + migration pointer)
+- IMPL-0018 — `_helpers.tpl` `fail`-guard precedent (`validateBackendSecrets`)
+- `SECURITY.md` — the two-layer webhook narrative being rewritten
+- `internal/monitoring/dashboard/e4.go` / `internal/monitoring/alert/alert.go` — the E4 matchers and `RepoGuardianWebhookRejectionsHigh` catalogue entry (D3)
+- Provider references: see INV-0016's References section (Tailscale operator/Funnel, AWS LBC Gateway API GA, ngrok operator + Traffic Policy, Cloudflare Tunnel + WAF, cfgate/lexfrei/STRRL controllers)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -54,4 +54,5 @@ docz create design "Your Design Title"
 | DESIGN-0020 | Absent check mode and conditional file rules | Implemented | 2026-07-23 | Donald Gifford | [0020-absent-check-mode-and-conditional-file-rules.md](0020-absent-check-mode-and-conditional-file-rules.md) |
 | DESIGN-0021 | Delayed-requeue job contract and rate-limit consolidation | Implemented | 2026-07-26 | Donald Gifford | [0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md](0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md) |
 | DESIGN-0022 | Compliance posture state, dashboard suite, and OTEL-first observability | Implemented | 2026-08-02 | Donald Gifford | [0022-compliance-posture-state-dashboard-suite-and-otel-first.md](0022-compliance-posture-state-dashboard-suite-and-otel-first.md) |
+| DESIGN-0023 | Operator-owned ingress: remove the Tailscale sidecar and IP-allowlist middleware | Draft | 2026-08-15 | Donald Gifford | [0023-operator-owned-ingress-remove-the-tailscale-sidecar-and-ip.md](0023-operator-owned-ingress-remove-the-tailscale-sidecar-and-ip.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/docs/impl/0024-operator-owned-ingress-remove-the-tailscale-sidecar-and-ip.md
+++ b/docs/impl/0024-operator-owned-ingress-remove-the-tailscale-sidecar-and-ip.md
@@ -1,0 +1,454 @@
+---
+id: IMPL-0024
+title: "Operator-owned ingress: remove the Tailscale sidecar and IP-allowlist middleware"
+status: Draft
+author: Donald Gifford
+created: 2026-08-15
+---
+<!-- markdownlint-disable-file MD025 MD041 -->
+
+# IMPL 0024: Operator-owned ingress: remove the Tailscale sidecar and IP-allowlist middleware
+
+**Status:** Draft
+**Author:** Donald Gifford
+**Date:** 2026-08-15
+
+<!--toc:start-->
+- [Objective](#objective)
+- [Scope](#scope)
+  - [In Scope](#in-scope)
+  - [Out of Scope](#out-of-scope)
+- [Pre-implementation audit (2026-08-15)](#pre-implementation-audit-2026-08-15)
+- [Implementation Phases](#implementation-phases)
+  - [Phase 1: Binary — repoint the counter, delete the middleware, keep the drift gates green](#phase-1-binary--repoint-the-counter-delete-the-middleware-keep-the-drift-gates-green)
+    - [Tasks](#tasks)
+    - [Success Criteria](#success-criteria)
+  - [Phase 2: Chart — delete the surfaces, guard the removed values, cut 1.0.0](#phase-2-chart--delete-the-surfaces-guard-the-removed-values-cut-100)
+    - [Tasks](#tasks-1)
+    - [Success Criteria](#success-criteria-1)
+  - [Phase 3: Docs — ingress matrix, trust-model rewrite, supersession sweep](#phase-3-docs--ingress-matrix-trust-model-rewrite-supersession-sweep)
+    - [Tasks](#tasks-2)
+    - [Success Criteria](#success-criteria-2)
+  - [Phase 4: Ship — atomic PR, release verification](#phase-4-ship--atomic-pr-release-verification)
+    - [Tasks](#tasks-3)
+    - [Success Criteria](#success-criteria-3)
+- [File Changes](#file-changes)
+- [Testing Plan](#testing-plan)
+- [Dependencies](#dependencies)
+- [Open Questions](#open-questions)
+- [References](#references)
+<!--toc:end-->
+
+## Objective
+
+Execute DESIGN-0023: delete the chart's Tailscale sidecar surface and
+the binary's webhook IP-allowlist middleware, fail loudly on stale
+config at chart render and binary startup, repoint
+`webhook_rejected_total` at the HMAC path, and ship
+`docs/operations/ingress.md` as the options matrix. One atomic PR
+(DESIGN-0023 OQ4 = a); appVersion `minor`; chart **`1.0.0` stable**
+(OQ3).
+
+**Implements:** DESIGN-0023 (from INV-0016, Concluded)
+
+## Scope
+
+### In Scope
+
+- Binary: `internal/webhook/allowlist.go` (+test) deletion, `main.go`
+  wiring, three config knobs across env + HCL, metric repoint
+  (`reason="signature"`), alert description rewrite, E4 matcher
+  reduction, generated-monitoring regeneration.
+- Chart: `tailscale.*` + `webhookIPAllowlist.*` removal, render
+  guards (schema + `_helpers.tpl`), tests, examples, NOTES.txt,
+  README regeneration, `version: 1.0.0` / `appVersion: "1.14.0"`.
+- Docs: `docs/operations/ingress.md` (matrix + migration section +
+  recipes), SECURITY.md rewrite, `policy-reference.md` attr removal,
+  supersession sweep, CLAUDE.md updates.
+
+### Out of Scope
+
+- Validating any matrix row (checkboxes are checked by later
+  operator work, not this PR).
+- CIDR-refresh automation for edge allowlists.
+- Any change to webhook liveness telemetry
+  (`webhook_received_total`, WebhookSilence alert).
+- Go interface changes / mock regeneration (none needed — verified:
+  no `github.Client`/`Store`/`Queue` surface moves).
+
+## Pre-implementation audit (2026-08-15)
+
+Code audit against DESIGN-0023's assumptions, per the standing
+pre-IMPL pattern. Confirmations and deltas the design didn't name:
+
+- **Go files touching the three knobs** (design named 5; audit found
+  10): `cmd/repo-guardian/main.go`, `internal/config/config.go` +
+  `config_test.go`, `internal/monitoring/dashboard/e4.go`,
+  `internal/policy/{types,loader,defaults}.go` **+ all three test
+  files** (`types_test.go`, `loader_test.go`, `defaults_test.go`).
+- **`templates/NOTES.txt`** has a `tailscale.enabled` block (webhook
+  URL + `tailscale status` command) the design missed — delete and
+  replace with an `ingress.md` pointer.
+- **`values.schema.json` contains NEITHER block today** — the schema
+  tolerates unknown keys, so D5's rejection entries are additions,
+  not edits.
+- **Both example values files carry `webhookIPAllowlist:` blocks**
+  (`examples/values-with-policy.yaml:153`,
+  `values-multi-org.yaml:100`) and `examples/examples_test.go`
+  exercises them — they would fail the new render guard if not
+  stripped in the same PR.
+- **`docs/usage/policy-reference.md`** documents all three guardian
+  attrs (lines ~69–71) and the env-mapping rows (~637–638).
+- **E4** (`e4.go:33-39`): `logRejectedIP`, `logNoIP` fold out of
+  `webhookRejectedRe`; `logInvalidPayload` and `logEnqueueFailed`
+  (and `webhookIncidentsRe`) survive; the comment block above the
+  consts describes the two-layer split and needs rewriting.
+- **The chart's PrometheusRule does not carry
+  `RepoGuardianWebhookRejectionsHigh`** — catalogue/generated tier
+  only; no hand-mirror to keep in step.
+- **docz `design` statuses have no `Superseded`** (Draft / In Review
+  / Approved / Implemented / Abandoned) → Open Question 1.
+- **GHCR has no published chart `1.0.0`** (verified via anonymous
+  `helm show chart`); ECR check is a Phase 4 task.
+
+## Implementation Phases
+
+Each phase builds on the previous one. A phase is complete when all
+its tasks are checked off and its success criteria are met. Tasks
+are ordered so the tree stays green (`make lint && make test`) after
+every task — in particular 1.2 bundles the deletion with the E4
+matcher edit because `TestLogLines_AreStillEmittedByTheBinary` fails
+the moment a matched log line stops being emitted.
+
+---
+
+### Phase 1: Binary — repoint the counter, delete the middleware, keep the drift gates green
+
+Removes the middleware and its config surface while keeping every
+IMPL-0023 drift gate green at each step. The counter gains its new
+producer *before* losing its old one, so
+`repo_guardian_webhook_rejected_total` never has zero producers on
+any commit.
+
+#### Tasks
+
+- [ ] 1.1 Repoint `webhook_rejected_total`: increment
+  `metrics.WebhookRejectedTotal.WithLabelValues("signature")` on the
+  401 branch of `webhook.Handler.ServeHTTP`
+  (`internal/webhook/handler.go:86-92`); update the metric's help
+  text in `internal/metrics/metrics.go:177-180` ("rejected by IP
+  allowlist" → "rejected (signature validation)"); handler test
+  asserting exactly-once increment via `testutil.ToFloat64` and that
+  the 202 contract tests still pass.
+- [ ] 1.2 Delete `internal/webhook/allowlist.go` and
+  `allowlist_test.go`; remove `wrapWebhookAllowlist` and its call
+  site from `cmd/repo-guardian/main.go` (~665, ~188 — handler mounts
+  directly, otelhttp stays OUTERMOST); in the same commit reduce E4:
+  drop `logRejectedIP`/`logNoIP` from `e4.go`, reduce
+  `webhookRejectedRe` to `logInvalidPayload`, rewrite the const
+  comment block and the webhook panel description (~207, currently
+  explains allowlist-vs-signature + `TRUST_PROXY_HEADERS` behind
+  Tailscale); run `make monitoring-generate` and commit
+  `contrib/generated/` in the same commit.
+- [ ] 1.3 Rewrite `RepoGuardianWebhookRejectionsHigh`'s
+  `Description` (`internal/monitoring/alert/alert.go:154` — the
+  current text promises allowlist 403s that no longer exist);
+  regenerate; `make lint-monitoring lint-alerts-contrib` green.
+- [ ] 1.4 Remove the env knobs from `internal/config/config.go`
+  (`WebhookIPAllowlist`, `WebhookIPAllowlistFailOpen`,
+  `TrustProxyHeaders` fields; `envOrDefaultBool` loads ~278-290);
+  update `config_test.go`.
+- [ ] 1.5 Remove the HCL attrs — the INV-0010 lockstep in reverse,
+  all three spots per attribute: `guardianBodySchema` (~378),
+  `setGuardianAttr` (~429), `mergeGuardianConfig` (~1167), plus
+  `applyEnvOverrides` (~1191) and `defaults.go` (~111); update
+  `types.go`, `types_test.go`, `loader_test.go`, `defaults_test.go`.
+- [ ] 1.6 Add the loader regression test: a `guardian {}` block
+  containing `webhook_ip_allowlist = true` fails `Load` with
+  "Unsupported argument". **Verify non-vacuously**: re-add the
+  attribute to `guardianBodySchema`, watch the test fail, remove it
+  (back up first per standing practice).
+- [ ] 1.7 (Per Open Question 2 decision) startup `slog.Warn` when
+  any of the three removed env vars is still set, naming
+  `docs/operations/ingress.md` — or skip this task if OQ2 = b.
+
+#### Success Criteria
+
+- `grep -rn "WebhookIPAllowlist\|TrustProxyHeaders\|WEBHOOK_IP_ALLOWLIST\|TRUST_PROXY_HEADERS\|webhook_ip_allowlist\|trust_proxy_headers" internal/ cmd/ --include='*.go'`
+  returns only the OQ2 warn strings (if 1.7 taken) and nothing else.
+- `make ci` green; `TestLogLines_AreStillEmittedByTheBinary`,
+  `make lint-monitoring`, `make lint-alerts-contrib` all green.
+- The loader regression test exists and has been proven non-vacuous.
+- `webhook_rejected_total{reason="signature"}` increments on a
+  bad-signature POST (handler test) and no other reason value is
+  producible.
+
+---
+
+### Phase 2: Chart — delete the surfaces, guard the removed values, cut 1.0.0
+
+The chart half of the atomic change. Guards land before version
+bump so the negative tests exercise the final message text.
+
+#### Tasks
+
+- [ ] 2.1 `values.yaml`: delete the `webhookIPAllowlist:` block
+  (~174-180) and the `tailscale:` block (~182-196).
+- [ ] 2.2 `templates/deployment.yaml`: delete the
+  `WEBHOOK_IP_ALLOWLIST` env, the `tailscale.enabled` env fork
+  (~100-113), the tailscale sidecar container, the
+  `tailscale-state` emptyDir + serve-config volumes/mounts.
+- [ ] 2.3 Delete `templates/tailscale-configmap.yaml` and
+  `templates/tailscale-rbac.yaml`; remove the `tailscale.enabled`
+  block from `templates/NOTES.txt` (webhook-URL guidance now points
+  at `docs/operations/ingress.md`).
+- [ ] 2.4 `_helpers.tpl`: add a `repo-guardian.validateRemovedValues`
+  guard (IMPL-0018 `validateBackendSecrets` pattern, included at the
+  top of `deployment.yaml`): if `.Values.tailscale` or
+  `.Values.webhookIPAllowlist` is present, `fail` with the removed
+  block's name and the migration URL
+  (`docs/operations/ingress.md#migrating-from-the-baked-sidecar`).
+- [ ] 2.5 `values.schema.json`: add explicit rejection entries
+  (`"not": {}` with `"description"` naming the migration doc) for
+  `tailscale` and `webhookIPAllowlist` — first appearance of either
+  key in the schema (audit note).
+- [ ] 2.6 Tests: remove the 4 tailscale assertions from
+  `tests/deployment_test.yaml`; add negative cases to
+  `tests/values_guard_test.yaml` (`tailscale.enabled=true` and
+  `webhookIPAllowlist.enabled=true` each fail render with the
+  migration message) plus a positive default-values render case.
+- [ ] 2.7 Strip the `webhookIPAllowlist:` blocks from
+  `examples/values-with-policy.yaml` (~153) and
+  `examples/values-multi-org.yaml` (~100); `examples_test.go` green.
+- [ ] 2.8 `Chart.yaml`: `version: 1.0.0`, `appVersion: "1.14.0"`
+  (next minor after 1.13.0 — re-verify at PR time per the IMPL-0017
+  appVersion-vs-tag lesson); `make helm-docs` (README regenerates
+  from `.gotmpl` — never edit the rendered README).
+
+#### Success Criteria
+
+- `helm template` with default values renders no tailscale
+  artifacts, no allowlist env vars, and every resource carries
+  `namespace: {{ .Release.Namespace }}` (PR #67 sweep:
+  `helm template ... | grep -E '^kind:|^  namespace:'`).
+- helm-unittest fully green including the new negative guard cases;
+  the guard message names the migration URL (asserted, not assumed).
+- `make lint-alerts-chart` green (chart PrometheusRule untouched but
+  the gate re-verified).
+- `grep -rin "tailscale\|webhookIPAllowlist" charts/repo-guardian/`
+  matches only `CHANGELOG.md` (generated history) and the guard
+  strings in `_helpers.tpl`/`values.schema.json`.
+
+---
+
+### Phase 3: Docs — ingress matrix, trust-model rewrite, supersession sweep
+
+Everything the failure messages point at must exist before the PR
+merges — the guards from Phases 1–2 reference `ingress.md`, so this
+phase is load-bearing, not cleanup.
+
+#### Tasks
+
+- [ ] 3.1 Create `docs/operations/ingress.md`: "Migrating from the
+  baked sidecar" section first (DESIGN-0023 OQ2 = a — operator
+  steps, loud-failure explanations, env-var silent-ignore
+  asymmetry, post-upgrade policy-hash re-enqueue note, webhook-gap
+  recovery via stale sweep); the seven-row options matrix verbatim
+  from DESIGN-0023 D6; per-option recipe sections including the
+  complete kustomize strategic-merge patch for the cloudflared
+  sidecar (pinned digest + renovate-style comment, tunnel-token
+  Secret ref — OQ6 = a) and each row's source-IP setup,
+  X-Forwarded-For note, CIDR-refresh ownership, and observability
+  story; closing checkbox contract.
+- [ ] 3.2 Rewrite SECURITY.md's webhook sections: HMAC is the
+  app-layer boundary; source-IP enforcement is operator-owned per
+  `ingress.md`; one history paragraph pointing at INV-0016 with the
+  spoofability finding (so the middleware doesn't get reintroduced
+  as a "cheap second layer").
+- [ ] 3.3 `docs/usage/policy-reference.md`: remove the three
+  guardian-attr rows (~69-71) and the two env-mapping rows
+  (~637-638).
+- [ ] 3.4 Sweep the remaining live docs: `docs/operations/
+  ent-setup.md`, `docs/index.md`, `docs/README.md`,
+  `contrib/README.md` — replace Tailscale/allowlist references with
+  `ingress.md` pointers (historical design/impl docs stay
+  untouched).
+- [ ] 3.5 Supersession: DESIGN-0004 and DESIGN-0003 get status +
+  banner per Open Question 1's decision; INV-0001 gets a banner
+  pointing at INV-0016 (status stays Concluded); `docz update
+  design` / `docz update inv`.
+- [ ] 3.6 CLAUDE.md: remove the "Webhook IP allowlist" and
+  "Tailscale Funnel" key-design-pattern bullets, update the
+  `webhook/` architecture line (drop "IP allowlist middleware"),
+  and add a short entry recording this change's contracts (HMAC
+  sole app layer; `reason="signature"`; removed knobs fail
+  load/render).
+- [ ] 3.7 `docz update impl` + `docz wiki update`; `make
+  lint-docs`-equivalent checks if present (yamllint/markdownlint
+  via existing make targets).
+
+#### Success Criteria
+
+- Repo-wide `grep -ril tailscale` outside `docs/{design,impl,investigation,rfc,adr}/`
+  and chart CHANGELOG matches only `ingress.md` and SECURITY.md
+  (both intentional).
+- Every URL emitted by a Phase 1–2 failure path resolves to a real
+  heading in `ingress.md`.
+- mkdocs nav includes `ingress.md`; docz indexes regenerated
+  cleanly.
+
+---
+
+### Phase 4: Ship — atomic PR, release verification
+
+The release-side checklist, including the two items that fail
+*silently* if skipped (post-mortem discipline).
+
+#### Tasks
+
+- [ ] 4.1 Full local gate: `make ci`, `helm-unittest`, `make
+  lint-monitoring lint-alerts-contrib lint-alerts-chart`; confirm no
+  mock regeneration needed (no interface diffs in `git diff
+  --stat`).
+- [ ] 4.2 **Verify no chart `1.0.0` exists in ECR** (GHCR already
+  verified clean 2026-08-15): `helm show chart oci://<ECR>/
+  repo-guardian-chart --version 1.0.0` (or `aws ecr
+  describe-images`) — required because the publish workflow's `helm
+  pull` idempotency precheck *silently skips* publishing over an
+  existing version.
+- [ ] 4.3 Re-verify `appVersion` against the tag the `minor` label
+  will actually cut (IMPL-0017 lesson) — if a release landed since,
+  adjust `appVersion` before merge.
+- [ ] 4.4 Open the single atomic PR with the `minor` label; body
+  carries the migration summary and the breaking-change callouts.
+- [ ] 4.5 Post-merge: confirm the push-triggered `release.yml` run
+  **creates jobs** (startup_failure is silent — post-mortem), then
+  v1.14.0 tag exists, chart `1.0.0` published to GHCR **and** ECR,
+  both signed with provenance attached.
+- [ ] 4.6 Flip DESIGN-0023 → Implemented, IMPL-0024 → Completed;
+  `docz update design` / `docz update impl`.
+
+#### Success Criteria
+
+- Release run created jobs and completed; v1.14.0 tag on the merge
+  commit; chart `1.0.0` pullable from both registries; cosign
+  verification passes.
+- A `helm upgrade` with old values fails render with the migration
+  message; a binary started against an old `guardian.hcl` exits
+  with "Unsupported argument" — both confirmed once against real
+  artifacts, not only unit tests.
+- Docs statuses flipped; indexes regenerated.
+
+---
+
+## File Changes
+
+| File | Action | Description |
+|------|--------|-------------|
+| `internal/webhook/allowlist.go` / `allowlist_test.go` | Delete | middleware + meta fetcher + tests (511 LOC) |
+| `internal/webhook/handler.go` (+ test) | Modify | 401 branch increments `webhook_rejected_total{reason="signature"}` |
+| `internal/metrics/metrics.go` | Modify | counter help text |
+| `cmd/repo-guardian/main.go` | Modify | drop `wrapWebhookAllowlist` + call site (+ OQ2 warn if taken) |
+| `internal/config/config.go` (+ test) | Modify | drop three env knobs |
+| `internal/policy/{types,loader,defaults}.go` (+ 3 tests) | Modify | drop three HCL attrs (lockstep ×3 spots each) + regression test |
+| `internal/monitoring/dashboard/e4.go` | Modify | matcher reduction + panel description |
+| `internal/monitoring/alert/alert.go` | Modify | WebhookRejectionsHigh description |
+| `contrib/generated/**` | Regenerate | `make monitoring-generate` |
+| `charts/repo-guardian/values.yaml`, `values.schema.json`, `Chart.yaml` | Modify | blocks deleted; rejections added; `1.0.0` / `1.14.0` |
+| `charts/repo-guardian/templates/{deployment.yaml,NOTES.txt,_helpers.tpl}` | Modify | env fork + sidecar + volumes out; guard in |
+| `charts/repo-guardian/templates/tailscale-{configmap,rbac}.yaml` | Delete | 59 lines |
+| `charts/repo-guardian/tests/{deployment_test,values_guard_test}.yaml` | Modify | assertions out; negative guards in |
+| `examples/values-{with-policy,multi-org}.yaml` | Modify | strip `webhookIPAllowlist:` blocks |
+| `docs/operations/ingress.md` | Create | migration section + options matrix + recipes |
+| `SECURITY.md`, `docs/usage/policy-reference.md`, `docs/operations/ent-setup.md`, `docs/index.md`, `docs/README.md`, `contrib/README.md`, `CLAUDE.md` | Modify | trust-model rewrite + reference sweep |
+| `docs/design/0003-*`, `0004-*`, `docs/investigation/0001-*` | Modify | supersession (per OQ1) |
+| `.docz.yaml` | Modify (if OQ1 = a) | add `Superseded` to design statuses |
+
+## Testing Plan
+
+- [ ] Handler test: bad signature → 401 + exactly-once
+  `reason="signature"` increment (`testutil.ToFloat64`); 202
+  contract untouched.
+- [ ] Loader regression: stale attr → "Unsupported argument",
+  proven non-vacuous by temporary schema re-add.
+- [ ] helm-unittest: negative guard cases assert the migration
+  message text; positive default render; sidecar assertions
+  removed.
+- [ ] Drift gates (existing): `TestLogLines_AreStillEmittedByTheBinary`,
+  `make lint-monitoring`, `make lint-alerts-contrib`,
+  `make lint-alerts-chart`.
+- [ ] Render sweep: `helm template | grep -E '^kind:|^  namespace:'`
+  (PR #67 pattern) + absence grep for tailscale/allowlist strings.
+- [ ] `examples_test.go` green after example strips.
+- [ ] End-to-end negative checks against real artifacts in Phase 4
+  (old values → render failure; old HCL → startup failure).
+
+## Dependencies
+
+- PR #180 (INV-0016) and the DESIGN-0023 PR merge first — this
+  IMPL's failure messages and supersession banners reference both.
+- No Go module, tool, or schema-migration dependencies. No mock
+  regeneration (no interface changes).
+- Phase 4.2 needs ECR read access (AWS credentials) — operator-side
+  step if CI credentials aren't at hand.
+
+## Open Questions
+
+Format: (a) is the recommendation; pick a letter or write in
+**other**.
+
+**1. How do DESIGN-0003 and DESIGN-0004 record supersession?**
+The docz `design` status list has no `Superseded` (audit finding);
+RFC and ADR types both have it.
+
+- (a) **Add `Superseded` to the design statuses in `.docz.yaml`**
+  and set both docs to it, with a banner naming DESIGN-0023. One
+  config line; the design lifecycle gains the state it evidently
+  needs (this is the second time a design has been superseded in
+  practice), and the README index shows the truth at a glance.
+- (b) Banner-only: leave both docs at their current status, add a
+  prominent "Superseded by DESIGN-0023" banner under the H1. No
+  config change, but the index table keeps listing a dead design as
+  Approved/Implemented.
+- (c) Set them to `Abandoned` — exists today, but semantically wrong
+  (the designs shipped and served; they weren't abandoned).
+- other: ____
+
+**2. Should the binary warn when the removed env vars are still
+set?**
+The HCL and chart surfaces fail loudly, but a stale
+`TRUST_PROXY_HEADERS=true` env patch is silently ignored
+(DESIGN-0023 documented the asymmetry; this question is whether to
+soften it).
+
+- (a) **Yes — one `slog.Warn` at startup** listing whichever of the
+  three removed vars are set, pointing at
+  `docs/operations/ingress.md`. ~10 lines plus a test; turns the
+  one silent migration edge into a logged one, and E4's evidence
+  tier picks it up for free. Remove the warn in a future major as
+  a tombstone.
+- (b) No — the design documented the asymmetry, the migration note
+  covers it, and startup warnings for env vars the binary no longer
+  knows about set a precedent of keeping ghost knowledge around.
+- other: ____
+
+**3. Does the E4 webhook "Rejections by message" panel survive?**
+Its matcher reduces to the single `invalid webhook payload` line.
+
+- (a) **Keep the panel** with the reduced matcher and a rewritten
+  description ("signature rejections only; source-IP rejections now
+  happen at the operator's edge — see ingress.md"). A wrong-secret
+  incident after rotation is exactly when an operator looks at E4,
+  and the panel now graphs precisely that.
+- (b) Fold it away: delete the panel, keep the line only in the
+  broader incidents panel (`webhookIncidentsRe`). One less panel,
+  but the highest-signal failure mode loses its dedicated view.
+- other: ____
+
+## References
+
+- [DESIGN-0023](../design/0023-operator-owned-ingress-remove-the-tailscale-sidecar-and-ip.md) — the design this implements (all six design OQs decided 2026-08-15)
+- [INV-0016](../investigation/0016-retire-the-baked-tailscale-sidecar-for-operator-managed-ingress.md) — Observations 1–9, options matrix, straight-removal decision
+- [IMPL-0016](0016-deprecate-memory-backend.md) — remove-the-baked-thing precedent
+- [IMPL-0003](0003-github-webhook-ip-allowlist-middleware.md) — the middleware's original implementation (historical)
+- CLAUDE.md — INV-0010 guardian strict-decode lockstep; IMPL-0023 drift gates; PR #67 namespace sweep; IMPL-0017 appVersion-vs-tag lesson; release post-mortem (startup_failure is silent)

--- a/docs/impl/0024-operator-owned-ingress-remove-the-tailscale-sidecar-and-ip.md
+++ b/docs/impl/0024-operator-owned-ingress-remove-the-tailscale-sidecar-and-ip.md
@@ -148,7 +148,8 @@ any commit.
   `webhookRejectedRe` to `logInvalidPayload`, rewrite the const
   comment block and the webhook panel description (~207, currently
   explains allowlist-vs-signature + `TRUST_PROXY_HEADERS` behind
-  Tailscale); run `make monitoring-generate` and commit
+  Tailscale — the panel itself survives, OQ3 = a); run
+  `make monitoring-generate` and commit
   `contrib/generated/` in the same commit.
 - [ ] 1.3 Rewrite `RepoGuardianWebhookRejectionsHigh`'s
   `Description` (`internal/monitoring/alert/alert.go:154` — the
@@ -168,14 +169,15 @@ any commit.
   "Unsupported argument". **Verify non-vacuously**: re-add the
   attribute to `guardianBodySchema`, watch the test fail, remove it
   (back up first per standing practice).
-- [ ] 1.7 (Per Open Question 2 decision) startup `slog.Warn` when
-  any of the three removed env vars is still set, naming
-  `docs/operations/ingress.md` — or skip this task if OQ2 = b.
+- [ ] 1.7 (OQ2 = a) startup `slog.Warn` when any of the three
+  removed env vars is still set, naming
+  `docs/operations/ingress.md`; test with `t.Setenv` (no
+  `t.Parallel`).
 
 #### Success Criteria
 
 - `grep -rn "WebhookIPAllowlist\|TrustProxyHeaders\|WEBHOOK_IP_ALLOWLIST\|TRUST_PROXY_HEADERS\|webhook_ip_allowlist\|trust_proxy_headers" internal/ cmd/ --include='*.go'`
-  returns only the OQ2 warn strings (if 1.7 taken) and nothing else.
+  returns only the 1.7 warn strings and nothing else.
 - `make ci` green; `TestLogLines_AreStillEmittedByTheBinary`,
   `make lint-monitoring`, `make lint-alerts-contrib` all green.
 - The loader regression test exists and has been proven non-vacuous.
@@ -273,10 +275,11 @@ phase is load-bearing, not cleanup.
   `contrib/README.md` — replace Tailscale/allowlist references with
   `ingress.md` pointers (historical design/impl docs stay
   untouched).
-- [ ] 3.5 Supersession: DESIGN-0004 and DESIGN-0003 get status +
-  banner per Open Question 1's decision; INV-0001 gets a banner
-  pointing at INV-0016 (status stays Concluded); `docz update
-  design` / `docz update inv`.
+- [ ] 3.5 Supersession (OQ1 = a): add `Superseded` to the design
+  statuses in `.docz.yaml`; set DESIGN-0004 and DESIGN-0003 to
+  `Superseded` with a banner naming DESIGN-0023; INV-0001 gets a
+  banner pointing at INV-0016 (status stays Concluded); `docz
+  update design` / `docz update inv`.
 - [ ] 3.6 CLAUDE.md: remove the "Webhook IP allowlist" and
   "Tailscale Funnel" key-design-pattern bullets, update the
   `webhook/` architecture line (drop "IP allowlist middleware"),
@@ -348,7 +351,7 @@ The release-side checklist, including the two items that fail
 | `internal/webhook/allowlist.go` / `allowlist_test.go` | Delete | middleware + meta fetcher + tests (511 LOC) |
 | `internal/webhook/handler.go` (+ test) | Modify | 401 branch increments `webhook_rejected_total{reason="signature"}` |
 | `internal/metrics/metrics.go` | Modify | counter help text |
-| `cmd/repo-guardian/main.go` | Modify | drop `wrapWebhookAllowlist` + call site (+ OQ2 warn if taken) |
+| `cmd/repo-guardian/main.go` | Modify | drop `wrapWebhookAllowlist` + call site; add removed-env-var startup warn (OQ2 = a) |
 | `internal/config/config.go` (+ test) | Modify | drop three env knobs |
 | `internal/policy/{types,loader,defaults}.go` (+ 3 tests) | Modify | drop three HCL attrs (lockstep ×3 spots each) + regression test |
 | `internal/monitoring/dashboard/e4.go` | Modify | matcher reduction + panel description |
@@ -362,7 +365,7 @@ The release-side checklist, including the two items that fail
 | `docs/operations/ingress.md` | Create | migration section + options matrix + recipes |
 | `SECURITY.md`, `docs/usage/policy-reference.md`, `docs/operations/ent-setup.md`, `docs/index.md`, `docs/README.md`, `contrib/README.md`, `CLAUDE.md` | Modify | trust-model rewrite + reference sweep |
 | `docs/design/0003-*`, `0004-*`, `docs/investigation/0001-*` | Modify | supersession (per OQ1) |
-| `.docz.yaml` | Modify (if OQ1 = a) | add `Superseded` to design statuses |
+| `.docz.yaml` | Modify | add `Superseded` to design statuses (OQ1 = a) |
 
 ## Testing Plan
 
@@ -394,10 +397,12 @@ The release-side checklist, including the two items that fail
 
 ## Open Questions
 
-Format: (a) is the recommendation; pick a letter or write in
-**other**.
+**All three decided 2026-08-15** (operator review): 1a, 2a, 3a.
+Decisions are folded into the tasks above (1.2, 1.7, 3.5, File
+Changes); the original options are preserved below for the record.
 
 **1. How do DESIGN-0003 and DESIGN-0004 record supersession?**
+*Decided: (a).*
 The docz `design` status list has no `Superseded` (audit finding);
 RFC and ADR types both have it.
 
@@ -416,6 +421,7 @@ RFC and ADR types both have it.
 
 **2. Should the binary warn when the removed env vars are still
 set?**
+*Decided: (a).*
 The HCL and chart surfaces fail loudly, but a stale
 `TRUST_PROXY_HEADERS=true` env patch is silently ignored
 (DESIGN-0023 documented the asymmetry; this question is whether to
@@ -433,6 +439,7 @@ soften it).
 - other: ____
 
 **3. Does the E4 webhook "Rejections by message" panel survive?**
+*Decided: (a).*
 Its matcher reduces to the single `invalid webhook payload` line.
 
 - (a) **Keep the panel** with the reduced matcher and a rewritten

--- a/docs/impl/README.md
+++ b/docs/impl/README.md
@@ -55,4 +55,5 @@ docz create impl "Your Implementation Title"
 | IMPL-0021 | Post-IMPL-0019 hardening and structural cleanup (INV-0011 Group A Medium + Group B) | Completed | 2026-07-23 | Donald Gifford | [0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md](0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md) |
 | IMPL-0022 | Delayed-requeue job contract and rate-limit consolidation | Completed | 2026-08-02 | Donald Gifford | [0022-delayed-requeue-job-contract-and-rate-limit-consolidation.md](0022-delayed-requeue-job-contract-and-rate-limit-consolidation.md) |
 | IMPL-0023 | Compliance posture state, dashboard suite, and OTEL-first observability | Completed | 2026-08-02 | Donald Gifford | [0023-compliance-posture-state-dashboard-suite-and-otel-first.md](0023-compliance-posture-state-dashboard-suite-and-otel-first.md) |
+| IMPL-0024 | Operator-owned ingress: remove the Tailscale sidecar and IP-allowlist middleware | Draft | 2026-08-15 | Donald Gifford | [0024-operator-owned-ingress-remove-the-tailscale-sidecar-and-ip.md](0024-operator-owned-ingress-remove-the-tailscale-sidecar-and-ip.md) |
 <!-- END DOCZ AUTO-GENERATED -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
         - 'IMPL-0021: Post-IMPL-0019 hardening and structural cleanup (INV-0011 Group A Medium + Group B)': impl/0021-post-impl-0019-hardening-and-structural-cleanup-inv-0011-group.md
         - 'IMPL-0022: Delayed-requeue job contract and rate-limit consolidation': impl/0022-delayed-requeue-job-contract-and-rate-limit-consolidation.md
         - 'IMPL-0023: Compliance posture state, dashboard suite, and OTEL-first observability': impl/0023-compliance-posture-state-dashboard-suite-and-otel-first.md
+        - 'IMPL-0024: Operator-owned ingress: remove the Tailscale sidecar and IP-allowlist middleware': impl/0024-operator-owned-ingress-remove-the-tailscale-sidecar-and-ip.md
     - Investigations:
         - Overview: investigation/README.md
         - 'INV-0001: Tailscale Funnel for Webhook Testing': investigation/0001-tailscale-funnel-for-webhook-testing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
         - 'DESIGN-0020: Absent check mode and conditional file rules': design/0020-absent-check-mode-and-conditional-file-rules.md
         - 'DESIGN-0021: Delayed-requeue job contract and rate-limit consolidation': design/0021-delayed-requeue-job-contract-and-rate-limit-consolidation.md
         - 'DESIGN-0022: Compliance posture state, dashboard suite, and OTEL-first observability': design/0022-compliance-posture-state-dashboard-suite-and-otel-first.md
+        - 'DESIGN-0023: Operator-owned ingress: remove the Tailscale sidecar and IP-allowlist middleware': design/0023-operator-owned-ingress-remove-the-tailscale-sidecar-and-ip.md
     - Implementation Plans:
         - Overview: impl/README.md
         - 'IMPL-0001: Repo Guardian Implementation Plan': impl/0001-repo-guardian-implementation-plan.md


### PR DESCRIPTION
## Summary

The design + implementation pair executing concluded INV-0016 (#180). Both are decision-complete — all nine open questions (six design, three impl) resolved 2026-08-15 and folded into the docs, with the original options preserved for the record.

**DESIGN-0023** (Draft): delete the chart's `tailscale.*` surface and the binary's IP-allowlist middleware (spoofable behind every documented proxy); HMAC becomes the sole app-layer defense; source-IP enforcement moves to the operator's edge; `docs/operations/ingress.md` ships as a seven-row options matrix with validation checkboxes — no crowned winner. Key decisions: repoint `webhook_rejected_total` at the HMAC path (`reason="signature"`); migration note lives at the top of `ingress.md`; **chart ships as `1.0.0` stable** (GHCR verified clean of a published 1.0.0; ECR check on the release checklist); one atomic PR; no in-app client-IP telemetry; `ingress.md` carries a pinned, renovate-annotated cloudflared kustomize patch example.

**IMPL-0024** (Draft): four phases with checkbox tasks and success criteria, ordered so `make lint && make test` stay green after every task (the middleware deletion is bundled with the E4 matcher edit; the counter gains its HMAC producer before losing its allowlist one). Includes the pre-implementation audit, which caught surfaces the design missed: `NOTES.txt`, four extra test files, both example values files, `policy-reference.md` rows, and the missing `Superseded` docz status (decided: add it). Impl decisions: startup warn on stale removed env vars; the E4 rejections panel survives with a reduced matcher.

Docs-only; the code lands via IMPL-0024's atomic PR (`minor` → v1.14.0, chart `1.0.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)